### PR TITLE
set a default value for the status

### DIFF
--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -139,6 +139,7 @@ class TripUpdate(db.Model, TimestampMixin):
     def __init__(self, vj=None):
         self.created_at = datetime.datetime.utcnow()
         self.vj = vj
+        self.status = 'none'
 
     @classmethod
     def find_by_dated_vj(cls, vj_navitia_id, vj_circulation_date):


### PR DESCRIPTION
I don't understand how the status  can be nullable and have a none
value, but since we don't handle all IRE flow for the moment, we can
have 'none'