### PR TITLE
Add test for back to normal

### DIFF
--- a/tests/fixtures/cots_train_870154_partial_normal.json
+++ b/tests/fixtures/cots_train_870154_partial_normal.json
@@ -1,0 +1,708 @@
+{
+	"ressource": "courseOPE",
+	"mode": "modification",
+	"evt": ["PERTURBATION"],
+	"PdPObserveArrivee": [],
+	"PdPObserveDepart": [],
+	"PdPPronosticBrutArrivee": ["718c4652-a5f7-49f0-8529-ab3b5b41f870",
+	"8cabf482-5316-43ee-bf75-7249fe1994b0",
+	"391c9a2e-fe63-4664-8bb5-8e5dcbce948e",
+	"5733ad2f-918e-46e2-a287-610eb63fd7d3",
+	"c296a1f6-891b-4b1e-873f-0b438ebc001c",
+	"bd94ab98-a55a-49f2-97eb-bfb7de7ddbb6",
+	"ca34497a-e868-481e-a3a8-d9521c05d37e",
+	"8c2bf83b-e026-46ba-96d8-0f420386ca89",
+	"9092b3b2-7e1b-4cc1-a92f-6689bc566d99",
+	"5d7dbc20-daa1-4dc9-aebe-7998afccf766",
+	"84c90b78-5f9a-4137-bd57-25be94c0246c"],
+	"PdPPronosticBrutDepart": ["718c4652-a5f7-49f0-8529-ab3b5b41f870",
+	"8cabf482-5316-43ee-bf75-7249fe1994b0",
+	"391c9a2e-fe63-4664-8bb5-8e5dcbce948e",
+	"5733ad2f-918e-46e2-a287-610eb63fd7d3",
+	"bd94ab98-a55a-49f2-97eb-bfb7de7ddbb6",
+	"ca34497a-e868-481e-a3a8-d9521c05d37e",
+	"8c2bf83b-e026-46ba-96d8-0f420386ca89",
+	"9092b3b2-7e1b-4cc1-a92f-6689bc566d99",
+	"5d7dbc20-daa1-4dc9-aebe-7998afccf766",
+	"84c90b78-5f9a-4137-bd57-25be94c0246c"],
+	"PdPPronosticIVArrivee": ["718c4652-a5f7-49f0-8529-ab3b5b41f870",
+	"8cabf482-5316-43ee-bf75-7249fe1994b0",
+	"391c9a2e-fe63-4664-8bb5-8e5dcbce948e",
+	"5733ad2f-918e-46e2-a287-610eb63fd7d3",
+	"c296a1f6-891b-4b1e-873f-0b438ebc001c",
+	"bd94ab98-a55a-49f2-97eb-bfb7de7ddbb6",
+	"ca34497a-e868-481e-a3a8-d9521c05d37e",
+	"8c2bf83b-e026-46ba-96d8-0f420386ca89",
+	"9092b3b2-7e1b-4cc1-a92f-6689bc566d99",
+	"5d7dbc20-daa1-4dc9-aebe-7998afccf766",
+	"84c90b78-5f9a-4137-bd57-25be94c0246c"],
+	"PdPPronosticIVDepart": ["718c4652-a5f7-49f0-8529-ab3b5b41f870",
+	"8cabf482-5316-43ee-bf75-7249fe1994b0",
+	"391c9a2e-fe63-4664-8bb5-8e5dcbce948e",
+	"5733ad2f-918e-46e2-a287-610eb63fd7d3",
+	"bd94ab98-a55a-49f2-97eb-bfb7de7ddbb6",
+	"ca34497a-e868-481e-a3a8-d9521c05d37e",
+	"8c2bf83b-e026-46ba-96d8-0f420386ca89",
+	"9092b3b2-7e1b-4cc1-a92f-6689bc566d99",
+	"5d7dbc20-daa1-4dc9-aebe-7998afccf766",
+	"84c90b78-5f9a-4137-bd57-25be94c0246c"],
+	"PdPImpacteDepart": [],
+	"PdPImpacteArrivee": [],
+	"nouvelleVersion": {
+		"codeCompagnieTransporteur": "1187",
+		"codeMarqueTransporteur": "TER",
+		"codeRelation": "MP06SP",
+		"codeService": "A2018",
+		"codeTransporteurResponsable": "5T",
+		"codeTypeMoyenTransport": "0",
+		"coursePTP": {
+			"@id": "81a3b095-c97e-433e-9471-a8a723d9095a",
+			"impactPTP": "MODIFICATION",
+			"validePourDiffusion": "true"
+		},
+		"dateDebutService": "2017-12-10",
+		"dateDerniereModification": "2018-11-02T09:20:07+0000",
+		"dateFinService": "2018-12-08",
+		"estDiscontinue": false,
+		"estTechnique": false,
+		"estimationManuelle": false,
+		"etat": "ACTIVE",
+		"idVersion": "74eec32c-8173-4b05-8678-bf708fc3e909",
+		"identifiantDansSystemeCreateur": "d1fdf817-763c-4c10-9596-334e33a2e446",
+		"indicateurFer": "FERRE",
+		"listeCouplageCourseOPE": [],
+		"listeCodeTransporteurAssocie": [],
+		"listeEvenement": [{
+			"dateHeureCreation": "2018-11-02T09:00:15+0000",
+			"identifiantDansSystemeCreateur": "CROMPY050920180051",
+			"lieu": {
+				"cr": "0087",
+				"ci": "613422",
+				"ch": "BV"
+			},
+			"systemeCreateur": "2887"
+		}],
+		"listeJourRegimeDApplication": [{
+			"date": "2018-11-02"
+		}],
+		"listeJourRegimeFacultatif": [],
+		"listeMotif": [],
+		"listePointDeParcours": [{
+			"@id": "99fdb6ab-093d-4640-90f6-8509369553b2",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613422",
+			"ch": "BV",
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "10:54:00",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T08:54:00+0000",
+				"heureLocale": "10:54:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"idMotifInterneDepartReference": 98,
+			"listeHoraireProjeteArrivee": [],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T08:59:00+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 300,
+				"pronosticIV": 300,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [],
+			"listeMotifDepart": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 98,
+				"source": "IRE-GOP"
+			}],
+			"rang": 1,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "ca34497a-e868-481e-a3a8-d9521c05d37e",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613257",
+			"ch": "00",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:17:30",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:18:30",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T09:17:30+0000",
+				"heureLocale": "11:17:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T09:18:30+0000",
+				"heureLocale": "11:18:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"idMotifInterneArriveeReference": 9,
+			"idMotifInterneDepartReference": 9,
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T09:17:00+0000",
+				"dateHeureEmission": "2018-11-02T09:20:07+0000",
+				"pronosticBrut": 0,
+				"pronosticIV": 0,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T09:18:00+0000",
+				"dateHeureEmission": "2018-11-02T09:20:07+0000",
+				"pronosticBrut": 0,
+				"pronosticIV": 0,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 98,
+				"source": "IRE-GOP"
+			},
+			{
+				"dateHeureDeclaration": "2018-11-02T09:20:07+0000",
+				"idMotifInterne": 9,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifDepart": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 98,
+				"source": "IRE-GOP"
+			},
+			{
+				"dateHeureDeclaration": "2018-11-02T09:20:07+0000",
+				"idMotifInterne": 9,
+				"source": "IRE-GOP"
+			}],
+			"rang": 2,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "718c4652-a5f7-49f0-8529-ab3b5b41f870",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613232",
+			"ch": "00",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:29:30",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:30:30",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T09:29:30+0000",
+				"heureLocale": "11:29:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T09:30:30+0000",
+				"heureLocale": "11:30:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"idMotifInterneArriveeReference": 9,
+			"idMotifInterneDepartReference": 9,
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T09:29:00+0000",
+				"dateHeureEmission": "2018-11-02T09:20:07+0000",
+				"pronosticBrut": 0,
+				"pronosticIV": 0,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T09:30:00+0000",
+				"dateHeureEmission": "2018-11-02T09:20:07+0000",
+				"pronosticBrut": 0,
+				"pronosticIV": 0,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 98,
+				"source": "IRE-GOP"
+			},
+			{
+				"dateHeureDeclaration": "2018-11-02T09:20:07+0000",
+				"idMotifInterne": 9,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifDepart": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 98,
+				"source": "IRE-GOP"
+			},
+			{
+				"dateHeureDeclaration": "2018-11-02T09:20:07+0000",
+				"idMotifInterne": 9,
+				"source": "IRE-GOP"
+			}],
+			"rang": 3,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "391c9a2e-fe63-4664-8bb5-8e5dcbce948e",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613224",
+			"ch": "00",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:33:30",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:34:30",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T09:33:30+0000",
+				"heureLocale": "11:33:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T09:34:30+0000",
+				"heureLocale": "11:34:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"idMotifInterneArriveeReference": 9,
+			"idMotifInterneDepartReference": 9,
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T09:33:00+0000",
+				"dateHeureEmission": "2018-11-02T09:20:07+0000",
+				"pronosticBrut": 0,
+				"pronosticIV": 0,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T09:34:00+0000",
+				"dateHeureEmission": "2018-11-02T09:20:07+0000",
+				"pronosticBrut": 0,
+				"pronosticIV": 0,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 98,
+				"source": "IRE-GOP"
+			},
+			{
+				"dateHeureDeclaration": "2018-11-02T09:20:07+0000",
+				"idMotifInterne": 9,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifDepart": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 98,
+				"source": "IRE-GOP"
+			},
+			{
+				"dateHeureDeclaration": "2018-11-02T09:20:07+0000",
+				"idMotifInterne": 9,
+				"source": "IRE-GOP"
+			}],
+			"rang": 4,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "84c90b78-5f9a-4137-bd57-25be94c0246c",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613661",
+			"ch": "BV",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:38:30",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:39:30",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T09:38:30+0000",
+				"heureLocale": "11:38:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T09:39:30+0000",
+				"heureLocale": "11:39:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T09:38:00+0000",
+				"dateHeureEmission": "2018-11-02T09:20:07+0000",
+				"pronosticBrut": 0,
+				"pronosticIV": 0,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T09:39:00+0000",
+				"dateHeureEmission": "2018-11-02T09:20:07+0000",
+				"pronosticBrut": 0,
+				"pronosticIV": 0,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [],
+			"listeMotifDepart": [],
+			"rang": 5,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "8c2bf83b-e026-46ba-96d8-0f420386ca89",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613109",
+			"ch": "BV",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:53:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:55:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T09:53:00+0000",
+				"heureLocale": "11:53:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T09:55:00+0000",
+				"heureLocale": "11:55:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T09:53:00+0000",
+				"dateHeureEmission": "2018-11-02T09:20:07+0000",
+				"pronosticBrut": 0,
+				"pronosticIV": 0,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T09:55:00+0000",
+				"dateHeureEmission": "2018-11-02T09:20:07+0000",
+				"pronosticBrut": 0,
+				"pronosticIV": 0,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [],
+			"listeMotifDepart": [],
+			"rang": 6,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "9092b3b2-7e1b-4cc1-a92f-6689bc566d99",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613091",
+			"ch": "BV",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "12:01:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "12:02:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T10:01:00+0000",
+				"heureLocale": "12:01:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T10:02:00+0000",
+				"heureLocale": "12:02:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"listeHoraireProjeteArrivee": [],
+			"listeHoraireProjeteDepart": [],
+			"rang": 7,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "5d7dbc20-daa1-4dc9-aebe-7998afccf766",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613075",
+			"ch": "00",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "12:17:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "12:18:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T10:17:00+0000",
+				"heureLocale": "12:17:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T10:18:00+0000",
+				"heureLocale": "12:18:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T10:17:00+0000",
+				"dateHeureEmission": "2018-11-02T09:20:07+0000",
+				"pronosticBrut": 0,
+				"pronosticIV": 0,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T10:18:00+0000",
+				"dateHeureEmission": "2018-11-02T09:20:07+0000",
+				"pronosticBrut": 0,
+				"pronosticIV": 0,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [],
+			"listeMotifDepart": [],
+			"rang": 8,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "5733ad2f-918e-46e2-a287-610eb63fd7d3",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613059",
+			"ch": "BV",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "12:29:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "12:30:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T10:29:00+0000",
+				"heureLocale": "12:29:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T10:30:00+0000",
+				"heureLocale": "12:30:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T10:29:00+0000",
+				"dateHeureEmission": "2018-11-02T09:20:07+0000",
+				"pronosticBrut": 0,
+				"pronosticIV": 0,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T10:30:00+0000",
+				"dateHeureEmission": "2018-11-02T09:20:07+0000",
+				"pronosticBrut": 0,
+				"pronosticIV": 0,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [],
+			"listeMotifDepart": [],
+			"rang": 9,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "bd94ab98-a55a-49f2-97eb-bfb7de7ddbb6",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "594572",
+			"ch": "00",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "12:51:30",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "12:52:30",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T10:51:30+0000",
+				"heureLocale": "12:51:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T10:52:30+0000",
+				"heureLocale": "12:52:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T10:51:00+0000",
+				"dateHeureEmission": "2018-11-02T09:20:07+0000",
+				"pronosticBrut": 0,
+				"pronosticIV": 0,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T10:52:00+0000",
+				"dateHeureEmission": "2018-11-02T09:20:07+0000",
+				"pronosticBrut": 0,
+				"pronosticIV": 0,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [],
+			"listeMotifDepart": [],
+			"rang": 11,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "c296a1f6-891b-4b1e-873f-0b438ebc001c",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"cr": "0087",
+			"ci": "594002",
+			"ch": "BV",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "13:15:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T11:15:00+0000",
+				"heureLocale": "13:15:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T11:15:00+0000",
+				"dateHeureEmission": "2018-11-02T09:20:07+0000",
+				"pronosticBrut": 0,
+				"pronosticIV": 0,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [],
+			"listeMotifArrivee": [],
+			"listeMotifDepart": [],
+			"rang": 12,
+			"typeArret": "CH"
+		}],
+		"listeService": [],
+		"listeSubstitutionCourse": [],
+		"listeUtilisationSillon": [{
+			"identifiantSillon": {
+				"numeroOperationnelSillon": "870154",
+				"sillonTTH": "042610010014"
+			},
+			"listeJourRegimeDApplication": [{
+				"date": "2018-11-02"
+			}],
+			"listeJourRegimeFacultatif": [],
+			"pointDebutUtilisationSillon": {
+				"@id": "99fdb6ab-093d-4640-90f6-8509369553b2"
+			},
+			"pointFinUtilisationSillon": {
+				"@id": "c296a1f6-891b-4b1e-873f-0b438ebc001c"
+			},
+			"porteur": true,
+			"rangPRDebutUtilisationSillon": 1,
+			"decalagePasseMinuit": 0,
+			"rangPRFinUtilisationSillon": 26
+		}],
+		"numeroCourse": "870154",
+		"statutSillonCourse": "NON_CONNU",
+		"statutOperationnel": "PERTURBEE",
+		"systemeCreateur": "2148",
+		"type": "COURSE_OPE",
+		"@id": "d1fdf817-763c-4c10-9596-334e33a2e446"
+	}
+}

--- a/tests/fixtures/cots_train_870154_partial_removal_delay.json
+++ b/tests/fixtures/cots_train_870154_partial_removal_delay.json
@@ -1,0 +1,831 @@
+{
+	"ressource": "courseOPE",
+	"mode": "modification",
+	"evt": ["PERTURBATION"],
+	"PdPObserveArrivee": [],
+	"PdPObserveDepart": [],
+	"PdPPronosticBrutArrivee": ["718c4652-a5f7-49f0-8529-ab3b5b41f870",
+	"8cabf482-5316-43ee-bf75-7249fe1994b0",
+	"391c9a2e-fe63-4664-8bb5-8e5dcbce948e",
+	"5733ad2f-918e-46e2-a287-610eb63fd7d3",
+	"c296a1f6-891b-4b1e-873f-0b438ebc001c",
+	"bd94ab98-a55a-49f2-97eb-bfb7de7ddbb6",
+	"ca34497a-e868-481e-a3a8-d9521c05d37e",
+	"8c2bf83b-e026-46ba-96d8-0f420386ca89",
+	"9092b3b2-7e1b-4cc1-a92f-6689bc566d99",
+	"5d7dbc20-daa1-4dc9-aebe-7998afccf766",
+	"84c90b78-5f9a-4137-bd57-25be94c0246c"],
+	"PdPPronosticBrutDepart": ["718c4652-a5f7-49f0-8529-ab3b5b41f870",
+	"8cabf482-5316-43ee-bf75-7249fe1994b0",
+	"391c9a2e-fe63-4664-8bb5-8e5dcbce948e",
+	"5733ad2f-918e-46e2-a287-610eb63fd7d3",
+	"bd94ab98-a55a-49f2-97eb-bfb7de7ddbb6",
+	"ca34497a-e868-481e-a3a8-d9521c05d37e",
+	"8c2bf83b-e026-46ba-96d8-0f420386ca89",
+	"99fdb6ab-093d-4640-90f6-8509369553b2",
+	"9092b3b2-7e1b-4cc1-a92f-6689bc566d99",
+	"5d7dbc20-daa1-4dc9-aebe-7998afccf766",
+	"84c90b78-5f9a-4137-bd57-25be94c0246c"],
+	"PdPPronosticIVArrivee": ["718c4652-a5f7-49f0-8529-ab3b5b41f870",
+	"8cabf482-5316-43ee-bf75-7249fe1994b0",
+	"391c9a2e-fe63-4664-8bb5-8e5dcbce948e",
+	"5733ad2f-918e-46e2-a287-610eb63fd7d3",
+	"c296a1f6-891b-4b1e-873f-0b438ebc001c",
+	"bd94ab98-a55a-49f2-97eb-bfb7de7ddbb6",
+	"ca34497a-e868-481e-a3a8-d9521c05d37e",
+	"8c2bf83b-e026-46ba-96d8-0f420386ca89",
+	"9092b3b2-7e1b-4cc1-a92f-6689bc566d99",
+	"5d7dbc20-daa1-4dc9-aebe-7998afccf766",
+	"84c90b78-5f9a-4137-bd57-25be94c0246c"],
+	"PdPPronosticIVDepart": ["718c4652-a5f7-49f0-8529-ab3b5b41f870",
+	"8cabf482-5316-43ee-bf75-7249fe1994b0",
+	"391c9a2e-fe63-4664-8bb5-8e5dcbce948e",
+	"5733ad2f-918e-46e2-a287-610eb63fd7d3",
+	"bd94ab98-a55a-49f2-97eb-bfb7de7ddbb6",
+	"ca34497a-e868-481e-a3a8-d9521c05d37e",
+	"8c2bf83b-e026-46ba-96d8-0f420386ca89",
+	"99fdb6ab-093d-4640-90f6-8509369553b2",
+	"9092b3b2-7e1b-4cc1-a92f-6689bc566d99",
+	"5d7dbc20-daa1-4dc9-aebe-7998afccf766",
+	"84c90b78-5f9a-4137-bd57-25be94c0246c"],
+	"PdPImpacteDepart": [],
+	"PdPImpacteArrivee": [],
+	"nouvelleVersion": {
+		"codeCompagnieTransporteur": "1187",
+		"codeMarqueTransporteur": "TER",
+		"codeRelation": "MP06SP",
+		"codeService": "A2018",
+		"codeTransporteurResponsable": "5T",
+		"codeTypeMoyenTransport": "0",
+		"coursePTP": {
+			"@id": "81a3b095-c97e-433e-9471-a8a723d9095a",
+			"impactPTP": "MODIFICATION",
+			"validePourDiffusion": "true"
+		},
+		"dateDebutService": "2017-12-10",
+		"dateDerniereModification": "2018-11-02T09:00:15+0000",
+		"dateFinService": "2018-12-08",
+		"estDiscontinue": false,
+		"estTechnique": false,
+		"estimationManuelle": false,
+		"etat": "ACTIVE",
+		"idMotifInterneReference": 24,
+		"idVersion": "2ed34927-ba6a-4733-ba9e-694cacea7bba",
+		"identifiantDansSystemeCreateur": "d1fdf817-763c-4c10-9596-334e33a2e446",
+		"indicateurFer": "FERRE",
+		"listeCouplageCourseOPE": [],
+		"listeCodeTransporteurAssocie": [],
+		"listeEvenement": [{
+			"dateHeureCreation": "2018-11-02T09:00:15+0000",
+			"identifiantDansSystemeCreateur": "CROMPY050920180051",
+			"lieu": {
+				"cr": "0087",
+				"ci": "613422",
+				"ch": "BV"
+			},
+			"systemeCreateur": "2887"
+		}],
+		"listeJourRegimeDApplication": [{
+			"date": "2018-11-02"
+		}],
+		"listeJourRegimeFacultatif": [],
+		"listeMotif": [{
+			"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+			"idMotifInterne": 24,
+			"source": "IRE-GOP"
+		}],
+		"listePointDeParcours": [{
+			"@id": "99fdb6ab-093d-4640-90f6-8509369553b2",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613422",
+			"ch": "BV",
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "10:54:00",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T08:54:00+0000",
+				"heureLocale": "10:54:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"idMotifInterneDepartReference": 98,
+			"listeHoraireProjeteArrivee": [],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T08:59:00+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 300,
+				"pronosticIV": 300,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [],
+			"listeMotifDepart": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 98,
+				"source": "IRE-GOP"
+			}],
+			"rang": 1,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "ca34497a-e868-481e-a3a8-d9521c05d37e",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613257",
+			"ch": "00",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:17:30",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:18:30",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T09:17:30+0000",
+				"heureLocale": "11:17:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T09:18:30+0000",
+				"heureLocale": "11:18:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"idMotifInterneArriveeReference": 98,
+			"idMotifInterneDepartReference": 98,
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T09:22:30+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 300,
+				"pronosticIV": 300,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T09:23:30+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 300,
+				"pronosticIV": 300,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 98,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifDepart": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 98,
+				"source": "IRE-GOP"
+			}],
+			"rang": 2,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "718c4652-a5f7-49f0-8529-ab3b5b41f870",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613232",
+			"ch": "00",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:29:30",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:30:30",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T09:29:30+0000",
+				"heureLocale": "11:29:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T09:30:30+0000",
+				"heureLocale": "11:30:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"idMotifInterneArriveeReference": 98,
+			"idMotifInterneDepartReference": 98,
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T09:34:30+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 300,
+				"pronosticIV": 300,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T09:35:30+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 300,
+				"pronosticIV": 300,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 98,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifDepart": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 98,
+				"source": "IRE-GOP"
+			}],
+			"rang": 3,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "391c9a2e-fe63-4664-8bb5-8e5dcbce948e",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613224",
+			"ch": "00",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:33:30",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:34:30",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T09:33:30+0000",
+				"heureLocale": "11:33:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T09:34:30+0000",
+				"heureLocale": "11:34:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"idMotifInterneArriveeReference": 98,
+			"idMotifInterneDepartReference": 98,
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T09:38:30+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 300,
+				"pronosticIV": 300,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T09:39:30+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 300,
+				"pronosticIV": 300,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 98,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifDepart": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 98,
+				"source": "IRE-GOP"
+			}],
+			"rang": 4,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "84c90b78-5f9a-4137-bd57-25be94c0246c",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613661",
+			"ch": "BV",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:38:30",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:39:30",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T09:38:30+0000",
+				"heureLocale": "11:38:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T09:39:30+0000",
+				"heureLocale": "11:39:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"idMotifInterneArriveeReference": 3,
+			"idMotifInterneDepartReference": 3,
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T09:43:30+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 300,
+				"pronosticIV": 300,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T09:44:30+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 300,
+				"pronosticIV": 300,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 3,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifDepart": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 3,
+				"source": "IRE-GOP"
+			}],
+			"rang": 5,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "8c2bf83b-e026-46ba-96d8-0f420386ca89",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613109",
+			"ch": "BV",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:53:00",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "11:55:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T09:53:00+0000",
+				"heureLocale": "11:53:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T09:55:00+0000",
+				"heureLocale": "11:55:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"idMotifInterneArriveeReference": 3,
+			"idMotifInterneDepartReference": 24,
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T09:58:00+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 300,
+				"pronosticIV": 300,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T10:00:00+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 600,
+				"pronosticIV": 600,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 3,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifDepart": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 24,
+				"source": "IRE-GOP"
+			}],
+			"rang": 6,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "9092b3b2-7e1b-4cc1-a92f-6689bc566d99",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613091",
+			"ch": "BV",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "12:01:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "12:02:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T10:01:00+0000",
+				"heureLocale": "12:01:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T10:02:00+0000",
+				"heureLocale": "12:02:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"idMotifInterneArriveeReference": 24,
+			"idMotifInterneDepartReference": 24,
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T10:06:00+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 600,
+				"pronosticIV": 600,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T10:07:00+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 600,
+				"pronosticIV": 600,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 24,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifDepart": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 24,
+				"source": "IRE-GOP"
+			}],
+			"rang": 7,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "5d7dbc20-daa1-4dc9-aebe-7998afccf766",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613075",
+			"ch": "00",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "12:17:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "12:18:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T10:17:00+0000",
+				"heureLocale": "12:17:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T10:18:00+0000",
+				"heureLocale": "12:18:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"idMotifInterneArriveeReference": 24,
+			"idMotifInterneDepartReference": 24,
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T10:22:00+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 600,
+				"pronosticIV": 600,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T10:23:00+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 600,
+				"pronosticIV": 600,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 24,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifDepart": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 24,
+				"source": "IRE-GOP"
+			}],
+			"rang": 8,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "5733ad2f-918e-46e2-a287-610eb63fd7d3",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613059",
+			"ch": "BV",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "12:29:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "12:30:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T10:29:00+0000",
+				"heureLocale": "12:29:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T10:30:00+0000",
+				"heureLocale": "12:30:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"idMotifInterneArriveeReference": 24,
+			"idMotifInterneDepartReference": 24,
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T10:34:00+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 600,
+				"pronosticIV": 600,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T10:35:00+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 600,
+				"pronosticIV": 600,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 24,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifDepart": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 24,
+				"source": "IRE-GOP"
+			}],
+			"rang": 9,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "8cabf482-5316-43ee-bf75-7249fe1994b0",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "613042",
+			"ch": "BV",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "12:36:30",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "12:37:30",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T10:36:30+0000",
+				"heureLocale": "12:36:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T10:37:30+0000",
+				"heureLocale": "12:37:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"idMotifInterneArriveeReference": 24,
+			"idMotifInterneDepartReference": 24,
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T10:41:30+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 600,
+				"pronosticIV": 600,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T10:42:30+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 600,
+				"pronosticIV": 600,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 24,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifDepart": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 24,
+				"source": "IRE-GOP"
+			}],
+			"rang": 10,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "bd94ab98-a55a-49f2-97eb-bfb7de7ddbb6",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"categorieStatistiqueDepart": "RCT",
+			"cr": "0087",
+			"ci": "594572",
+			"ch": "00",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "12:51:30",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "12:52:30",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T10:51:30+0000",
+				"heureLocale": "12:51:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2018-11-02T10:52:30+0000",
+				"heureLocale": "12:52:30",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"idMotifInterneArriveeReference": 24,
+			"idMotifInterneDepartReference": 24,
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T10:56:30+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 600,
+				"pronosticIV": 600,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [{
+				"dateHeure": "2018-11-02T10:57:30+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 600,
+				"pronosticIV": 600,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifArrivee": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 24,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifDepart": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 24,
+				"source": "IRE-GOP"
+			}],
+			"rang": 11,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "c296a1f6-891b-4b1e-873f-0b438ebc001c",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "RCT",
+			"cr": "0087",
+			"ci": "594002",
+			"ch": "BV",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": true,
+				"heureLocale": "13:15:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2018-11-02T11:15:00+0000",
+				"heureLocale": "13:15:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0
+			},
+			"idMotifInterneArriveeReference": 24,
+			"listeHoraireProjeteArrivee": [{
+				"dateHeure": "2018-11-02T11:20:00+0000",
+				"dateHeureEmission": "2018-11-02T09:00:15+0000",
+				"pronosticBrut": 600,
+				"pronosticIV": 600,
+				"source": "IRE-GOP"
+			}],
+			"listeHoraireProjeteDepart": [],
+			"listeMotifArrivee": [{
+				"dateHeureDeclaration": "2018-11-02T09:00:15+0000",
+				"idMotifInterne": 24,
+				"source": "IRE-GOP"
+			}],
+			"listeMotifDepart": [],
+			"rang": 12,
+			"typeArret": "CH"
+		}],
+		"listeService": [],
+		"listeSubstitutionCourse": [],
+		"listeUtilisationSillon": [{
+			"identifiantSillon": {
+				"numeroOperationnelSillon": "870154",
+				"sillonTTH": "042610010014"
+			},
+			"listeJourRegimeDApplication": [{
+				"date": "2018-11-02"
+			}],
+			"listeJourRegimeFacultatif": [],
+			"pointDebutUtilisationSillon": {
+				"@id": "99fdb6ab-093d-4640-90f6-8509369553b2"
+			},
+			"pointFinUtilisationSillon": {
+				"@id": "c296a1f6-891b-4b1e-873f-0b438ebc001c"
+			},
+			"porteur": true,
+			"rangPRDebutUtilisationSillon": 1,
+			"decalagePasseMinuit": 0,
+			"rangPRFinUtilisationSillon": 26
+		}],
+		"numeroCourse": "870154",
+		"statutSillonCourse": "NON_CONNU",
+		"statutOperationnel": "PERTURBEE",
+		"systemeCreateur": "2148",
+		"type": "COURSE_OPE",
+		"@id": "d1fdf817-763c-4c10-9596-334e33a2e446"
+	}
+}

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -187,7 +187,9 @@ def test_cots_delayed_then_ok(mock_rabbitmq):
 def test_cots_partial_removal_delayed_then_partial_removal_ok(mock_rabbitmq):
     """
 
-    We delay a stop, then the vj is back on time
+    Removing first 5 stops and delay the rest by 10 min,
+    then only the first 4 stops are removed, the rest are back and on time
+    (no information on 10th stop so it should stay delayed)
     """
     cots_870154 = get_fixture_data('cots_train_870154_partial_removal_delay.json')
     res = api_post('/cots', data=cots_870154)

--- a/tests/integration/utils_sncf_test.py
+++ b/tests/integration/utils_sncf_test.py
@@ -113,7 +113,7 @@ def check_db_870154_partial_removal(contributor=None):
         # 12 stop times must have been created
         assert len(db_trip.stop_time_updates) == 12
 
-        # the first 5 stops are removed (Rodez to Viviez-Decazeville, also arrival in Capdenac)
+        # only the first 4 stops are removed (Rodez to Aubin) in both cases (delay or back to normal)
         first_st = db_trip.stop_time_updates[0]
         assert first_st.stop_id == 'stop_point:OCE:SP:TrainTER-87613422'
         assert first_st.arrival_status == 'none'
@@ -148,16 +148,10 @@ def check_db_870154_delay():
         assert len(StopTimeUpdate.query.all()) == 12
         db_trip = TripUpdate.find_by_dated_vj('OCE:SN870154F01001', datetime(2018, 11, 2, 9, 54, tzinfo=utc))
         assert db_trip
-
-        assert db_trip.vj.navitia_trip_id == 'OCE:SN870154F01001'
-        assert db_trip.vj.get_start_timestamp() == datetime(2018, 11, 2, 9, 54, tzinfo=utc)
-        assert db_trip.vj_id == db_trip.vj.id
-        assert db_trip.status == 'update'
         assert db_trip.message == u'Régulation du trafic'
-        # 12 stop times must have been created
-        assert len(db_trip.stop_time_updates) == 12
 
-        # departure, arrival at 5th and arrival at 6th stops are deleted with a cause
+        # only in "delay-case" departure, arrival at 5th (Viviez-Decazeville)
+        # and arrival at 6th stops (Capdenac) are deleted with a cause
         fifth_st = db_trip.stop_time_updates[4]
         assert fifth_st.stop_id == 'stop_point:OCE:SP:TrainTER-87613661'
         assert fifth_st.arrival_status == 'delete'
@@ -242,14 +236,7 @@ def check_db_870154_normal():
         assert len(StopTimeUpdate.query.all()) == 12
         db_trip = TripUpdate.find_by_dated_vj('OCE:SN870154F01001', datetime(2018, 11, 2, 9, 54, tzinfo=utc))
         assert db_trip
-
-        assert db_trip.vj.navitia_trip_id == 'OCE:SN870154F01001'
-        assert db_trip.vj.get_start_timestamp() == datetime(2018, 11, 2, 9, 54, tzinfo=utc)
-        assert db_trip.vj_id == db_trip.vj.id
-        assert db_trip.status == 'update'
         assert db_trip.message is None
-        # 12 stop times must have been created
-        assert len(db_trip.stop_time_updates) == 12
 
         # departure, arrival at 5th and arrival at 6th stops are back to normal
         fifth_st = db_trip.stop_time_updates[4]

--- a/tests/mock_navitia/__init__.py
+++ b/tests/mock_navitia/__init__.py
@@ -34,6 +34,7 @@ import vj_6113
 import vj_6112
 import vj_6114
 import vj_96231
+import vj_870154
 import vj_840426
 import vj_R_vj1
 import vj_R_vj2
@@ -48,6 +49,7 @@ mocks = [
     vj_6113.response,
     vj_6114.response,
     vj_96231.response,
+    vj_870154.response,
     vj_840426.response,
     vj_R_vj1.response,
     vj_R_vj2.response,

--- a/tests/mock_navitia/vj_870154.py
+++ b/tests/mock_navitia/vj_870154.py
@@ -1,0 +1,1026 @@
+# coding=utf-8
+# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+import navitia_response
+
+response = navitia_response.NavitiaResponse()
+
+response.query = 'vehicle_journeys/?depth=2&since=20181102T095400&headsign=870154&show_codes=true&until=20181102T141500'
+
+response.response_code = 200
+
+response.json_response = """{
+   "pagination":{
+      "start_page":0,
+      "items_on_page":1,
+      "items_per_page":25,
+      "total_result":1
+   },
+   "links":[
+      {
+         "href":"http:\/\/navitia2-ws.ctp.customer.canaltp.fr\/v1\/coverage\/sncf\/stop_points\/{stop_point.id}",
+         "type":"stop_point",
+         "rel":"stop_points",
+         "templated":true
+      },
+      {
+         "href":"http:\/\/navitia2-ws.ctp.customer.canaltp.fr\/v1\/coverage\/sncf\/stop_areas\/{stop_area.id}",
+         "type":"stop_area",
+         "rel":"stop_areas",
+         "templated":true
+      },
+      {
+         "href":"http:\/\/navitia2-ws.ctp.customer.canaltp.fr\/v1\/coverage\/sncf\/journey_patterns\/{journey_pattern.id}",
+         "type":"journey_pattern",
+         "rel":"journey_patterns",
+         "templated":true
+      },
+      {
+         "href":"http:\/\/navitia2-ws.ctp.customer.canaltp.fr\/v1\/coverage\/sncf\/routes\/{route.id}",
+         "type":"route",
+         "rel":"routes",
+         "templated":true
+      },
+      {
+         "href":"http:\/\/navitia2-ws.ctp.customer.canaltp.fr\/v1\/coverage\/sncf\/journey_pattern_points\/{journey_pattern_point.id}",
+         "type":"journey_pattern_point",
+         "rel":"journey_pattern_points",
+         "templated":true
+      },
+      {
+         "href":"http:\/\/navitia2-ws.ctp.customer.canaltp.fr\/v1\/coverage\/sncf\/vehicle_journeys\/{vehicle_journeys.id}",
+         "type":"vehicle_journeys",
+         "rel":"vehicle_journeys",
+         "templated":true
+      },
+      {
+         "href":"http:\/\/navitia2-ws.ctp.customer.canaltp.fr\/v1\/coverage\/sncf\/trips\/{trip.id}",
+         "type":"trip",
+         "rel":"trips",
+         "templated":true
+      },
+      {
+         "href":"http:\/\/navitia2-ws.ctp.customer.canaltp.fr\/v1\/coverage\/sncf\/vehicle_journeys?depth=2&since=20181102T095400&until=20181102T141500&headsign=870154",
+         "type":"first",
+         "templated":false
+      }
+   ],
+   "disruptions":[
+
+   ],
+   "feed_publishers":[
+
+   ],
+   "context":{
+      "timezone":"Europe\/Paris",
+      "current_datetime":"20181010T163752"
+   },
+   "vehicle_journeys":[
+      {
+         "codes":[
+
+         ],
+         "name":"870154",
+         "journey_pattern":{
+            "route":{
+               "direction":{
+                  "embedded_type":"stop_area",
+                  "stop_area":{
+                     "codes":[
+                        {
+                           "type":"CR-CI-CH",
+                           "value":"0087-594002-BV"
+                        },
+                        {
+                           "type":"UIC8",
+                           "value":"87594002"
+                        },
+                        {
+                           "type":"external_code",
+                           "value":"OCE87594002"
+                        }
+                     ],
+                     "name":"Brive-la-Gaillarde",
+                     "links":[
+
+                     ],
+                     "coord":{
+                        "lat":"45.152554",
+                        "lon":"1.528616"
+                     },
+                     "label":"Brive-la-Gaillarde (Brive-la-Gaillarde)",
+                     "timezone":"Europe\/Paris",
+                     "id":"stop_area:OCE:SA:87594002"
+                  },
+                  "quality":0,
+                  "name":"Brive-la-Gaillarde (Brive-la-Gaillarde)",
+                  "id":"stop_area:OCE:SA:87594002"
+               },
+               "name":"Rodez vers Brive-la-Gaillarde (Train TER)",
+               "links":[
+
+               ],
+               "is_frequence":"False",
+               "geojson":{
+                  "type":"MultiLineString",
+                  "coordinates":[
+
+                  ]
+               },
+               "direction_type":"backward",
+               "id":"route:OCE:4623-TrainTER-87613422-87594002"
+            },
+            "id":"journey_pattern:1204",
+            "name":"journey_pattern:1204"
+         },
+         "disruptions":[
+
+         ],
+         "calendars":[
+            {
+               "active_periods":[
+                  {
+                     "begin":"20181102",
+                     "end":"20181201"
+                  }
+               ],
+               "week_pattern":{
+                  "monday":true,
+                  "tuesday":true,
+                  "friday":true,
+                  "wednesday":true,
+                  "thursday":true,
+                  "sunday":false,
+                  "saturday":false
+               }
+            }
+         ],
+         "stop_times":[
+            {
+               "stop_point":{
+                  "name":"Rodez",
+                  "links":[
+
+                  ],
+                  "coord":{
+                     "lat":"44.362645",
+                     "lon":"2.580254"
+                  },
+                  "label":"Rodez (Rodez)",
+                  "equipments":[
+
+                  ],
+                  "administrative_regions":[
+                     {
+                        "insee":"12202",
+                        "name":"Rodez",
+                        "level":8,
+                        "coord":{
+                           "lat":"44.351002",
+                           "lon":"2.5733"
+                        },
+                        "label":"Rodez (12000)",
+                        "id":"admin:fr:12202",
+                        "zip_code":"12000"
+                     }
+                  ],
+                  "fare_zone":{
+                     "name":"0"
+                  },
+                  "id":"stop_point:OCE:SP:TrainTER-87613422",
+                  "stop_area":{
+                     "codes":[
+                        {
+                           "type":"CR-CI-CH",
+                           "value":"0087-613422-BV"
+                        },
+                        {
+                           "type":"UIC8",
+                           "value":"87613422"
+                        },
+                        {
+                           "type":"external_code",
+                           "value":"OCE87613422"
+                        }
+                     ],
+                     "name":"Rodez",
+                     "links":[
+
+                     ],
+                     "coord":{
+                        "lat":"44.362645",
+                        "lon":"2.580254"
+                     },
+                     "label":"Rodez (Rodez)",
+                     "timezone":"Europe\/Paris",
+                     "id":"stop_area:OCE:SA:87613422"
+                  }
+               },
+               "utc_arrival_time":"095400",
+               "utc_departure_time":"095400",
+               "headsign":"870154",
+               "arrival_time":"105400",
+               "journey_pattern_point":{
+                  "id":"journey_pattern_point:9786"
+               },
+               "departure_time":"105400"
+            },
+            {
+               "stop_point":{
+                  "name":"St-Christophe",
+                  "links":[
+
+                  ],
+                  "coord":{
+                     "lat":"44.464679",
+                     "lon":"2.407487"
+                  },
+                  "label":"St-Christophe (Saint-Christophe-Vallon)",
+                  "equipments":[
+
+                  ],
+                  "administrative_regions":[
+                     {
+                        "insee":"12215",
+                        "name":"Saint-Christophe-Vallon",
+                        "level":8,
+                        "coord":{
+                           "lat":"44.4702",
+                           "lon":"2.409979"
+                        },
+                        "label":"Saint-Christophe-Vallon (12330)",
+                        "id":"admin:fr:12215",
+                        "zip_code":"12330"
+                     }
+                  ],
+                  "fare_zone":{
+                     "name":"0"
+                  },
+                  "id":"stop_point:OCE:SP:TrainTER-87613257",
+                  "stop_area":{
+                     "codes":[
+                        {
+                           "type":"CR-CI-CH",
+                           "value":"0087-613257-00"
+                        },
+                        {
+                           "type":"UIC8",
+                           "value":"87613257"
+                        },
+                        {
+                           "type":"external_code",
+                           "value":"OCE87613257"
+                        }
+                     ],
+                     "name":"St-Christophe",
+                     "links":[
+
+                     ],
+                     "coord":{
+                        "lat":"44.464679",
+                        "lon":"2.407487"
+                     },
+                     "label":"St-Christophe (Saint-Christophe-Vallon)",
+                     "timezone":"Europe\/Paris",
+                     "id":"stop_area:OCE:SA:87613257"
+                  }
+               },
+               "utc_arrival_time":"101700",
+               "utc_departure_time":"101800",
+               "headsign":"870154",
+               "arrival_time":"111700",
+               "journey_pattern_point":{
+                  "id":"journey_pattern_point:9787"
+               },
+               "departure_time":"111800"
+            },
+            {
+               "stop_point":{
+                  "name":"Cransac",
+                  "links":[
+
+                  ],
+                  "coord":{
+                     "lat":"44.523054",
+                     "lon":"2.270766"
+                  },
+                  "label":"Cransac (Cransac)",
+                  "equipments":[
+
+                  ],
+                  "administrative_regions":[
+                     {
+                        "insee":"12083",
+                        "name":"Cransac",
+                        "level":8,
+                        "coord":{
+                           "lat":"44.524727",
+                           "lon":"2.281037"
+                        },
+                        "label":"Cransac (12110)",
+                        "id":"admin:fr:12083",
+                        "zip_code":"12110"
+                     }
+                  ],
+                  "fare_zone":{
+                     "name":"0"
+                  },
+                  "id":"stop_point:OCE:SP:TrainTER-87613232",
+                  "stop_area":{
+                     "codes":[
+                        {
+                           "type":"CR-CI-CH",
+                           "value":"0087-613232-00"
+                        },
+                        {
+                           "type":"UIC8",
+                           "value":"87613232"
+                        },
+                        {
+                           "type":"external_code",
+                           "value":"OCE87613232"
+                        }
+                     ],
+                     "name":"Cransac",
+                     "links":[
+
+                     ],
+                     "coord":{
+                        "lat":"44.523054",
+                        "lon":"2.270766"
+                     },
+                     "label":"Cransac (Cransac)",
+                     "timezone":"Europe\/Paris",
+                     "id":"stop_area:OCE:SA:87613232"
+                  }
+               },
+               "utc_arrival_time":"102900",
+               "utc_departure_time":"103000",
+               "headsign":"870154",
+               "arrival_time":"112900",
+               "journey_pattern_point":{
+                  "id":"journey_pattern_point:9788"
+               },
+               "departure_time":"113000"
+            },
+            {
+               "stop_point":{
+                  "name":"Aubin",
+                  "links":[
+
+                  ],
+                  "coord":{
+                     "lat":"44.527347",
+                     "lon":"2.239558"
+                  },
+                  "label":"Aubin (Aubin)",
+                  "equipments":[
+
+                  ],
+                  "administrative_regions":[
+                     {
+                        "insee":"12013",
+                        "name":"Aubin",
+                        "level":8,
+                        "coord":{
+                           "lat":"44.527306",
+                           "lon":"2.243437"
+                        },
+                        "label":"Aubin (12110)",
+                        "id":"admin:fr:12013",
+                        "zip_code":"12110"
+                     }
+                  ],
+                  "fare_zone":{
+                     "name":"0"
+                  },
+                  "id":"stop_point:OCE:SP:TrainTER-87613224",
+                  "stop_area":{
+                     "codes":[
+                        {
+                           "type":"CR-CI-CH",
+                           "value":"0087-613224-00"
+                        },
+                        {
+                           "type":"UIC8",
+                           "value":"87613224"
+                        },
+                        {
+                           "type":"external_code",
+                           "value":"OCE87613224"
+                        }
+                     ],
+                     "name":"Aubin",
+                     "links":[
+
+                     ],
+                     "coord":{
+                        "lat":"44.527347",
+                        "lon":"2.239558"
+                     },
+                     "label":"Aubin (Aubin)",
+                     "timezone":"Europe\/Paris",
+                     "id":"stop_area:OCE:SA:87613224"
+                  }
+               },
+               "utc_arrival_time":"103300",
+               "utc_departure_time":"103400",
+               "headsign":"870154",
+               "arrival_time":"113300",
+               "journey_pattern_point":{
+                  "id":"journey_pattern_point:9789"
+               },
+               "departure_time":"113400"
+            },
+            {
+               "stop_point":{
+                  "name":"Viviez-Decazeville",
+                  "links":[
+
+                  ],
+                  "coord":{
+                     "lat":"44.55703",
+                     "lon":"2.218023"
+                  },
+                  "label":"Viviez-Decazeville (Viviez)",
+                  "equipments":[
+
+                  ],
+                  "administrative_regions":[
+                     {
+                        "insee":"12305",
+                        "name":"Viviez",
+                        "level":8,
+                        "coord":{
+                           "lat":"44.555798",
+                           "lon":"2.215909"
+                        },
+                        "label":"Viviez (12110)",
+                        "id":"admin:fr:12305",
+                        "zip_code":"12110"
+                     }
+                  ],
+                  "fare_zone":{
+                     "name":"0"
+                  },
+                  "id":"stop_point:OCE:SP:TrainTER-87613661",
+                  "stop_area":{
+                     "codes":[
+                        {
+                           "type":"CR-CI-CH",
+                           "value":"0087-613661-BV"
+                        },
+                        {
+                           "type":"UIC8",
+                           "value":"87613661"
+                        },
+                        {
+                           "type":"external_code",
+                           "value":"OCE87613661"
+                        }
+                     ],
+                     "name":"Viviez-Decazeville",
+                     "links":[
+
+                     ],
+                     "coord":{
+                        "lat":"44.55703",
+                        "lon":"2.218023"
+                     },
+                     "label":"Viviez-Decazeville (Viviez)",
+                     "timezone":"Europe\/Paris",
+                     "id":"stop_area:OCE:SA:87613661"
+                  }
+               },
+               "utc_arrival_time":"103800",
+               "utc_departure_time":"103900",
+               "headsign":"870154",
+               "arrival_time":"113800",
+               "journey_pattern_point":{
+                  "id":"journey_pattern_point:9790"
+               },
+               "departure_time":"113900"
+            },
+            {
+               "stop_point":{
+                  "name":"Capdenac",
+                  "links":[
+
+                  ],
+                  "coord":{
+                     "lat":"44.577647",
+                     "lon":"2.0789"
+                  },
+                  "label":"Capdenac (Capdenac-Gare)",
+                  "equipments":[
+
+                  ],
+                  "administrative_regions":[
+                     {
+                        "insee":"12052",
+                        "name":"Capdenac-Gare",
+                        "level":8,
+                        "coord":{
+                           "lat":"44.574112",
+                           "lon":"2.080516"
+                        },
+                        "label":"Capdenac-Gare (12700)",
+                        "id":"admin:fr:12052",
+                        "zip_code":"12700"
+                     }
+                  ],
+                  "fare_zone":{
+                     "name":"0"
+                  },
+                  "id":"stop_point:OCE:SP:TrainTER-87613109",
+                  "stop_area":{
+                     "codes":[
+                        {
+                           "type":"CR-CI-CH",
+                           "value":"0087-613109-BV"
+                        },
+                        {
+                           "type":"UIC8",
+                           "value":"87613109"
+                        },
+                        {
+                           "type":"external_code",
+                           "value":"OCE87613109"
+                        }
+                     ],
+                     "name":"Capdenac",
+                     "links":[
+
+                     ],
+                     "coord":{
+                        "lat":"44.577647",
+                        "lon":"2.0789"
+                     },
+                     "label":"Capdenac (Capdenac-Gare)",
+                     "timezone":"Europe\/Paris",
+                     "id":"stop_area:OCE:SA:87613109"
+                  }
+               },
+               "utc_arrival_time":"105300",
+               "utc_departure_time":"105500",
+               "headsign":"870154",
+               "arrival_time":"115300",
+               "journey_pattern_point":{
+                  "id":"journey_pattern_point:9791"
+               },
+               "departure_time":"115500"
+            },
+            {
+               "stop_point":{
+                  "name":"Figeac",
+                  "links":[
+
+                  ],
+                  "coord":{
+                     "lat":"44.603505",
+                     "lon":"2.037074"
+                  },
+                  "label":"Figeac (Figeac)",
+                  "equipments":[
+
+                  ],
+                  "administrative_regions":[
+                     {
+                        "insee":"46102",
+                        "name":"Figeac",
+                        "level":8,
+                        "coord":{
+                           "lat":"44.609234",
+                           "lon":"2.032432"
+                        },
+                        "label":"Figeac (46100)",
+                        "id":"admin:fr:46102",
+                        "zip_code":"46100"
+                     }
+                  ],
+                  "fare_zone":{
+                     "name":"0"
+                  },
+                  "id":"stop_point:OCE:SP:TrainTER-87613091",
+                  "stop_area":{
+                     "codes":[
+                        {
+                           "type":"CR-CI-CH",
+                           "value":"0087-613091-BV"
+                        },
+                        {
+                           "type":"UIC8",
+                           "value":"87613091"
+                        },
+                        {
+                           "type":"external_code",
+                           "value":"OCE87613091"
+                        }
+                     ],
+                     "name":"Figeac",
+                     "links":[
+
+                     ],
+                     "coord":{
+                        "lat":"44.603505",
+                        "lon":"2.037074"
+                     },
+                     "label":"Figeac (Figeac)",
+                     "timezone":"Europe\/Paris",
+                     "id":"stop_area:OCE:SA:87613091"
+                  }
+               },
+               "utc_arrival_time":"110100",
+               "utc_departure_time":"110200",
+               "headsign":"870154",
+               "arrival_time":"120100",
+               "journey_pattern_point":{
+                  "id":"journey_pattern_point:9792"
+               },
+               "departure_time":"120200"
+            },
+            {
+               "stop_point":{
+                  "name":"Assier",
+                  "links":[
+
+                  ],
+                  "coord":{
+                     "lat":"44.674584",
+                     "lon":"1.869744"
+                  },
+                  "label":"Assier (Assier)",
+                  "equipments":[
+
+                  ],
+                  "administrative_regions":[
+                     {
+                        "insee":"46009",
+                        "name":"Assier",
+                        "level":8,
+                        "coord":{
+                           "lat":"44.675301",
+                           "lon":"1.876286"
+                        },
+                        "label":"Assier (46320)",
+                        "id":"admin:fr:46009",
+                        "zip_code":"46320"
+                     }
+                  ],
+                  "fare_zone":{
+                     "name":"0"
+                  },
+                  "id":"stop_point:OCE:SP:TrainTER-87613075",
+                  "stop_area":{
+                     "codes":[
+                        {
+                           "type":"CR-CI-CH",
+                           "value":"0087-613075-00"
+                        },
+                        {
+                           "type":"UIC8",
+                           "value":"87613075"
+                        },
+                        {
+                           "type":"external_code",
+                           "value":"OCE87613075"
+                        }
+                     ],
+                     "name":"Assier",
+                     "links":[
+
+                     ],
+                     "coord":{
+                        "lat":"44.674584",
+                        "lon":"1.869744"
+                     },
+                     "label":"Assier (Assier)",
+                     "timezone":"Europe\/Paris",
+                     "id":"stop_area:OCE:SA:87613075"
+                  }
+               },
+               "utc_arrival_time":"111700",
+               "utc_departure_time":"111800",
+               "headsign":"870154",
+               "arrival_time":"121700",
+               "journey_pattern_point":{
+                  "id":"journey_pattern_point:9793"
+               },
+               "departure_time":"121800"
+            },
+            {
+               "stop_point":{
+                  "name":"Gramat",
+                  "links":[
+
+                  ],
+                  "coord":{
+                     "lat":"44.77348",
+                     "lon":"1.722367"
+                  },
+                  "label":"Gramat (Gramat)",
+                  "equipments":[
+
+                  ],
+                  "administrative_regions":[
+                     {
+                        "insee":"46128",
+                        "name":"Gramat",
+                        "level":8,
+                        "coord":{
+                           "lat":"44.778996",
+                           "lon":"1.723394"
+                        },
+                        "label":"Gramat (46500)",
+                        "id":"admin:fr:46128",
+                        "zip_code":"46500"
+                     }
+                  ],
+                  "fare_zone":{
+                     "name":"0"
+                  },
+                  "id":"stop_point:OCE:SP:TrainTER-87613059",
+                  "stop_area":{
+                     "codes":[
+                        {
+                           "type":"CR-CI-CH",
+                           "value":"0087-613059-BV"
+                        },
+                        {
+                           "type":"UIC8",
+                           "value":"87613059"
+                        },
+                        {
+                           "type":"external_code",
+                           "value":"OCE87613059"
+                        }
+                     ],
+                     "name":"Gramat",
+                     "links":[
+
+                     ],
+                     "coord":{
+                        "lat":"44.77348",
+                        "lon":"1.722367"
+                     },
+                     "label":"Gramat (Gramat)",
+                     "timezone":"Europe\/Paris",
+                     "id":"stop_area:OCE:SA:87613059"
+                  }
+               },
+               "utc_arrival_time":"112900",
+               "utc_departure_time":"113000",
+               "headsign":"870154",
+               "arrival_time":"122900",
+               "journey_pattern_point":{
+                  "id":"journey_pattern_point:9794"
+               },
+               "departure_time":"123000"
+            },
+            {
+               "stop_point":{
+                  "name":"Rocamadour-Padirac",
+                  "links":[
+
+                  ],
+                  "coord":{
+                     "lat":"44.817902",
+                     "lon":"1.657441"
+                  },
+                  "label":"Rocamadour-Padirac (Rocamadour)",
+                  "equipments":[
+
+                  ],
+                  "administrative_regions":[
+                     {
+                        "insee":"46240",
+                        "name":"Rocamadour",
+                        "level":8,
+                        "coord":{
+                           "lat":"44.799187",
+                           "lon":"1.618352"
+                        },
+                        "label":"Rocamadour (46500)",
+                        "id":"admin:fr:46240",
+                        "zip_code":"46500"
+                     }
+                  ],
+                  "fare_zone":{
+                     "name":"0"
+                  },
+                  "id":"stop_point:OCE:SP:TrainTER-87613042",
+                  "stop_area":{
+                     "codes":[
+                        {
+                           "type":"CR-CI-CH",
+                           "value":"0087-613042-BV"
+                        },
+                        {
+                           "type":"UIC8",
+                           "value":"87613042"
+                        },
+                        {
+                           "type":"external_code",
+                           "value":"OCE87613042"
+                        }
+                     ],
+                     "name":"Rocamadour-Padirac",
+                     "links":[
+
+                     ],
+                     "coord":{
+                        "lat":"44.817902",
+                        "lon":"1.657441"
+                     },
+                     "label":"Rocamadour-Padirac (Rocamadour)",
+                     "timezone":"Europe\/Paris",
+                     "id":"stop_area:OCE:SA:87613042"
+                  }
+               },
+               "utc_arrival_time":"113600",
+               "utc_departure_time":"113700",
+               "headsign":"870154",
+               "arrival_time":"123600",
+               "journey_pattern_point":{
+                  "id":"journey_pattern_point:9795"
+               },
+               "departure_time":"123700"
+            },
+            {
+               "stop_point":{
+                  "name":"St-Denis-pr\u00e8s-Martel",
+                  "links":[
+
+                  ],
+                  "coord":{
+                     "lat":"44.945783",
+                     "lon":"1.666282"
+                  },
+                  "label":"St-Denis-pr\u00e8s-Martel (Saint-Denis-l\u00e8s-Martel)",
+                  "equipments":[
+
+                  ],
+                  "administrative_regions":[
+                     {
+                        "insee":"46265",
+                        "name":"Saint-Denis-l\u00e8s-Martel",
+                        "level":8,
+                        "coord":{
+                           "lat":"44.940029",
+                           "lon":"1.661536"
+                        },
+                        "label":"Saint-Denis-l\u00e8s-Martel (46600)",
+                        "id":"admin:fr:46265",
+                        "zip_code":"46600"
+                     }
+                  ],
+                  "fare_zone":{
+                     "name":"0"
+                  },
+                  "id":"stop_point:OCE:SP:TrainTER-87594572",
+                  "stop_area":{
+                     "codes":[
+                        {
+                           "type":"CR-CI-CH",
+                           "value":"0087-594572-00"
+                        },
+                        {
+                           "type":"UIC8",
+                           "value":"87594572"
+                        },
+                        {
+                           "type":"external_code",
+                           "value":"OCE87594572"
+                        }
+                     ],
+                     "name":"St-Denis-pr\u00e8s-Martel",
+                     "links":[
+
+                     ],
+                     "coord":{
+                        "lat":"44.945783",
+                        "lon":"1.666282"
+                     },
+                     "label":"St-Denis-pr\u00e8s-Martel (Saint-Denis-l\u00e8s-Martel)",
+                     "timezone":"Europe\/Paris",
+                     "id":"stop_area:OCE:SA:87594572"
+                  }
+               },
+               "utc_arrival_time":"115100",
+               "utc_departure_time":"115200",
+               "headsign":"870154",
+               "arrival_time":"125100",
+               "journey_pattern_point":{
+                  "id":"journey_pattern_point:9796"
+               },
+               "departure_time":"125200"
+            },
+            {
+               "stop_point":{
+                  "name":"Brive-la-Gaillarde",
+                  "links":[
+
+                  ],
+                  "coord":{
+                     "lat":"45.152554",
+                     "lon":"1.528616"
+                  },
+                  "label":"Brive-la-Gaillarde (Brive-la-Gaillarde)",
+                  "equipments":[
+
+                  ],
+                  "administrative_regions":[
+                     {
+                        "insee":"19031",
+                        "name":"Brive-la-Gaillarde",
+                        "level":8,
+                        "coord":{
+                           "lat":"45.158497",
+                           "lon":"1.533238"
+                        },
+                        "label":"Brive-la-Gaillarde (19100)",
+                        "id":"admin:fr:19031",
+                        "zip_code":"19100"
+                     }
+                  ],
+                  "fare_zone":{
+                     "name":"0"
+                  },
+                  "id":"stop_point:OCE:SP:TrainTER-87594002",
+                  "stop_area":{
+                     "codes":[
+                        {
+                           "type":"CR-CI-CH",
+                           "value":"0087-594002-BV"
+                        },
+                        {
+                           "type":"UIC8",
+                           "value":"87594002"
+                        },
+                        {
+                           "type":"external_code",
+                           "value":"OCE87594002"
+                        }
+                     ],
+                     "name":"Brive-la-Gaillarde",
+                     "links":[
+
+                     ],
+                     "coord":{
+                        "lat":"45.152554",
+                        "lon":"1.528616"
+                     },
+                     "label":"Brive-la-Gaillarde (Brive-la-Gaillarde)",
+                     "timezone":"Europe\/Paris",
+                     "id":"stop_area:OCE:SA:87594002"
+                  }
+               },
+               "utc_arrival_time":"121500",
+               "utc_departure_time":"121500",
+               "headsign":"870154",
+               "arrival_time":"131500",
+               "journey_pattern_point":{
+                  "id":"journey_pattern_point:9797"
+               },
+               "departure_time":"131500"
+            }
+         ],
+         "validity_pattern":{
+            "beginning_date":"20181009",
+            "days":"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011111001111100111110011111001000000000000000000000000"
+         },
+         "id":"vehicle_journey:OCE:SN870154F01001",
+         "trip":{
+            "id":"OCE:SN870154F01001",
+            "name":"870154"
+         }
+      }
+   ]
+}
+"""


### PR DESCRIPTION
Fix https://github.com/CanalTP/kirin/issues/182
(mostly inspired from provided feeds)

* (partial removal + delay) then (one stop removed and delayed stops are OK)
* test also behavior when missing some info on back-to-normal feed (on delayed stops)
* test that causes disappear correctly

- [x] hand-tested with navitia plugged on Artemis' instance