### PR TITLE
gtfs_rt: datetimes in UTC for parameters since and until

### DIFF
--- a/kirin/gtfs_rt/model_maker.py
+++ b/kirin/gtfs_rt/model_maker.py
@@ -60,8 +60,7 @@ def handle(proto, navitia_wrapper, contributor):
 
 def to_str(date):
     # the date is in UTC, thus we don't have to care about the coverage's timezone
-    # TODO I don't understand why it doesn't work with UTC, so for now it's in  local
-    return date.strftime("%Y%m%dT%H%M%S")
+    return date.strftime("%Y%m%dT%H%M%SZ")
 
 
 class KirinModelBuilder(object):

--- a/tests/mock_navitia/vj_R_vj1.py
+++ b/tests/mock_navitia/vj_R_vj1.py
@@ -31,7 +31,7 @@ import navitia_response
 response = navitia_response.NavitiaResponse()
 
 response.query = 'vehicle_journeys/?filter=vehicle_journey.has_code(source, Code-R-vj1)' \
-                 '&depth=2&since=20120615T120000&until=20120615T180000'
+                 '&depth=2&since=20120615T120000Z&until=20120615T180000Z'
 
 response.response_code = 200
 


### PR DESCRIPTION
After the correction of timestamps in tripupdates.pb provided by STS we have to use parameters "since" and "until" with datetimes values in UTC format(with Z: example &since=20170914T141900Z)