### PR TITLE
Remove all unicode literals

### DIFF
--- a/kirin/abstract_sncf_model_maker.py
+++ b/kirin/abstract_sncf_model_maker.py
@@ -28,7 +28,7 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 
-from __future__ import absolute_import, print_function, unicode_literals, division
+from __future__ import absolute_import, print_function, division
 import logging
 from datetime import timedelta
 from kirin.utils import record_internal_failure
@@ -52,17 +52,17 @@ def headsigns(str):
     the parity is the number after the '/'. it gives an alternative train number
 
     >>> headsigns('2038')
-    [u'2038']
+    ['2038']
     >>> headsigns('002038')
-    [u'2038']
+    ['2038']
     >>> headsigns('002038/12')
-    [u'2038', u'2012']
+    ['2038', '2012']
     >>> headsigns('2038/3')
-    [u'2038', u'2033']
+    ['2038', '2033']
     >>> headsigns('2038/123')
-    [u'2038', u'2123']
+    ['2038', '2123']
     >>> headsigns('2038/12345')
-    [u'2038', u'12345']
+    ['2038', '12345']
 
     """
     h = str.lstrip('0')

--- a/kirin/cots/model_maker.py
+++ b/kirin/cots/model_maker.py
@@ -28,7 +28,7 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 
-from __future__ import absolute_import, print_function, unicode_literals, division
+from __future__ import absolute_import, print_function, division
 
 import logging
 from datetime import datetime

--- a/kirin/new_relic.py
+++ b/kirin/new_relic.py
@@ -27,7 +27,7 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 
-from __future__ import absolute_import, print_function, unicode_literals, division
+from __future__ import absolute_import, print_function, division
 import logging
 import flask
 import os

--- a/tests/cots_rt_test.py
+++ b/tests/cots_rt_test.py
@@ -28,7 +28,7 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 
-from __future__ import absolute_import, print_function, unicode_literals, division
+from __future__ import absolute_import, print_function, division
 from kirin.cots.model_maker import _retrieve_interesting_pdp
 
 


### PR DESCRIPTION
A complete switch to unicode is discussed in #176 but partial unicode is hazardous

Please review only commits starting from 'Remove all unicode literals ' (only last commit) as this PR is on top of #175 (to avoid conflicts)

TODO ('do_not_merge' handles that):
- [x] merge #175 before (which requires #172 to be merged before)