### PR TITLE
HACK: convert vj id to meta-vj id in model_maker

### DIFF
--- a/kirin/ire/model_maker.py
+++ b/kirin/ire/model_maker.py
@@ -36,6 +36,7 @@ from kirin.core import model
 import xml.etree.cElementTree as ElementTree
 from kirin.exceptions import InvalidArguments, ObjectNotFound
 import navitia_wrapper
+import re
 
 
 def get_node(elt, xpath):
@@ -146,6 +147,9 @@ class KirinModelBuilder(object):
         vjs = []
         for nav_vj in navitia_vjs:
             vj = model.VehicleJourney(nav_vj, vj_start.date())
+            #ugly hack: we convert a vehicle_journey id in a meta-vj id
+            vj.navitia_id = re.sub('^vehicle_journey:', '', vj.navitia_id)
+            vj.navitia_id = re.sub('_dst_\d$', '', vj.navitia_id)
             vjs.append(vj)
 
         return vjs

--- a/tests/integration/ire_model_maker_test.py
+++ b/tests/integration/ire_model_maker_test.py
@@ -57,7 +57,7 @@ def test_train_delayed(mock_navitia_fixture):
 
         assert len(trip_updates) == 1
         trip_up = trip_updates[0]
-        assert trip_up.vj.navitia_id == 'vehicle_journey:OCETrainTER-87212027-85000109-3:11859'
+        assert trip_up.vj.navitia_id == 'OCETrainTER-87212027-85000109-3:11859'
         assert trip_up.vj_id == trip_up.vj.id
         assert trip_up.status == 'update'
 
@@ -81,7 +81,7 @@ def test_train_trip_removal(mock_navitia_fixture):
 
         assert len(trip_updates) == 1
         trip_up = trip_updates[0]
-        assert trip_up.vj.navitia_id == 'vehicle_journey:OCETGV-87686006-87751008-2:25768'
+        assert trip_up.vj.navitia_id == 'OCETGV-87686006-87751008-2:25768'
         assert trip_up.vj_id == trip_up.vj.id
         assert trip_up.status == 'delete'
         # full trip removal : no stop_time to precise

--- a/tests/integration/ire_test.py
+++ b/tests/integration/ire_test.py
@@ -87,11 +87,11 @@ def check_db_ire_96231_delayed():
         assert len(RealTimeUpdate.query.all()) >= 1
         assert len(TripUpdate.query.all()) >= 1
         assert len(StopTimeUpdate.query.all()) >= 6
-        db_trip_delayed = TripUpdate.find_by_dated_vj('vehicle_journey:OCETrainTER-87212027-85000109-3:11859',
+        db_trip_delayed = TripUpdate.find_by_dated_vj('OCETrainTER-87212027-85000109-3:11859',
                                                       datetime.date(2015, 9, 21))
         assert db_trip_delayed
 
-        assert db_trip_delayed.vj.navitia_id == 'vehicle_journey:OCETrainTER-87212027-85000109-3:11859'
+        assert db_trip_delayed.vj.navitia_id == 'OCETrainTER-87212027-85000109-3:11859'
         assert db_trip_delayed.vj.circulation_date == datetime.date(2015, 9, 21)
         assert db_trip_delayed.vj_id == db_trip_delayed.vj.id
         assert db_trip_delayed.status == 'update'
@@ -105,11 +105,11 @@ def check_db_ire_96231_trip_removal():
         assert len(RealTimeUpdate.query.all()) >= 1
         assert len(TripUpdate.query.all()) >= 1
         assert len(StopTimeUpdate.query.all()) >= 0
-        db_trip_removal = TripUpdate.find_by_dated_vj('vehicle_journey:OCETrainTER-87212027-85000109-3:11859',
+        db_trip_removal = TripUpdate.find_by_dated_vj('OCETrainTER-87212027-85000109-3:11859',
                                                       datetime.date(2015, 9, 21))
         assert db_trip_removal
 
-        assert db_trip_removal.vj.navitia_id == 'vehicle_journey:OCETrainTER-87212027-85000109-3:11859'
+        assert db_trip_removal.vj.navitia_id == 'OCETrainTER-87212027-85000109-3:11859'
         assert db_trip_removal.vj.circulation_date == datetime.date(2015, 9, 21)
         assert db_trip_removal.vj_id == db_trip_removal.vj.id
         assert db_trip_removal.status == 'delete'
@@ -122,11 +122,11 @@ def check_db_ire_6113_trip_removal():
         assert len(RealTimeUpdate.query.all()) >= 1
         assert len(TripUpdate.query.all()) >= 1
         assert len(StopTimeUpdate.query.all()) >= 0
-        db_trip_removal = TripUpdate.find_by_dated_vj('vehicle_journey:OCETGV-87686006-87751008-2:25768',
+        db_trip_removal = TripUpdate.find_by_dated_vj('OCETGV-87686006-87751008-2:25768',
                                                       datetime.date(2015, 10, 6))
         assert db_trip_removal
 
-        assert db_trip_removal.vj.navitia_id == 'vehicle_journey:OCETGV-87686006-87751008-2:25768'
+        assert db_trip_removal.vj.navitia_id == 'OCETGV-87686006-87751008-2:25768'
         assert db_trip_removal.vj.circulation_date == datetime.date(2015, 10, 6)
         assert db_trip_removal.vj_id == db_trip_removal.vj.id
         assert db_trip_removal.status == 'delete'
@@ -139,11 +139,11 @@ def check_db_ire_JOHN_trip_removal():
         assert len(RealTimeUpdate.query.all()) >= 1
         assert len(TripUpdate.query.all()) >= 2
         assert len(StopTimeUpdate.query.all()) >= 0
-        db_trip1_removal = TripUpdate.find_by_dated_vj('vehicle_journey:OCETGV-87686006-87751008-2:25768',
+        db_trip1_removal = TripUpdate.find_by_dated_vj('OCETGV-87686006-87751008-2:25768',
                                                       datetime.date(2015, 9, 21))
         assert db_trip1_removal
 
-        assert db_trip1_removal.vj.navitia_id == 'vehicle_journey:OCETGV-87686006-87751008-2:25768'
+        assert db_trip1_removal.vj.navitia_id == 'OCETGV-87686006-87751008-2:25768'
         assert db_trip1_removal.vj.circulation_date == datetime.date(2015, 9, 21)
         assert db_trip1_removal.vj_id == db_trip1_removal.vj.id
         assert db_trip1_removal.status == 'delete'
@@ -151,11 +151,11 @@ def check_db_ire_JOHN_trip_removal():
         assert len(db_trip1_removal.stop_time_updates) == 0
 
 
-        db_trip2_removal = TripUpdate.find_by_dated_vj('vehicle_journey:OCETrainTER-87212027-85000109-3:11859',
+        db_trip2_removal = TripUpdate.find_by_dated_vj('OCETrainTER-87212027-85000109-3:11859',
                                                       datetime.date(2015, 9, 21))
         assert db_trip2_removal
 
-        assert db_trip2_removal.vj.navitia_id == 'vehicle_journey:OCETrainTER-87212027-85000109-3:11859'
+        assert db_trip2_removal.vj.navitia_id == 'OCETrainTER-87212027-85000109-3:11859'
         assert db_trip2_removal.vj.circulation_date == datetime.date(2015, 9, 21)
         assert db_trip2_removal.vj_id == db_trip2_removal.vj.id
         assert db_trip2_removal.status == 'delete'


### PR DESCRIPTION
Currently navitia don't return the meta-vj of a vj...