### PR TITLE
fix connection closed by status

### DIFF
--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -45,12 +45,12 @@ meta = sqlalchemy.schema.MetaData(naming_convention={
         "pk": "pk_%(table_name)s"
       })
 
-#force the server to use UTC time for each connection
-def set_utc_on_connect(dbapi_con, con_record):
+#force the server to use UTC time for each connection checkouted from the pool
+@sqlalchemy.event.listens_for(sqlalchemy.pool.Pool, 'checkout')
+def set_utc_on_connect(dbapi_con, connection_record, connection_proxy):
     c = dbapi_con.cursor()
     c.execute("SET timezone='utc'")
     c.close()
-sqlalchemy.event.listen(sqlalchemy.pool.Pool, 'connect', set_utc_on_connect)
 
 
 def gen_uuid():


### PR DESCRIPTION

![7dqpf4k](https://user-images.githubusercontent.com/6093486/33935622-f0d5e0b0-dffc-11e7-8fb7-c91522cb2a7d.gif)


Bug Scenario:

* launch Kirin web service
* do GET on /status
* do POST on /ire or /gtfs_rt twice with the same file
* persist_realtime crashed 

Reason:

DB connections' timezone must be set to UTC in kirin, this is done at [this line](https://github.com/CanalTP/kirin/blob/6a9c80d9d6978feadb41ad9873cae3195d8b0a62/kirin/core/model.py#L49). The interesting thing is, when /status is called, the event `connect` is triggered and a connection is established with timezone=UTC, then the connection is 'checkin'ed(abandoned) by the Pool. When a another connection is asked, the event `connect` is NEVER triggered again! After a deep investigation in the source code of SQLAlchemy(1.0.8), it turns out that this event is triggered [only once](https://github.com/zzzeek/sqlalchemy/blob/552f1f135f66a1a3b9a1a8c3d5e1e6431e4fd234/lib/sqlalchemy/pool.py#L452) at the very beginning.

This bug is only related to kirin web service, hopefully it should not impact the kirin worker

Solution:

I changed the event to `checkout` so that the timezone is set to UTC every time a connection is checked out from the Pool.

An alternative way to do the same job is :

```python
@sqlalchemy.event.listens_for(db.get_engine(app), 'do_connect')
def receive_do_execute(dialect, conn_rec, cargs, cparams):
    cparams.update({"options": "-c timezone=utc"})
    dialect.connect(*cargs, **cparams)
```
- [x] To be tested on kirin worker