### PR TITLE
Finish TripUpdate's start_date is UTC (3/3)

### DIFF
--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -93,8 +93,6 @@ class VehicleJourney(db.Model):
     # timestamp of VJ's start
     start_timestamp = db.Column(db.DateTime, nullable=False) # ! USE get_start_timestamp() !
 
-    circulation_date = db.Column(db.Date, nullable=True) #only for retrocompatibility
-
     __table_args__ = (db.UniqueConstraint('navitia_trip_id', 'start_timestamp',
                                           name='vehicle_journey_navitia_trip_id_start_timestamp_idx'),)
 
@@ -104,7 +102,6 @@ class VehicleJourney(db.Model):
         self.id = gen_uuid()
         if 'trip' in navitia_vj and 'id' in navitia_vj['trip']:
             self.navitia_trip_id = navitia_vj['trip']['id']
-        self.circulation_date = local_circulation_date #only for retrocompatibility
 
         first_stop_time = navitia_vj.get('stop_times', [{}])[0]
         start_time = first_stop_time['arrival_time']

--- a/migrations/versions/2763a0e3f0bf_rm_vj_circulation_date.py
+++ b/migrations/versions/2763a0e3f0bf_rm_vj_circulation_date.py
@@ -1,0 +1,26 @@
+"""
+removal of circulation_date (which is replaced by start_timestamp)
+Follow up of migration 2762a0e3f0bf (done afterward so that the code/migrations are retrocompatible)
+
+Revision ID: 2763a0e3f0bf
+Revises: 5680194aac0b
+Create Date: 2017-10-13 19:56:39.429947
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2763a0e3f0bf'
+down_revision = '5680194aac0b'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.drop_column('vehicle_journey', 'circulation_date')
+
+
+def downgrade():
+    op.add_column('vehicle_journey', sa.Column('circulation_date', sa.DATE(), autoincrement=False, nullable=True))
+    op.execute("UPDATE vehicle_journey SET circulation_date = start_timestamp::date "
+               "WHERE circulation_date IS NULL")


### PR DESCRIPTION
Final migration
To be merged after that #114 then #113 are merged.

Read by commit (so you can follow migration, as they are PR): have to be retrocompatible n <-> n-1 when deploying

* Read carefully model.py first.
* New tests are only in gtfs_rt_test.py (others are "only" updated).
* SQL migration may be "too" smart? Hope it's correctly anticipated.