### PR TITLE
optimization partial update

### DIFF
--- a/kirin/core/handler.py
+++ b/kirin/core/handler.py
@@ -322,7 +322,9 @@ def merge(navitia_vj, db_trip_update, new_trip_update):
             Third case: we have already recorded a delay but nothing is mentioned in the new trip update
             Then      : For IRE, we do nothing but only update stop time's order
                         For gtfs-rt, according to the specification, we should use the delay from the previous
-                        stop time, which will be handled later by the connector-specified model maker 
+                        stop time, which will be handled sooner by the connector-specified model maker
+                        
+                        *** Here, we MUST NOT do anything, only update stop time's order ***
             """
             db_st = db_trip_update.find_stop(stop_id)
             res_st = db_st if db_st is not None else StopTimeUpdate(navitia_stop['stop_point'],

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -161,7 +161,7 @@ class StopTimeUpdate(db.Model, TimestampMixin):
                  departure=None, arrival=None,
                  departure_delay=None, arrival_delay=None,
                  dep_status='none', arr_status='none',
-                 message=None):
+                 message=None, order=None):
         self.id = gen_uuid()
         self.navitia_stop = navitia_stop
         self.stop_id = navitia_stop['id']
@@ -172,6 +172,7 @@ class StopTimeUpdate(db.Model, TimestampMixin):
         self.departure = departure
         self.arrival = arrival
         self.message = message
+        self.order = order
 
     def update_departure(self, time=None, delay=None, status=None):
         if time:
@@ -189,6 +190,20 @@ class StopTimeUpdate(db.Model, TimestampMixin):
         if status:
             self.arrival_status = status
 
+    def is_ne(self, other):
+        """
+        we don't want to override the __ne__ function to avoid side effects
+        :param other:
+        :return:
+        """
+        return (self.stop_id != other.stop_id or
+                self.message != other.message or
+                self.departure != other.departure or
+                self.departure_delay != other.departure_delay or
+                self.departure_status != other.departure_status or
+                self.arrival != other.arrival or
+                self.arrival_delay != other.arrival_delay or
+                self.arrival_status != other.arrival_status)
 
 associate_realtimeupdate_tripupdate = db.Table('associate_realtimeupdate_tripupdate',
                                     db.metadata,

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -198,6 +198,7 @@ class StopTimeUpdate(db.Model, TimestampMixin):
         """
         return (self.stop_id != other.stop_id or
                 self.message != other.message or
+                self.order != other.order or
                 self.departure != other.departure or
                 self.departure_delay != other.departure_delay or
                 self.departure_status != other.departure_status or

--- a/kirin/gtfs_rt/gtfs_rt.py
+++ b/kirin/gtfs_rt/gtfs_rt.py
@@ -70,8 +70,6 @@ class GtfsRT(Resource):
             proto.ParseFromString(raw_proto)
         except DecodeError:
             raise InvalidArguments('invalid protobuf')
-
-        proto.ParseFromString(raw_proto)
-        model_maker.handle(proto, self.navitia_wrapper, self.contributor)
-
-        return 'OK', 200
+        else:
+            model_maker.handle(proto, self.navitia_wrapper, self.contributor)
+            return 'OK', 200

--- a/tests/integration/gtfs_rt_test.py
+++ b/tests/integration/gtfs_rt_test.py
@@ -524,7 +524,7 @@ def test_gtfs_rt_partial_update_same_feed(partial_update_gtfs_rt_data_1):
 
 
 def test_gtfs_rt_partial_update_diff_feed_1(partial_update_gtfs_rt_data_1,
-                                          partial_update_gtfs_rt_data_2):
+                                            partial_update_gtfs_rt_data_2):
     """
     In this test, we will send the two different gtfs-rt
     """
@@ -544,8 +544,8 @@ def test_gtfs_rt_partial_update_diff_feed_1(partial_update_gtfs_rt_data_1,
         assert trip_update.stop_time_updates[3].arrival_delay.seconds == 0
         assert len(trip_update.real_time_updates) == 1
 
-    # Now we apply exactly the same gtfs-rt, the new gtfs-rt will be save into the db,
-    # which increment the nb of RealTimeUpdate, but the rest remains the same
+    # Now we apply another gtfs-rt, the new gtfs-rt will be save into the db and
+    # increments the nb of real_time_updates
     resp = tester.post('/gtfs_rt', data=partial_update_gtfs_rt_data_2.SerializeToString())
     assert resp.status_code == 200
     with app.app_context():

--- a/tests/integration/gtfs_rt_test.py
+++ b/tests/integration/gtfs_rt_test.py
@@ -236,8 +236,8 @@ def pass_midnight_gtfs_rt_data():
     stu.stop_id = "Code-StopR1"
 
     stu = trip_update.stop_time_update.add()
-    stu.arrival.delay = 120
-    stu.departure.delay = 120
+    stu.arrival.delay = 60
+    stu.departure.delay = 60
     stu.stop_sequence = 2
     stu.stop_id = "Code-StopR2"
 
@@ -290,9 +290,9 @@ def test_gtfs_pass_midnight_model_builder(pass_midnight_gtfs_rt_data):
         second_stop = trip_updates[0].stop_time_updates[1]
         assert second_stop.stop_id == 'StopR2'
         assert second_stop.arrival_status == 'update'
-        assert second_stop.arrival_delay == timedelta(minutes=2)
+        assert second_stop.arrival_delay == timedelta(minutes=1)
         assert second_stop.departure_status == 'update'
-        assert second_stop.departure_delay == timedelta(minutes=2)
+        assert second_stop.departure_delay == timedelta(minutes=1)
         assert second_stop.message is None
 
         second_stop = trip_updates[0].stop_time_updates[2]
@@ -361,10 +361,10 @@ def test_gtfs_rt_pass_midnight(pass_midnight_gtfs_rt_data, mock_rabbitmq):
         second_stop = trip_update.stop_time_updates[1]
         assert second_stop.stop_id == 'StopR2'
         assert second_stop.arrival_status == 'update'
-        assert second_stop.arrival == datetime.datetime(2012, 6, 16, 04, 01)
-        assert second_stop.arrival_delay == timedelta(minutes=2)
-        assert second_stop.departure == datetime.datetime(2012, 6, 16, 04, 02)
-        assert second_stop.departure_delay == timedelta(minutes=2)
+        assert second_stop.arrival == datetime.datetime(2012, 6, 16, 04, 00)
+        assert second_stop.arrival_delay == timedelta(minutes=1)
+        assert second_stop.departure == datetime.datetime(2012, 6, 16, 04, 01)
+        assert second_stop.departure_delay == timedelta(minutes=1)
         assert second_stop.departure_status == 'update'
         assert second_stop.message is None
 

--- a/tests/mock_navitia/__init__.py
+++ b/tests/mock_navitia/__init__.py
@@ -33,6 +33,7 @@ import vj_6114
 import vj_96231
 import vj_80426
 import vj_R_vj1
+import vj_R_vj2
 import vj_pass_midnight
 
 mocks = [
@@ -43,6 +44,7 @@ mocks = [
     vj_96231.response,
     vj_80426.response,
     vj_R_vj1.response,
+    vj_R_vj2.response,
     vj_pass_midnight.response,
 ]
 _mock_navitia_call = {r.query: r for r in mocks}

--- a/tests/mock_navitia/vj_R_vj2.py
+++ b/tests/mock_navitia/vj_R_vj2.py
@@ -1,0 +1,250 @@
+# coding=utf-8
+# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+# the software to build cool stuff with public transport.
+#
+# powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+# a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+import navitia_response
+
+response = navitia_response.NavitiaResponse()
+
+response.query = 'vehicle_journeys/?filter=vehicle_journey.has_code(source, Code-R-vj2)' \
+                 '&depth=2&since=20120615T120000Z&until=20120615T190000Z'
+
+response.response_code = 200
+
+response.json_response = '''
+{
+    "disruptions": [], 
+    "feed_publishers": [
+        {
+            "id": "builder", 
+            "license": "ODBL", 
+            "name": "departure board", 
+            "url": "www.canaltp.fr"
+        }
+    ], 
+    "links": [
+    ], 
+    "pagination": {
+        "items_on_page": 1, 
+        "items_per_page": 25, 
+        "start_page": 0, 
+        "total_result": 1
+    }, 
+    "vehicle_journeys": [
+        {
+            "calendars": [
+                {
+                    "active_periods": [
+                        {
+                            "begin": "20120615", 
+                            "end": "20130615"
+                        }
+                    ], 
+                    "week_pattern": {
+                        "friday": true, 
+                        "monday": false, 
+                        "saturday": false, 
+                        "sunday": false, 
+                        "thursday": false, 
+                        "tuesday": false, 
+                        "wednesday": false
+                    }
+                }
+            ], 
+            "disruptions": [], 
+            "id": "R:vj2",
+            "name": "R:vj2", 
+            "stop_times": [
+                {
+                    "arrival_time": "100000", 
+                    "departure_time": "100000", 
+                    "headsign": "R:vj2", 
+                    "journey_pattern_point": {
+                        "id": "journey_pattern_point:14"
+                    }, 
+                    "stop_point": {
+                        "codes": [
+                            {
+                                "type": "source", 
+                                "value": "Code-StopR1"
+                            }
+                        ], 
+                        "coord": {
+                            "lat": "0", 
+                            "lon": "0"
+                        }, 
+                        "equipments": [
+                            "has_wheelchair_boarding", 
+                            "has_bike_accepted"
+                        ], 
+                        "id": "StopR1", 
+                        "label": "StopR1", 
+                        "links": [], 
+                        "name": "StopR1", 
+                        "stop_area": {
+                            "coord": {
+                                "lat": "0", 
+                                "lon": "0"
+                            }, 
+                            "id": "StopR1", 
+                            "label": "StopR1", 
+                            "links": [], 
+                            "name": "StopR1", 
+                            "timezone": "America/Montreal"
+                        }
+                    }
+                }, 
+                {
+                    "arrival_time": "103000", 
+                    "departure_time": "103000", 
+                    "headsign": "R:vj2", 
+                    "journey_pattern_point": {
+                        "id": "journey_pattern_point:15"
+                    }, 
+                    "stop_point": {
+                        "codes": [
+                            {
+                                "type": "source", 
+                                "value": "Code-StopR2"
+                            }
+                        ], 
+                        "coord": {
+                            "lat": "0", 
+                            "lon": "0"
+                        }, 
+                        "equipments": [
+                            "has_wheelchair_boarding", 
+                            "has_bike_accepted"
+                        ], 
+                        "id": "StopR2", 
+                        "label": "StopR2", 
+                        "links": [], 
+                        "name": "StopR2", 
+                        "stop_area": {
+                            "coord": {
+                                "lat": "0", 
+                                "lon": "0"
+                            }, 
+                            "id": "StopR2", 
+                            "label": "StopR2", 
+                            "links": [], 
+                            "name": "StopR2", 
+                            "timezone": "America/Montreal"
+                        }
+                    }
+                }, 
+                {
+                    "arrival_time": "110000", 
+                    "departure_time": "110000", 
+                    "headsign": "R:vj2", 
+                    "journey_pattern_point": {
+                        "id": "journey_pattern_point:16"
+                    }, 
+                    "stop_point": {
+                        "codes": [
+                            {
+                                "type": "source", 
+                                "value": "Code-StopR3"
+                            }
+                        ], 
+                        "coord": {
+                            "lat": "0", 
+                            "lon": "0"
+                        }, 
+                        "equipments": [
+                            "has_wheelchair_boarding", 
+                            "has_bike_accepted"
+                        ], 
+                        "id": "StopR3", 
+                        "label": "StopR3", 
+                        "links": [], 
+                        "name": "StopR3", 
+                        "stop_area": {
+                            "coord": {
+                                "lat": "0", 
+                                "lon": "0"
+                            }, 
+                            "id": "StopR3", 
+                            "label": "StopR3", 
+                            "links": [], 
+                            "name": "StopR3", 
+                            "timezone": "America/Montreal"
+                        }
+                    }
+                }, 
+                {
+                    "arrival_time": "113000", 
+                    "departure_time": "113000", 
+                    "headsign": "R:vj2", 
+                    "journey_pattern_point": {
+                        "id": "journey_pattern_point:17"
+                    }, 
+                    "stop_point": {
+                        "codes": [
+                            {
+                                "type": "source", 
+                                "value": "Code-StopR4"
+                            }
+                        ], 
+                        "coord": {
+                            "lat": "0", 
+                            "lon": "0"
+                        }, 
+                        "equipments": [
+                            "has_wheelchair_boarding", 
+                            "has_bike_accepted"
+                        ], 
+                        "id": "StopR4", 
+                        "label": "StopR4", 
+                        "links": [], 
+                        "name": "StopR4", 
+                        "stop_area": {
+                            "coord": {
+                                "lat": "0", 
+                                "lon": "0"
+                            }, 
+                            "id": "StopR4", 
+                            "label": "StopR4", 
+                            "links": [], 
+                            "name": "StopR4", 
+                            "timezone": "America/Montreal"
+                        }
+                    }
+                }
+            ], 
+            "trip": {
+                "id": "R:vj2", 
+                "name": "R:vj2"
+            }, 
+            "validity_pattern": {
+                "beginning_date": "20120614", 
+                "days": "100000010000001000000100000010000001000000100000010000001000000100000010000001000000100000010000001000000100000010000001000000100000010000001000000100000010000001000000100000010000001000000100000010000001000000100000010000001000000100000010000001000000100000010000001000000100000010000001000000100000010000001000000100000010000001000000100000010000001000000100000010"
+            }
+        }
+    ]
+}
+'''


### PR DESCRIPTION
Optimize the partial update:

in a lot of time, we receive gtfs-rt which updates just a part of VJs, so we want to ignore those are not impacted by the entry gtfs-rt,  there is no need to send these VJ to kraken and no need to save them in the db either

- [x] add tests!