### PR TITLE
kirin: fix for migration with lots data and live insert

### DIFF
--- a/migrations/versions/3a12525235bf_add_validity.py
+++ b/migrations/versions/3a12525235bf_add_validity.py
@@ -13,10 +13,9 @@ down_revision = '2763a0e3f0bf'
 
 from alembic import op
 
-
 def upgrade():
     op.execute("UPDATE real_time_update SET status = 'OK' WHERE status IS NULL")
-    op.alter_column('real_time_update', 'status', nullable=False)
+    op.alter_column('real_time_update', 'status', server_default='OK')
     op.create_index('status_idx', 'real_time_update', ['status'], unique=False)
 
 


### PR DESCRIPTION
During Migraion:

- Script updates the tables updating status = 'OK' where it was NULL

- The poller inserts somes lines in the table real_time_update with status = NULL

- At last when the script alters the table with status not NULL, because of some lines inserted by poller
there is an erreur "column "status" contains null values"

Solution: 

- Alter the column status with server_default='OK' in this version.

- Alter the column status with nullable=False in the next migration.