### PR TITLE
Read base_schedule stop_times from horaireVoyageurDepart/dateHeure

### DIFF
--- a/kirin/abstract_sncf_model_maker.py
+++ b/kirin/abstract_sncf_model_maker.py
@@ -45,7 +45,7 @@ def to_navitia_str(dt):
     """
     format a datetime to a navitia-readable str
     """
-    return dt.strftime("%Y%m%dT%H%M%S")
+    return dt.strftime("%Y%m%dT%H%M%S%z")
 
 
 def headsigns(str):

--- a/kirin/cots/model_maker.py
+++ b/kirin/cots/model_maker.py
@@ -208,14 +208,11 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
             raise InvalidArguments('invalid json, "listePointDeParcours" has no valid stop_time in '
                                    'json elt {elt}'.format(elt=ujson.dumps(json_train)))
 
-        dates_str = [get_value(d, 'date') for d in get_value(json_train, 'listeJourRegimeDApplication')]
-        date = min([as_date(d) for d in dates_str]).date()
-        str_time_start = get_value(get_value(pdps[0], 'horaireVoyageurDepart'), 'heureLocale')
-        time_start = datetime.strptime(str_time_start, '%H:%M:%S').time()
-        vj_start = datetime.combine(date, time_start)
-        str_time_end = get_value(get_value(pdps[-1], 'horaireVoyageurArrivee'), 'heureLocale')
-        time_end = datetime.strptime(str_time_end, '%H:%M:%S').time()
-        vj_end = datetime.combine(date, time_end)
+        str_time_start = get_value(get_value(pdps[0], 'horaireVoyageurDepart'), 'dateHeure')
+        vj_start = parser.parse(str_time_start, dayfirst=False, yearfirst=True, ignoretz=False)
+
+        str_time_end = get_value(get_value(pdps[-1], 'horaireVoyageurArrivee'), 'dateHeure')
+        vj_end = parser.parse(str_time_end, dayfirst=False, yearfirst=True, ignoretz=False)
 
         return self._get_navitia_vjs(train_numbers, vj_start, vj_end)
 

--- a/tests/fixtures/cots_train_6111_pass_midnight_trip_removal.json
+++ b/tests/fixtures/cots_train_6111_pass_midnight_trip_removal.json
@@ -1,0 +1,183 @@
+{
+	"ressource": "courseOPE",
+	"mode": "modification",
+	"evt": ["PERTURBATION"],
+	"PdPObserveArrivee": [],
+	"PdPObserveDepart": [],
+	"PdPPronosticBrutArrivee": [],
+	"PdPPronosticBrutDepart": [],
+	"PdPPronosticIVArrivee": [],
+	"PdPPronosticIVDepart": [],
+	"PdPImpacteDepart": ["30aeb202-ac22-4d49-b6e7-7a20b282579f",
+	"62f6c51d-5685-4bd6-96f1-7e705aab1125",
+	"0042c560-acda-45a8-b4a3-398b7f805686",
+	"96ba8aaa-dc50-4f08-9da9-f3d39243c9a7",
+	"6cc75c0b-3664-4b56-9a33-6bf5349ae5fe",
+	"314ba1c6-42e7-49a3-ac60-53b55737134a",
+	"c12743ed-c02d-468b-a55e-b4c288fc9eab"],
+	"PdPImpacteArrivee": ["1a4baffb-e043-4b07-8a5c-8a4ec468cdd2",
+	"62f6c51d-5685-4bd6-96f1-7e705aab1125",
+	"0042c560-acda-45a8-b4a3-398b7f805686",
+	"96ba8aaa-dc50-4f08-9da9-f3d39243c9a7",
+	"6cc75c0b-3664-4b56-9a33-6bf5349ae5fe",
+	"314ba1c6-42e7-49a3-ac60-53b55737134a",
+	"c12743ed-c02d-468b-a55e-b4c288fc9eab"],
+	"nouvelleVersion": {
+		"codeCompagnieTransporteur": "1187",
+		"codeMarqueTransporteur": "TGV",
+		"codeRelation": "1",
+		"codeService": "A2018",
+		"codeSousRelation": "001200",
+		"codeTransporteurResponsable": "1N",
+		"codeTypeMoyenTransport": "0",
+		"coursePTA": {
+			"@id": "7ef94a59-05d6-4da3-acd8-09ab6b607beb"
+		},
+		"dateDebutService": "2017-12-10",
+		"dateDerniereModification": "2015-10-06T07:49:50+0000",
+		"dateFinService": "2018-12-08",
+		"estDiscontinue": false,
+		"estTechnique": false,
+		"estimationManuelle": false,
+		"etat": "ACTIVE",
+		"idVersion": "db1e8b70-9c8d-4320-b9f6-45c45a9b4e9d",
+		"identifiantDansSystemeCreateur": "a3ce8bfa-4fcd-4cc1-97f2-dfb94e742107",
+		"indicateurFer": "FERRE",
+		"listeCouplageCourseOPE": [{
+			"courseCouplee": {
+				"codeCompagnieTransporteur": "1187",
+				"dateCirculation": "2015-10-06",
+				"indicateurFer": "FERRE",
+				"numeroCourse": "5032",
+				"@id": "f7b2e08e-ced6-4f5d-86b5-8d34461da03b"
+			},
+			"pointDebutCouplage": {
+				"@id": "30aeb202-ac22-4d49-b6e7-7a20b282579f"
+			},
+			"pointFinCouplage": {
+				"@id": "1a4baffb-e043-4b07-8a5c-8a4ec468cdd2"
+			}
+		}],
+		"listeCodeTransporteurAssocie": [],
+		"listeEvenement": [],
+		"listeJourRegimeDApplication": [{
+			"date": "2015-10-06"
+		}],
+		"listeJourRegimeFacultatif": [],
+		"idMotifInterneReference": 1,
+		"listeMotif": [{
+			"dateHeureDeclaration": "2015-10-06T07:49:50+0000",
+			"idMotifInterne": 1,
+			"source": "IRE-GOP"
+		}],
+		"listePointDeParcours": [{
+			"@id": "30aeb202-ac22-4d49-b6e7-7a20b282579f",
+			"arretFacultatif": false,
+			"categorieStatistiqueDepart": "LVN",
+			"cr": "0087",
+			"ci": "686006",
+			"ch": "BV",
+			"horaireProductionDepart": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": false,
+				"heureLocale": "23:16:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurDepart": {
+				"dateHeure": "2015-10-06T21:16:00+0000",
+				"heureLocale": "23:16:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"listeHoraireProjeteArrivee": [],
+			"listeHoraireProjeteDepart": [],
+			"listeMotifArrivee": [],
+			"listeMotifDepart": [],
+			"rang": 1,
+			"typeArret": "CH"
+		},
+		{
+			"@id": "0042c560-acda-45a8-b4a3-398b7f805686",
+			"arretFacultatif": false,
+			"categorieStatistiqueArrivee": "LVN",
+			"categorieStatistiqueDepart": "LVN",
+			"cr": "0087",
+			"ci": "751008",
+			"ch": "BV",
+			"horaireProductionArrivee": {
+				"idFuseauHoraire": "Europe/Paris",
+				"heureIncertaine": false,
+				"heureLocale": "06:34:00",
+				"nbJoursPasseMinuit": 0
+			},
+			"horaireVoyageurArrivee": {
+				"dateHeure": "2015-10-07T04:34:00+0000",
+				"heureLocale": "06:34:00",
+				"idFuseauHoraire": "Europe/Paris",
+				"nbJoursPasseMinuit": 0,
+				"statutCirculationOPE": "SUPPRESSION"
+			},
+			"listeHoraireProjeteArrivee": [],
+			"listeMotifArrivee": [],
+			"rang": 2,
+			"typeArret": "CH"
+		}],
+		"listeService": [{
+			"code": "CS01",
+			"listeJourRegimeDApplication": [{
+				"date": "2015-10-06"
+			}],
+			"listePropriete": [{
+				"code": "CP001",
+				"metaPropriete": {
+					"@id": "95352652-200c-430b-8a94-3852677c91ea"
+				},
+				"valeurChaine": "D"
+			},
+			{
+				"code": "CP002",
+				"metaPropriete": {
+					"@id": "350d89f9-8667-4456-9186-765ce07ea238"
+				},
+				"valeurChaine": "O"
+			}],
+			"metaService": {
+				"@id": "590ecf63-8dcc-46d5-b238-391fd681eba1"
+			},
+			"pointDeParcoursDebut": {
+				"@id": "30aeb202-ac22-4d49-b6e7-7a20b282579f"
+			},
+			"pointDeParcoursFin": {
+				"@id": "1a4baffb-e043-4b07-8a5c-8a4ec468cdd2"
+			}
+		}],
+		"listeSubstitutionCourse": [],
+		"listeUtilisationSillon": [{
+			"identifiantSillon": {
+				"numeroOperationnelSillon": "006111",
+				"sillonTTH": "042521690015"
+			},
+			"listeJourRegimeDApplication": [{
+				"date": "2015-10-06"
+			}],
+			"listeJourRegimeFacultatif": [],
+			"pointDebutUtilisationSillon": {
+				"@id": "30aeb202-ac22-4d49-b6e7-7a20b282579f"
+			},
+			"pointFinUtilisationSillon": {
+				"@id": "1a4baffb-e043-4b07-8a5c-8a4ec468cdd2"
+			},
+			"porteur": true,
+			"rangPRDebutUtilisationSillon": 1,
+			"decalagePasseMinuit": 0,
+			"rangPRFinUtilisationSillon": 133
+		}],
+		"numeroCourse": "006111",
+		"statutSillonCourse": "NON_CONNU",
+		"statutOperationnel": "SUPPRIMEE",
+		"systemeCreateur": "2148",
+		"type": "COURSE_OPE",
+		"@id": "a3ce8bfa-4fcd-4cc1-97f2-dfb94e742107"
+	}
+}

--- a/tests/fixtures/cots_train_870154_partial_normal.json
+++ b/tests/fixtures/cots_train_870154_partial_normal.json
@@ -103,7 +103,7 @@
 				"statutCirculationOPE": "SUPPRESSION"
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T08:54:00+0000",
+				"dateHeure": "2018-11-02T09:54:00+0000",
 				"heureLocale": "10:54:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0,
@@ -112,7 +112,7 @@
 			"idMotifInterneDepartReference": 98,
 			"listeHoraireProjeteArrivee": [],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T08:59:00+0000",
+				"dateHeure": "2018-11-02T09:59:00+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 300,
 				"pronosticIV": 300,
@@ -150,14 +150,14 @@
 				"statutCirculationOPE": "SUPPRESSION"
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T09:17:30+0000",
+				"dateHeure": "2018-11-02T10:17:30+0000",
 				"heureLocale": "11:17:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0,
 				"statutCirculationOPE": "SUPPRESSION"
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T09:18:30+0000",
+				"dateHeure": "2018-11-02T10:18:30+0000",
 				"heureLocale": "11:18:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0,
@@ -166,14 +166,14 @@
 			"idMotifInterneArriveeReference": 9,
 			"idMotifInterneDepartReference": 9,
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T09:17:00+0000",
+				"dateHeure": "2018-11-02T10:17:00+0000",
 				"dateHeureEmission": "2018-11-02T09:20:07+0000",
 				"pronosticBrut": 0,
 				"pronosticIV": 0,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T09:18:00+0000",
+				"dateHeure": "2018-11-02T10:18:00+0000",
 				"dateHeureEmission": "2018-11-02T09:20:07+0000",
 				"pronosticBrut": 0,
 				"pronosticIV": 0,
@@ -225,14 +225,14 @@
 				"statutCirculationOPE": "SUPPRESSION"
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T09:29:30+0000",
+				"dateHeure": "2018-11-02T10:29:30+0000",
 				"heureLocale": "11:29:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0,
 				"statutCirculationOPE": "SUPPRESSION"
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T09:30:30+0000",
+				"dateHeure": "2018-11-02T10:30:30+0000",
 				"heureLocale": "11:30:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0,
@@ -241,14 +241,14 @@
 			"idMotifInterneArriveeReference": 9,
 			"idMotifInterneDepartReference": 9,
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T09:29:00+0000",
+				"dateHeure": "2018-11-02T10:29:00+0000",
 				"dateHeureEmission": "2018-11-02T09:20:07+0000",
 				"pronosticBrut": 0,
 				"pronosticIV": 0,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T09:30:00+0000",
+				"dateHeure": "2018-11-02T10:30:00+0000",
 				"dateHeureEmission": "2018-11-02T09:20:07+0000",
 				"pronosticBrut": 0,
 				"pronosticIV": 0,
@@ -300,14 +300,14 @@
 				"statutCirculationOPE": "SUPPRESSION"
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T09:33:30+0000",
+				"dateHeure": "2018-11-02T10:33:30+0000",
 				"heureLocale": "11:33:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0,
 				"statutCirculationOPE": "SUPPRESSION"
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T09:34:30+0000",
+				"dateHeure": "2018-11-02T10:34:30+0000",
 				"heureLocale": "11:34:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0,
@@ -316,14 +316,14 @@
 			"idMotifInterneArriveeReference": 9,
 			"idMotifInterneDepartReference": 9,
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T09:33:00+0000",
+				"dateHeure": "2018-11-02T10:33:00+0000",
 				"dateHeureEmission": "2018-11-02T09:20:07+0000",
 				"pronosticBrut": 0,
 				"pronosticIV": 0,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T09:34:00+0000",
+				"dateHeure": "2018-11-02T10:34:00+0000",
 				"dateHeureEmission": "2018-11-02T09:20:07+0000",
 				"pronosticBrut": 0,
 				"pronosticIV": 0,
@@ -373,26 +373,26 @@
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T09:38:30+0000",
+				"dateHeure": "2018-11-02T10:38:30+0000",
 				"heureLocale": "11:38:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T09:39:30+0000",
+				"dateHeure": "2018-11-02T10:39:30+0000",
 				"heureLocale": "11:39:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T09:38:00+0000",
+				"dateHeure": "2018-11-02T10:38:00+0000",
 				"dateHeureEmission": "2018-11-02T09:20:07+0000",
 				"pronosticBrut": 0,
 				"pronosticIV": 0,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T09:39:00+0000",
+				"dateHeure": "2018-11-02T10:39:00+0000",
 				"dateHeureEmission": "2018-11-02T09:20:07+0000",
 				"pronosticBrut": 0,
 				"pronosticIV": 0,
@@ -424,26 +424,26 @@
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T09:53:00+0000",
+				"dateHeure": "2018-11-02T10:53:00+0000",
 				"heureLocale": "11:53:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T09:55:00+0000",
+				"dateHeure": "2018-11-02T10:55:00+0000",
 				"heureLocale": "11:55:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T09:53:00+0000",
+				"dateHeure": "2018-11-02T10:53:00+0000",
 				"dateHeureEmission": "2018-11-02T09:20:07+0000",
 				"pronosticBrut": 0,
 				"pronosticIV": 0,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T09:55:00+0000",
+				"dateHeure": "2018-11-02T10:55:00+0000",
 				"dateHeureEmission": "2018-11-02T09:20:07+0000",
 				"pronosticBrut": 0,
 				"pronosticIV": 0,
@@ -475,13 +475,13 @@
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T10:01:00+0000",
+				"dateHeure": "2018-11-02T11:01:00+0000",
 				"heureLocale": "12:01:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T10:02:00+0000",
+				"dateHeure": "2018-11-02T11:02:00+0000",
 				"heureLocale": "12:02:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
@@ -512,26 +512,26 @@
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T10:17:00+0000",
+				"dateHeure": "2018-11-02T11:17:00+0000",
 				"heureLocale": "12:17:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T10:18:00+0000",
+				"dateHeure": "2018-11-02T11:18:00+0000",
 				"heureLocale": "12:18:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T10:17:00+0000",
+				"dateHeure": "2018-11-02T11:17:00+0000",
 				"dateHeureEmission": "2018-11-02T09:20:07+0000",
 				"pronosticBrut": 0,
 				"pronosticIV": 0,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T10:18:00+0000",
+				"dateHeure": "2018-11-02T11:18:00+0000",
 				"dateHeureEmission": "2018-11-02T09:20:07+0000",
 				"pronosticBrut": 0,
 				"pronosticIV": 0,
@@ -563,26 +563,26 @@
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T10:29:00+0000",
+				"dateHeure": "2018-11-02T11:29:00+0000",
 				"heureLocale": "12:29:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T10:30:00+0000",
+				"dateHeure": "2018-11-02T11:30:00+0000",
 				"heureLocale": "12:30:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T10:29:00+0000",
+				"dateHeure": "2018-11-02T11:29:00+0000",
 				"dateHeureEmission": "2018-11-02T09:20:07+0000",
 				"pronosticBrut": 0,
 				"pronosticIV": 0,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T10:30:00+0000",
+				"dateHeure": "2018-11-02T11:30:00+0000",
 				"dateHeureEmission": "2018-11-02T09:20:07+0000",
 				"pronosticBrut": 0,
 				"pronosticIV": 0,
@@ -614,26 +614,26 @@
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T10:51:30+0000",
+				"dateHeure": "2018-11-02T11:51:30+0000",
 				"heureLocale": "12:51:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T10:52:30+0000",
+				"dateHeure": "2018-11-02T11:52:30+0000",
 				"heureLocale": "12:52:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T10:51:00+0000",
+				"dateHeure": "2018-11-02T11:51:00+0000",
 				"dateHeureEmission": "2018-11-02T09:20:07+0000",
 				"pronosticBrut": 0,
 				"pronosticIV": 0,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T10:52:00+0000",
+				"dateHeure": "2018-11-02T11:52:00+0000",
 				"dateHeureEmission": "2018-11-02T09:20:07+0000",
 				"pronosticBrut": 0,
 				"pronosticIV": 0,
@@ -658,13 +658,13 @@
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T11:15:00+0000",
+				"dateHeure": "2018-11-02T12:15:00+0000",
 				"heureLocale": "13:15:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T11:15:00+0000",
+				"dateHeure": "2018-11-02T12:15:00+0000",
 				"dateHeureEmission": "2018-11-02T09:20:07+0000",
 				"pronosticBrut": 0,
 				"pronosticIV": 0,

--- a/tests/fixtures/cots_train_870154_partial_removal_delay.json
+++ b/tests/fixtures/cots_train_870154_partial_removal_delay.json
@@ -110,7 +110,7 @@
 				"statutCirculationOPE": "SUPPRESSION"
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T08:54:00+0000",
+				"dateHeure": "2018-11-02T09:54:00+0000",
 				"heureLocale": "10:54:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0,
@@ -119,7 +119,7 @@
 			"idMotifInterneDepartReference": 98,
 			"listeHoraireProjeteArrivee": [],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T08:59:00+0000",
+				"dateHeure": "2018-11-02T09:59:00+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 300,
 				"pronosticIV": 300,
@@ -157,14 +157,14 @@
 				"statutCirculationOPE": "SUPPRESSION"
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T09:17:30+0000",
+				"dateHeure": "2018-11-02T10:17:30+0000",
 				"heureLocale": "11:17:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0,
 				"statutCirculationOPE": "SUPPRESSION"
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T09:18:30+0000",
+				"dateHeure": "2018-11-02T10:18:30+0000",
 				"heureLocale": "11:18:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0,
@@ -173,14 +173,14 @@
 			"idMotifInterneArriveeReference": 98,
 			"idMotifInterneDepartReference": 98,
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T09:22:30+0000",
+				"dateHeure": "2018-11-02T10:22:30+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 300,
 				"pronosticIV": 300,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T09:23:30+0000",
+				"dateHeure": "2018-11-02T10:23:30+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 300,
 				"pronosticIV": 300,
@@ -222,14 +222,14 @@
 				"statutCirculationOPE": "SUPPRESSION"
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T09:29:30+0000",
+				"dateHeure": "2018-11-02T10:29:30+0000",
 				"heureLocale": "11:29:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0,
 				"statutCirculationOPE": "SUPPRESSION"
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T09:30:30+0000",
+				"dateHeure": "2018-11-02T10:30:30+0000",
 				"heureLocale": "11:30:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0,
@@ -238,14 +238,14 @@
 			"idMotifInterneArriveeReference": 98,
 			"idMotifInterneDepartReference": 98,
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T09:34:30+0000",
+				"dateHeure": "2018-11-02T10:34:30+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 300,
 				"pronosticIV": 300,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T09:35:30+0000",
+				"dateHeure": "2018-11-02T10:35:30+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 300,
 				"pronosticIV": 300,
@@ -287,14 +287,14 @@
 				"statutCirculationOPE": "SUPPRESSION"
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T09:33:30+0000",
+				"dateHeure": "2018-11-02T10:33:30+0000",
 				"heureLocale": "11:33:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0,
 				"statutCirculationOPE": "SUPPRESSION"
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T09:34:30+0000",
+				"dateHeure": "2018-11-02T10:34:30+0000",
 				"heureLocale": "11:34:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0,
@@ -303,14 +303,14 @@
 			"idMotifInterneArriveeReference": 98,
 			"idMotifInterneDepartReference": 98,
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T09:38:30+0000",
+				"dateHeure": "2018-11-02T10:38:30+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 300,
 				"pronosticIV": 300,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T09:39:30+0000",
+				"dateHeure": "2018-11-02T10:39:30+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 300,
 				"pronosticIV": 300,
@@ -352,14 +352,14 @@
 				"statutCirculationOPE": "SUPPRESSION"
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T09:38:30+0000",
+				"dateHeure": "2018-11-02T10:38:30+0000",
 				"heureLocale": "11:38:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0,
 				"statutCirculationOPE": "SUPPRESSION"
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T09:39:30+0000",
+				"dateHeure": "2018-11-02T10:39:30+0000",
 				"heureLocale": "11:39:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0,
@@ -368,14 +368,14 @@
 			"idMotifInterneArriveeReference": 3,
 			"idMotifInterneDepartReference": 3,
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T09:43:30+0000",
+				"dateHeure": "2018-11-02T10:43:30+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 300,
 				"pronosticIV": 300,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T09:44:30+0000",
+				"dateHeure": "2018-11-02T10:44:30+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 300,
 				"pronosticIV": 300,
@@ -416,14 +416,14 @@
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T09:53:00+0000",
+				"dateHeure": "2018-11-02T10:53:00+0000",
 				"heureLocale": "11:53:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0,
 				"statutCirculationOPE": "SUPPRESSION"
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T09:55:00+0000",
+				"dateHeure": "2018-11-02T10:55:00+0000",
 				"heureLocale": "11:55:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
@@ -431,14 +431,14 @@
 			"idMotifInterneArriveeReference": 3,
 			"idMotifInterneDepartReference": 24,
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T09:58:00+0000",
+				"dateHeure": "2018-11-02T10:58:00+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 300,
 				"pronosticIV": 300,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T10:00:00+0000",
+				"dateHeure": "2018-11-02T11:00:00+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 600,
 				"pronosticIV": 600,
@@ -478,13 +478,13 @@
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T10:01:00+0000",
+				"dateHeure": "2018-11-02T11:01:00+0000",
 				"heureLocale": "12:01:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T10:02:00+0000",
+				"dateHeure": "2018-11-02T11:02:00+0000",
 				"heureLocale": "12:02:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
@@ -492,14 +492,14 @@
 			"idMotifInterneArriveeReference": 24,
 			"idMotifInterneDepartReference": 24,
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T10:06:00+0000",
+				"dateHeure": "2018-11-02T11:06:00+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 600,
 				"pronosticIV": 600,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T10:07:00+0000",
+				"dateHeure": "2018-11-02T11:07:00+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 600,
 				"pronosticIV": 600,
@@ -539,13 +539,13 @@
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T10:17:00+0000",
+				"dateHeure": "2018-11-02T11:17:00+0000",
 				"heureLocale": "12:17:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T10:18:00+0000",
+				"dateHeure": "2018-11-02T11:18:00+0000",
 				"heureLocale": "12:18:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
@@ -553,14 +553,14 @@
 			"idMotifInterneArriveeReference": 24,
 			"idMotifInterneDepartReference": 24,
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T10:22:00+0000",
+				"dateHeure": "2018-11-02T11:22:00+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 600,
 				"pronosticIV": 600,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T10:23:00+0000",
+				"dateHeure": "2018-11-02T11:23:00+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 600,
 				"pronosticIV": 600,
@@ -600,13 +600,13 @@
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T10:29:00+0000",
+				"dateHeure": "2018-11-02T11:29:00+0000",
 				"heureLocale": "12:29:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T10:30:00+0000",
+				"dateHeure": "2018-11-02T11:30:00+0000",
 				"heureLocale": "12:30:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
@@ -614,14 +614,14 @@
 			"idMotifInterneArriveeReference": 24,
 			"idMotifInterneDepartReference": 24,
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T10:34:00+0000",
+				"dateHeure": "2018-11-02T11:34:00+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 600,
 				"pronosticIV": 600,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T10:35:00+0000",
+				"dateHeure": "2018-11-02T11:35:00+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 600,
 				"pronosticIV": 600,
@@ -661,13 +661,13 @@
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T10:36:30+0000",
+				"dateHeure": "2018-11-02T11:36:30+0000",
 				"heureLocale": "12:36:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T10:37:30+0000",
+				"dateHeure": "2018-11-02T11:37:30+0000",
 				"heureLocale": "12:37:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
@@ -675,14 +675,14 @@
 			"idMotifInterneArriveeReference": 24,
 			"idMotifInterneDepartReference": 24,
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T10:41:30+0000",
+				"dateHeure": "2018-11-02T11:41:30+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 600,
 				"pronosticIV": 600,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T10:42:30+0000",
+				"dateHeure": "2018-11-02T11:42:30+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 600,
 				"pronosticIV": 600,
@@ -722,13 +722,13 @@
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T10:51:30+0000",
+				"dateHeure": "2018-11-02T11:51:30+0000",
 				"heureLocale": "12:51:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T10:52:30+0000",
+				"dateHeure": "2018-11-02T11:52:30+0000",
 				"heureLocale": "12:52:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
@@ -736,14 +736,14 @@
 			"idMotifInterneArriveeReference": 24,
 			"idMotifInterneDepartReference": 24,
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T10:56:30+0000",
+				"dateHeure": "2018-11-02T11:56:30+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 600,
 				"pronosticIV": 600,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T10:57:30+0000",
+				"dateHeure": "2018-11-02T11:57:30+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 600,
 				"pronosticIV": 600,
@@ -776,14 +776,14 @@
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T11:15:00+0000",
+				"dateHeure": "2018-11-02T12:15:00+0000",
 				"heureLocale": "13:15:00",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"idMotifInterneArriveeReference": 24,
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T11:20:00+0000",
+				"dateHeure": "2018-11-02T12:20:00+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 600,
 				"pronosticIV": 600,

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -43,7 +43,7 @@ from tests.integration.utils_sncf_test import check_db_96231_delayed, check_db_j
     check_db_96231_trip_removal, check_db_6113_trip_removal, check_db_6114_trip_removal, check_db_96231_normal, \
     check_db_840427_partial_removal, check_db_96231_partial_removal, check_db_870154_partial_removal, \
     check_db_870154_delay, check_db_870154_normal, check_db_96231_mixed_statuses_inside_stops, \
-    check_db_96231_mixed_statuses_delay_removal_delay
+    check_db_96231_mixed_statuses_delay_removal_delay, check_db_6111_trip_removal_pass_midnight
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -327,6 +327,22 @@ def test_cots_trip_removal_simple_post(mock_rabbitmq):
         assert len(TripUpdate.query.all()) == 1
         assert len(StopTimeUpdate.query.all()) == 0
     check_db_6113_trip_removal()
+    assert mock_rabbitmq.call_count == 1
+
+
+def test_cots_trip_removal_pass_midnight(mock_rabbitmq):
+    """
+    simple trip removal post on a pass-midnight trip
+    """
+    cots_6111 = get_fixture_data('cots_train_6111_pass_midnight_trip_removal.json')
+    res = api_post('/cots', data=cots_6111)
+    assert res == 'OK'
+
+    with app.app_context():
+        assert len(RealTimeUpdate.query.all()) == 1
+        assert len(TripUpdate.query.all()) == 1
+        assert len(StopTimeUpdate.query.all()) == 0
+    check_db_6111_trip_removal_pass_midnight()
     assert mock_rabbitmq.call_count == 1
 
 

--- a/tests/integration/utils_sncf_test.py
+++ b/tests/integration/utils_sncf_test.py
@@ -593,6 +593,25 @@ def check_db_6113_trip_removal():
         assert len(db_trip_removal.stop_time_updates) == 0
 
 
+def check_db_6111_trip_removal_pass_midnight():
+    with app.app_context():
+        assert len(RealTimeUpdate.query.all()) >= 1
+        assert len(TripUpdate.query.all()) >= 1
+        assert len(StopTimeUpdate.query.all()) >= 0
+        db_trip_removal = TripUpdate.find_by_dated_vj('trip:OCETGV-87686006-87751008-2:25768',
+                                                      datetime(2015, 10, 6, 20, 37, tzinfo=utc))
+        assert db_trip_removal
+
+        assert db_trip_removal.vj.navitia_trip_id == 'trip:OCETGV-87686006-87751008-2:25768'
+        assert db_trip_removal.vj.get_start_timestamp() == datetime(2015, 10, 6, 20, 37, tzinfo=utc)
+        assert db_trip_removal.vj_id == db_trip_removal.vj.id
+        assert db_trip_removal.status == 'delete'
+        print db_trip_removal.message
+        assert db_trip_removal.message == u'Accident à un Passage à Niveau'
+        # full trip removal : no stop_time to precise
+        assert len(db_trip_removal.stop_time_updates) == 0
+
+
 def check_db_6114_trip_removal():
     with app.app_context():
         assert len(RealTimeUpdate.query.all()) >= 1

--- a/tests/mock_navitia/__init__.py
+++ b/tests/mock_navitia/__init__.py
@@ -61,6 +61,9 @@ mocks = [
     vj_start_midnight.response
 ]
 _mock_navitia_call = {r.query: r for r in mocks}
+for r in mocks:
+    if hasattr(r, 'query_utc'):
+        _mock_navitia_call[r.query_utc] = r
 
 
 def mock_navitia_query(self, query, q=None):

--- a/tests/mock_navitia/__init__.py
+++ b/tests/mock_navitia/__init__.py
@@ -30,8 +30,9 @@
 # www.navitia.io
 import json
 import vj_john
-import vj_6113
+import vj_6111
 import vj_6112
+import vj_6113
 import vj_6114
 import vj_96231
 import vj_870154
@@ -45,6 +46,7 @@ import vj_start_midnight
 
 mocks = [
     vj_john.response,
+    vj_6111.response,
     vj_6112.response,
     vj_6113.response,
     vj_6114.response,

--- a/tests/mock_navitia/vj_6111.py
+++ b/tests/mock_navitia/vj_6111.py
@@ -1,0 +1,287 @@
+# coding=utf-8
+
+#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+import navitia_response
+
+response = navitia_response.NavitiaResponse()
+
+response.query = 'vehicle_journeys/?depth=2&since=20151006T221600&headsign=6111&show_codes=true&until=20151007T073400'
+response.query_utc = 'vehicle_journeys/?depth=2&since=20151006T201600+0000&headsign=6111&show_codes=true&until=20151007T053400+0000'
+
+response.response_code = 200
+
+response.json_response = """{
+    "vehicle_journeys": [
+        {
+            "codes": [
+                {
+                    "type": "external_code",
+                    "value": "OCESN006111F02009"
+                }
+            ],
+            "name": "6111",
+            "journey_pattern": {
+                "route": {
+                    "direction": {
+                        "embedded_type": "stop_area",
+                        "quality": 0,
+                        "stop_area": {
+                            "codes": [
+                                {
+                                    "type": "external_code",
+                                    "value": "OCE87751008"
+                                }
+                            ],
+                            "name": "gare de Marseille-St-Charles",
+                            "links": [
+
+                            ],
+                            "coord": {
+                                "lat": "43.30273",
+                                "lon": "5.380659"
+                            },
+                            "label": "gare de Marseille-St-Charles",
+                            "timezone": "Europe/Paris",
+                            "id": "stop_area:OCE:SA:87751008"
+                        },
+                        "name": "gare de Marseille-St-Charles",
+                        "id": "stop_area:OCE:SA:87751008"
+                    },
+                    "codes": [
+                        {
+                            "type": "external_code",
+                            "value": "OCETGV-87686006-87751008-2"
+                        }
+                    ],
+                    "name": "Paris-Gare-de-Lyon vers Marseille-St-Charles",
+                    "links": [
+
+                    ],
+                    "is_frequence": "false",
+                    "geojson": {
+                        "type": "MultiLineString",
+                        "coordinates": [
+
+                        ]
+                    },
+                    "id": "route:OCE:TGV-87686006-87751008-2"
+                },
+                "name": "gare de Marseille-St-Charles",
+                "id": "journey_pattern:OCE:TGV-87751008-87686006-4066"
+            },
+            "calendars": [
+                {
+                    "active_periods": [
+                        {
+                            "begin": "20150916",
+                            "end": "20151017"
+                        }
+                    ],
+                    "week_pattern": {
+                        "monday": true,
+                        "tuesday": true,
+                        "friday": true,
+                        "wednesday": true,
+                        "thursday": true,
+                        "sunday": true,
+                        "saturday": true
+                    }
+                }
+            ],
+            "stop_times": [
+                {
+                    "arrival_time": "223700",
+                    "journey_pattern_point": {
+                        "id": "OCE:TGV-87751008-87686006-4066:OCE:SP:TGV-87686006:0"
+                    },
+                    "headsign": "6111",
+                    "departure_time": "223700",
+                    "stop_point": {
+                        "codes": [
+                            {
+                                "type": "external_code",
+                                "value": "OCETGV-87686006"
+                            }
+                        ],
+                        "name": "gare de Paris-Gare-de-Lyon",
+                        "links": [
+
+                        ],
+                        "coord": {
+                            "lat": "48.844924",
+                            "lon": "2.373481"
+                        },
+                        "label": "gare de Paris-Gare-de-Lyon",
+                        "equipments": [
+
+                        ],
+                        "id": "stop_point:OCE:SP:TGV-87686006",
+                        "stop_area": {
+                            "codes": [
+                                {
+                                    "type": "external_code",
+                                    "value": "OCE87686006"
+                                }
+                            ],
+                            "name": "gare de Paris-Gare-de-Lyon",
+                            "links": [
+
+                            ],
+                            "coord": {
+                                "lat": "48.844924",
+                                "lon": "2.373481"
+                            },
+                            "label": "gare de Paris-Gare-de-Lyon",
+                            "timezone": "Europe/Paris",
+                            "id": "stop_area:OCE:SA:87686006"
+                        }
+                    }
+                },
+                {
+                    "arrival_time": "060300",
+                    "journey_pattern_point": {
+                        "id": "OCE:TGV-87751008-87686006-4066:OCE:SP:TGV-87751008:3"
+                    },
+                    "headsign": "6111",
+                    "departure_time": "060300",
+                    "stop_point": {
+                        "codes": [
+                            {
+                                "type": "external_code",
+                                "value": "OCETGV-87751008"
+                            }
+                        ],
+                        "name": "gare de Marseille-St-Charles",
+                        "links": [
+
+                        ],
+                        "coord": {
+                            "lat": "43.30273",
+                            "lon": "5.380659"
+                        },
+                        "label": "gare de Marseille-St-Charles",
+                        "equipments": [
+
+                        ],
+                        "id": "stop_point:OCE:SP:TGV-87751008",
+                        "stop_area": {
+                            "codes": [
+                                {
+                                    "type": "external_code",
+                                    "value": "OCE87751008"
+                                }
+                            ],
+                            "name": "gare de Marseille-St-Charles",
+                            "links": [
+
+                            ],
+                            "coord": {
+                                "lat": "43.30273",
+                                "lon": "5.380659"
+                            },
+                            "label": "gare de Marseille-St-Charles",
+                            "timezone": "Europe/Paris",
+                            "id": "stop_area:OCE:SA:87751008"
+                        }
+                    }
+                }
+            ],
+            "validity_pattern": {
+                "beginning_date": "20150915",
+                "days": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011111111111111111111111111111110"
+            },
+            "id": "vehicle_journey:OCETGV-87686006-87751008-2:25768",
+            "trip": {"id": "trip:OCETGV-87686006-87751008-2:25768"}
+        }
+    ],
+    "disruptions": [
+
+    ],
+    "pagination": {
+        "start_page": 0,
+        "items_on_page": 1,
+        "items_per_page": 25,
+        "total_result": 1
+    },
+    "links": [
+        {
+            "href": "http://localhost:5000/v1/coverage/navitia/stop_points/{stop_point.id}",
+            "type": "stop_point",
+            "rel": "stop_points",
+            "templated": true
+        },
+        {
+            "href": "http://localhost:5000/v1/coverage/navitia/stop_areas/{stop_area.id}",
+            "type": "stop_area",
+            "rel": "stop_areas",
+            "templated": true
+        },
+        {
+            "href": "http://localhost:5000/v1/coverage/navitia/journey_patterns/{journey_pattern.id}",
+            "type": "journey_pattern",
+            "rel": "journey_patterns",
+            "templated": true
+        },
+        {
+            "href": "http://localhost:5000/v1/coverage/navitia/routes/{route.id}",
+            "type": "route",
+            "rel": "routes",
+            "templated": true
+        },
+        {
+            "href": "http://localhost:5000/v1/coverage/navitia/journey_pattern_points/{journey_pattern_point.id}",
+            "type": "journey_pattern_point",
+            "rel": "journey_pattern_points",
+            "templated": true
+        },
+        {
+            "href": "http://localhost:5000/v1/coverage/navitia/vehicle_journeys/{vehicle_journeys.id}",
+            "type": "vehicle_journeys",
+            "rel": "vehicle_journeys",
+            "templated": true
+        },
+        {
+            "href": "http://localhost:5000/v1/coverage/navitia/vehicle_journeys",
+            "type": "first",
+            "templated": false
+        }
+    ],
+    "feed_publishers": [
+        {
+            "url": "",
+            "id": "navitia",
+            "license": "",
+            "name": ""
+        }
+    ]
+}"""
+
+
+

--- a/tests/mock_navitia/vj_6112.py
+++ b/tests/mock_navitia/vj_6112.py
@@ -33,6 +33,7 @@ import navitia_response
 response = navitia_response.NavitiaResponse()
 
 response.query = 'vehicle_journeys/?depth=2&since=20151006T121600&headsign=6112&show_codes=true&until=20151006T173400'
+response.query_utc = 'vehicle_journeys/?depth=2&since=20151006T101600+0000&headsign=6112&show_codes=true&until=20151006T153400+0000'
 
 response.response_code = 404
 

--- a/tests/mock_navitia/vj_6113.py
+++ b/tests/mock_navitia/vj_6113.py
@@ -33,6 +33,7 @@ import navitia_response
 response = navitia_response.NavitiaResponse()
 
 response.query = 'vehicle_journeys/?depth=2&since=20151006T121600&headsign=6113&show_codes=true&until=20151006T173400'
+response.query_utc = 'vehicle_journeys/?depth=2&since=20151006T101600+0000&headsign=6113&show_codes=true&until=20151006T153400+0000'
 
 response.response_code = 200
 

--- a/tests/mock_navitia/vj_6114.py
+++ b/tests/mock_navitia/vj_6114.py
@@ -33,6 +33,7 @@ import navitia_response
 response = navitia_response.NavitiaResponse()
 
 response.query = 'vehicle_journeys/?depth=2&since=20151006T121600&headsign=6114&show_codes=true&until=20151006T173400'
+response.query_utc = 'vehicle_journeys/?depth=2&since=20151006T101600+0000&headsign=6114&show_codes=true&until=20151006T153400+0000'
 
 response.response_code = 200
 

--- a/tests/mock_navitia/vj_840426.py
+++ b/tests/mock_navitia/vj_840426.py
@@ -33,6 +33,7 @@ import navitia_response
 response = navitia_response.NavitiaResponse()
 
 response.query = 'vehicle_journeys/?depth=2&since=20170318T130500&headsign=840427&show_codes=true&until=20170318T171600'
+response.query_utc = 'vehicle_journeys/?depth=2&since=20170318T120500+0000&headsign=840427&show_codes=true&until=20170318T161600+0000'
 
 response.response_code = 200
 

--- a/tests/mock_navitia/vj_870154.py
+++ b/tests/mock_navitia/vj_870154.py
@@ -32,6 +32,7 @@ import navitia_response
 response = navitia_response.NavitiaResponse()
 
 response.query = 'vehicle_journeys/?depth=2&since=20181102T095400&headsign=870154&show_codes=true&until=20181102T141500'
+response.query_utc = 'vehicle_journeys/?depth=2&since=20181102T085400+0000&headsign=870154&show_codes=true&until=20181102T131500+0000'
 
 response.response_code = 200
 

--- a/tests/mock_navitia/vj_96231.py
+++ b/tests/mock_navitia/vj_96231.py
@@ -33,6 +33,7 @@ import navitia_response
 response = navitia_response.NavitiaResponse()
 
 response.query = 'vehicle_journeys/?depth=2&since=20150921T153000&headsign=96231&show_codes=true&until=20150921T193900'
+response.query_utc = 'vehicle_journeys/?depth=2&since=20150921T133000+0000&headsign=96231&show_codes=true&until=20150921T173900+0000'
 
 response.response_code = 200
 

--- a/tests/mock_navitia/vj_john.py
+++ b/tests/mock_navitia/vj_john.py
@@ -33,6 +33,7 @@ import navitia_response
 response = navitia_response.NavitiaResponse()
 
 response.query = 'vehicle_journeys/?depth=2&since=20150921T153000&headsign=JOHN&show_codes=true&until=20150921T193900'
+response.query_utc = 'vehicle_journeys/?depth=2&since=20150921T133000+0000&headsign=JOHN&show_codes=true&until=20150921T173900+0000'
 
 response.response_code = 200
 


### PR DESCRIPTION
Fix #157 

:mag_right: Please review by commit:
* Adds a test on pass-midnight in COTS
* Correction/adaptation on test files and fixtures to prepare new reading
* Switch reading to new horaireVoyageurDepart/dateHeure

Hand-tested that Navitia correctly deals with `20181017T141200+0000` in `since` and `until` fields, also added a PR to autotest that on navitia: https://github.com/CanalTP/navitia/pull/2573

TODO:
- [x] merge #195 before as this PR is included (will rebase in between)