### PR TITLE
kirin: manage effect in kirin

### DIFF
--- a/documentation/internal_format.md
+++ b/documentation/internal_format.md
@@ -40,6 +40,7 @@ message | String, Optional | Text to be displayed in Navitia for the `VehicleJou
 contributor | String, Optional | Identifier of the realtime connector. It must be known by Kraken.
 company_id | String, Optional | Identifier of the transport operator found in Navitia for this trip.
 stop_time_updates | List | List of `StopTimeUpdate` provided by this bloc of data
+effect | Enum, optional | Effect to be displayed in navitia (Possible values are `NO_SERVICE`, `REDUCED_SERVICE`, `SIGNIFICANT_DELAYS`, `DETOUR`, `ADDITIONAL_SERVICE`, `MODIFIED_SERVICE`, `OTHER_EFFECT`, `UNKNOWN_EFFECT`, `STOP_MOVED`)
 
 ### VehicleJourney
 Property | TYpe | Description

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -50,6 +50,19 @@ meta = sqlalchemy.schema.MetaData(naming_convention={
         "pk": "pk_%(table_name)s"
       })
 
+TripEffect = db.Enum(
+    'NO_SERVICE',
+    'REDUCED_SERVICE',
+    'SIGNIFICANT_DELAYS',
+    'DETOUR',
+    'ADDITIONAL_SERVICE',
+    'MODIFIED_SERVICE',
+    'OTHER_EFFECT',
+    'UNKNOWN_EFFECT',
+    'STOP_MOVED',
+    name='trip_effect'
+)
+
 #force the server to use UTC time for each connection checkouted from the pool
 @sqlalchemy.event.listens_for(sqlalchemy.pool.Pool, 'checkout')
 def set_utc_on_connect(dbapi_con, connection_record, connection_proxy):
@@ -248,13 +261,15 @@ class TripUpdate(db.Model, TimestampMixin):
                                         collection_class=ordering_list('order'),
                                         cascade='all, delete-orphan')
     company_id = db.Column(db.Text, nullable=True)
+    effect = db.Column(TripEffect, nullable=True)
 
-    def __init__(self, vj=None, status='none', contributor=None, company_id=None):
+    def __init__(self, vj=None, status='none', contributor=None, company_id=None, effect=None):
         self.created_at = datetime.datetime.utcnow()
         self.vj = vj
         self.status = status
         self.contributor = contributor
         self.company_id = company_id
+        self.effect = effect
 
     def __repr__(self):
         return '<TripUpdate %r>' % self.vj_id

--- a/kirin/core/populate_pb.py
+++ b/kirin/core/populate_pb.py
@@ -68,6 +68,20 @@ def get_st_event(st_status):
         # 'update' or 'none' are modeled as 'SCHEDULED'
         return gtfs_realtime_pb2.TripUpdate.StopTimeUpdate.SCHEDULED
 
+def get_trip_event(trip_status):
+    trip_events = {
+        'NO_SERVICE': gtfs_realtime_pb2.Alert.NO_SERVICE,
+        'REDUCED_SERVICE': gtfs_realtime_pb2.Alert.REDUCED_SERVICE,
+        'SIGNIFICANT_DELAYS': gtfs_realtime_pb2.Alert.SIGNIFICANT_DELAYS,
+        'DETOUR': gtfs_realtime_pb2.Alert.DETOUR,
+        'ADDITIONAL_SERVICE': gtfs_realtime_pb2.Alert.ADDITIONAL_SERVICE,
+        'MODIFIED_SERVICE': gtfs_realtime_pb2.Alert.MODIFIED_SERVICE,
+        'OTHER_EFFECT': gtfs_realtime_pb2.Alert.OTHER_EFFECT,
+        'UNKNOWN_EFFECT': gtfs_realtime_pb2.Alert.UNKNOWN_EFFECT,
+        'STOP_MOVED': gtfs_realtime_pb2.Alert.STOP_MOVED,
+    }
+    return trip_events.get(trip_status, None)
+
 
 def fill_stop_times(pb_stop_time, stop_time):
     pb_stop_time.stop_id = stop_time.stop_id
@@ -103,6 +117,8 @@ def fill_trip_update(pb_trip_update, trip_update):
         fill_message(pb_trip_update, trip_update.message)
     if trip_update.company_id:
         pb_trip.Extensions[kirin_pb2.company_id] = trip_update.company_id
+    if trip_update.effect:
+        pb_trip_update.Extensions[kirin_pb2.effect] = get_trip_event(trip_update.effect)
 
     vj = trip_update.vj
     if vj:

--- a/kirin/cots/model_maker.py
+++ b/kirin/cots/model_maker.py
@@ -301,7 +301,7 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
         trip_update.effect = Effect.MODIFIED_SERVICE.name
 
         # Initialize stop_time staus to nochange
-        st_status = 'nochange'
+        highest_st_status = 'nochange'
         pdps = _retrieve_interesting_pdp(get_value(json_train, 'listePointDeParcours'))
         # manage realtime information stop_time by stop_time
         for pdp in pdps:
@@ -393,10 +393,10 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
                     raise InvalidArguments('invalid value {} for field horaireVoyageur{}/statutCirculationOPE'.
                                            format(cots_stop_time_status, arrival_departure_toggle))
 
-                st_status = _get_higher_status(st_status, _arr_or_dep_status[arrival_departure_toggle])
+                highest_st_status = _get_higher_status(highest_st_status, _arr_or_dep_status[arrival_departure_toggle])
 
         # Calculates effect from stop_time status list (this work is also done in kraken and has to be deleted)
-        trip_update.effect = _get_effect_by_stop_time_status(st_status)
+        trip_update.effect = _get_effect_by_stop_time_status(highest_st_status)
         return trip_update
 
     def _get_navitia_stop_point(self, pdp, nav_vj):

--- a/kirin/cots/model_maker.py
+++ b/kirin/cots/model_maker.py
@@ -61,10 +61,6 @@ class Effect(Enum):
     STOP_MOVED = 8
 
 
-trip_effect = ('NO_SERVICE', 'REDUCED_SERVICE', 'SIGNIFICANT_DELAYS', 'DETOUR', 'ADDITIONAL_SERVICE',
-              'MODIFIED_SERVICE', 'OTHER_EFFECT', 'UNKNOWN_EFFECT', 'STOP_MOVED')
-
-
 status_order = {
     'nochange': 0,
     'add': 1,
@@ -287,14 +283,14 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
             # the whole trip is deleted
             trip_update.status = 'delete'
             trip_update.stop_time_updates = []
-            trip_update.effect = trip_effect[Effect.NO_SERVICE.value]
+            trip_update.effect = Effect.NO_SERVICE.name
             return trip_update
 
         elif trip_status == 'AJOUTEE':
             # the trip is created from scratch
             # not handled yet
             self._record_and_log(logger, 'nouvelleVersion/statutOperationnel == "AJOUTEE" is not handled (yet)')
-            trip_update.effect = trip_effect[Effect.ADDITIONAL_SERVICE.value]
+            trip_update.effect = Effect.ADDITIONAL_SERVICE.name
             return trip_update
 
         # all other status is considered an 'update' of the trip_update and effect is calculated
@@ -302,7 +298,7 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
         # Ordered stop_time status= 'nochange', 'add', 'delete', 'update'
         # 'nochange' or 'update' -> SIGNIFICANT_DELAYS, add -> MODIFIED_SERVICE, delete = DETOUR
         trip_update.status = 'update'
-        trip_update.effect = trip_effect[Effect.MODIFIED_SERVICE.value]
+        trip_update.effect = Effect.MODIFIED_SERVICE.name
 
         # Initialize stop_time staus to nochange
         st_status = 'nochange'

--- a/kirin/cots/model_maker.py
+++ b/kirin/cots/model_maker.py
@@ -373,7 +373,7 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
                                                  '"{}" is not handled completely (yet), only removal'
                                                  .format(cots_stop_time_status))
                     setattr(st_update, _status_map[arrival_departure_toggle], 'delete')
-                    _arr_or_dep_status[arrival_departure_toggle] = stop_time_status.get('delete', 'nochange')
+                    _arr_or_dep_status[arrival_departure_toggle] = 'delete'
 
                 elif cots_stop_time_status == 'CREATION':
                     # new stop_time added

--- a/kirin/cots/model_maker.py
+++ b/kirin/cots/model_maker.py
@@ -73,8 +73,6 @@ order = {
     'update': 3
 }
 
-stop_time_status = OrderedDict(sorted(stop_time_status.items(), key=lambda t: order[t[0]]))
-
 
 def get_value(sub_json, key, nullable=False):
     """
@@ -194,9 +192,7 @@ def _retrieve_projected_time(source_ref, list_proj_time):
 
 
 def _get_higher_status(st1, st2):
-    idx1 = stop_time_status.keys().index(st1)
-    idx2 = stop_time_status.keys().index(st2)
-    return stop_time_status.keys()[max(idx1, idx2)]
+    return max([st1, st2], key=lambda st: order[st])
 
 
 def _get_effect_by_stop_time_status(status):

--- a/kirin/cots/model_maker.py
+++ b/kirin/cots/model_maker.py
@@ -44,8 +44,37 @@ from kirin.core import model
 from kirin.cots.message_handler import MessageHandler
 from kirin.exceptions import InvalidArguments
 from kirin.utils import record_internal_failure
+from collections import OrderedDict
 
 DEFAULT_COMPANY_ID = "1187"
+trip_effect = {
+    'NO_SERVICE': 'NO_SERVICE',
+    'REDUCED_SERVICE': 'REDUCED_SERVICE',
+    'SIGNIFICANT_DELAYS': 'SIGNIFICANT_DELAYS',
+    'DETOUR': 'DETOUR',
+    'ADDITIONAL_SERVICE': 'ADDITIONAL_SERVICE',
+    'MODIFIED_SERVICE': 'MODIFIED_SERVICE',
+    'OTHER_EFFECT': 'OTHER_EFFECT',
+    'UNKNOWN_EFFECT': 'UNKNOWN_EFFECT',
+    'STOP_MOVED': 'STOP_MOVED'
+}
+
+stop_time_status = {
+    'nochange': 'nochange',
+    'add': 'add',
+    'delete': 'delete',
+    'update': 'update'
+}
+
+order = {
+    'nochange': 0,
+    'add': 1,
+    'delete': 2,
+    'update': 3
+}
+
+stop_time_status = OrderedDict(sorted(stop_time_status.items(), key=lambda t: order[t[0]]))
+
 
 def get_value(sub_json, key, nullable=False):
     """
@@ -164,6 +193,26 @@ def _retrieve_projected_time(source_ref, list_proj_time):
     return None
 
 
+def _get_higher_status(st1, st2):
+    idx1 = stop_time_status.keys().index(st1)
+    idx2 = stop_time_status.keys().index(st2)
+    return stop_time_status.keys()[max(idx1, idx2)]
+
+
+def _get_effect_by_stop_time_status(status):
+    """
+    :param status: status value of stop_time
+    :return: the corresponding value for trip_update effect
+    """
+    status_to_effect = {
+        'nochange': 'SIGNIFICANT_DELAYS',
+        'add': 'MODIFIED_SERVICE',
+        'delete': 'DETOUR',
+        'update': 'SIGNIFICANT_DELAYS'
+    }
+    return status_to_effect.get(status, 'UNKNOWN_EFFECT')
+
+
 class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
 
     def __init__(self, nav, contributor=None):
@@ -243,17 +292,25 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
             # the whole trip is deleted
             trip_update.status = 'delete'
             trip_update.stop_time_updates = []
+            trip_update.effect = trip_effect.get('NO_SERVICE', None)
             return trip_update
 
         elif trip_status == 'AJOUTEE':
             # the trip is created from scratch
             # not handled yet
             self._record_and_log(logger, 'nouvelleVersion/statutOperationnel == "AJOUTEE" is not handled (yet)')
+            trip_update.effect = trip_effect.get('ADDITIONAL_SERVICE', None)
             return trip_update
 
-        # all other status is considered an 'update' of the trip
+        # all other status is considered an 'update' of the trip_update and effect is calculated
+        # from stop_time status list. This part is also done in kraken and is to be deleted later
+        # Ordered stop_time status= 'nochange', 'add', 'delete', 'update'
+        # 'nochange' or 'update' -> SIGNIFICANT_DELAYS, add -> MODIFIED_SERVICE, delete = DETOUR
         trip_update.status = 'update'
+        trip_update.effect = trip_effect.get('MODIFIED_SERVICE', None)
 
+        # Initialize stop_time staus to nochange
+        st_status = stop_time_status.get('nochange')
         pdps = _retrieve_interesting_pdp(get_value(json_train, 'listePointDeParcours'))
         # manage realtime information stop_time by stop_time
         for pdp in pdps:
@@ -280,6 +337,8 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
             _status_map = {'Arrivee': 'arrival_status', 'Depart': 'departure_status'}
             _delay_map = {'Arrivee': 'arrival_delay', 'Depart': 'departure_delay'}
             _add_map = {'Arrivee': 'arrival', 'Depart': 'departure'}
+            _arr_or_dep_status = {}
+
             # compute realtime information and fill st_update for arrival and departure
             for arrival_departure_toggle in ['Arrivee', 'Depart']:
                 cots_traveler_time = get_value(pdp,
@@ -310,10 +369,12 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
 
                     setattr(st_update, _status_map[arrival_departure_toggle], 'update')
                     setattr(st_update, _delay_map[arrival_departure_toggle], as_duration(cots_delay))
+                    _arr_or_dep_status[arrival_departure_toggle] = stop_time_status.get('update', 'nochange')
 
                 elif cots_stop_time_status == 'SUPPRESSION':
                     # partial delete
                     setattr(st_update, _status_map[arrival_departure_toggle], 'delete')
+                    _arr_or_dep_status[arrival_departure_toggle] = stop_time_status.get('delete', 'nochange')
 
                 elif cots_stop_time_status == 'SUPPRESSION_DETOURNEMENT':
                     # stop_time is replaced by another one
@@ -321,6 +382,7 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
                                                  '"{}" is not handled completely (yet), only removal'
                                                  .format(cots_stop_time_status))
                     setattr(st_update, _status_map[arrival_departure_toggle], 'delete')
+                    _arr_or_dep_status[arrival_departure_toggle] = stop_time_status.get('delete', 'nochange')
 
                 elif cots_stop_time_status == 'CREATION':
                     # new stop_time added
@@ -329,6 +391,7 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
                                                'dateHeure',
                                                nullable=True)
                     setattr(st_update, _add_map[arrival_departure_toggle], cots_stop_time)
+                    _arr_or_dep_status[arrival_departure_toggle] = stop_time_status.get('add', 'nochange')
 
                 elif cots_stop_time_status == 'DETOURNEMENT':
                     # new stop_time added also?
@@ -339,6 +402,10 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
                     raise InvalidArguments('invalid value {} for field horaireVoyageur{}/statutCirculationOPE'.
                                            format(cots_stop_time_status, arrival_departure_toggle))
 
+                st_status = _get_higher_status(st_status, _arr_or_dep_status[arrival_departure_toggle])
+
+        # Calculates effect from stop_time status list (this work is also done in kraken and has to be deleted)
+        trip_update.effect = _get_effect_by_stop_time_status(st_status)
         return trip_update
 
     def _get_navitia_stop_point(self, pdp, nav_vj):

--- a/migrations/versions/45f4c90aa775_add_effect_in_trip_update.py
+++ b/migrations/versions/45f4c90aa775_add_effect_in_trip_update.py
@@ -1,0 +1,29 @@
+"""
+Add attribut effect in trip_update
+Revision ID: 45f4c90aa775
+Revises: 4d9df787c7a7
+Create Date: 2018-11-23 09:55:16.326118
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '45f4c90aa775'
+down_revision = '4d9df787c7a7'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+trip_effect = sa.Enum('NO_SERVICE', 'REDUCED_SERVICE', 'SIGNIFICANT_DELAYS',
+                      'DETOUR', 'ADDITIONAL_SERVICE', 'MODIFIED_SERVICE',
+                      'OTHER_EFFECT', 'UNKNOWN_EFFECT', 'STOP_MOVED', name='trip_effect')
+
+
+def upgrade():
+    trip_effect.create(op.get_bind(), checkfirst=True)
+    op.add_column('trip_update', sa.Column('effect', trip_effect, nullable=True))
+
+
+def downgrade():
+    op.drop_column('trip_update', 'effect')
+    sa.Enum('', name='trip_effect').drop(op.get_bind(), checkfirst=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ celery==4.1.0
 redis==2.10.6
 flask-cache==0.13.1
 click==6.7
+enum34==1.1.6

--- a/tests/fixtures/cots_train_96231_add_without_delay.json
+++ b/tests/fixtures/cots_train_96231_add_without_delay.json
@@ -1,0 +1,443 @@
+{
+  "ressource": "courseOPE",
+  "mode": "modification",
+  "evt": [
+    "OBS",
+    "PERTURBATION"
+  ],
+  "PdPObserveArrivee": [
+    "5168b9d7-34b9-45d8-b434-88577c26bd72"
+  ],
+  "PdPObserveDepart": [
+  ],
+  "PdPPronosticBrutArrivee": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf",
+    "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+  ],
+  "PdPPronosticBrutDepart": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "5168b9d7-34b9-45d8-b434-88577c26bd72",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+  ],
+  "PdPPronosticIVArrivee": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf",
+    "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+  ],
+  "PdPPronosticIVDepart": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "5168b9d7-34b9-45d8-b434-88577c26bd72",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+  ],
+  "PdPImpacteDepart": [
+  ],
+  "PdPImpacteArrivee": [
+  ],
+  "nouvelleVersion": {
+    "codeCompagnieTransporteur": "OCETH",
+    "codeMarqueTransporteur": "TGV",
+    "codeRelation": "401",
+    "codeService": "A2018",
+    "codeSousRelation": "401400",
+    "codeTransporteurResponsable": "1A",
+    "codeTypeMoyenTransport": "0",
+    "coursePTA": {
+      "@id": "66e70e61-7b0d-4c60-bde5-c73f1bf4f99e"
+    },
+    "dateDebutService": "2017-12-10",
+    "dateDerniereModification": "2018-04-19T13:46:06+0000",
+    "dateFinService": "2018-12-08",
+    "estDiscontinue": false,
+    "estTechnique": false,
+    "estimationManuelle": false,
+    "etat": "ACTIVE",
+    "idVersion": "cbdb2075-e476-48f1-8dfa-4fa95ba226b9",
+    "identifiantDansSystemeCreateur": "e36bcf7e-5f34-4ebe-948e-99a525a89251",
+    "indicateurFer": "FERRE",
+    "listeCouplageCourseOPE": [
+      {
+        "courseCouplee": {
+          "@id": "8808999b-e31e-444d-bd17-a21adf9c6d35"
+        },
+        "pointDebutCouplage": {
+          "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+        },
+        "pointFinCouplage": {
+          "@id": "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+        }
+      }
+    ],
+    "listeCodeTransporteurAssocie": [
+    ],
+    "listeEvenement": [
+    ],
+    "listeJourRegimeDApplication": [
+      {
+        "date": "2015-09-21"
+      }
+    ],
+    "listeJourRegimeFacultatif": [
+    ],
+    "listeMotif": [
+    ],
+    "listePointDeParcours": [
+      {
+        "@id": "998484ec-4335-45b6-aad4-8840047b275f",
+        "arretFacultatif": false,
+        "categorieStatistiqueDepart": "LVK",
+        "cr": "0087",
+        "ci": "212027",
+        "ch": "BV",
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "16:30:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T14:30:00+0000",
+          "heureLocale": "16:30:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+        ],
+        "listeHoraireProjeteDepart": [
+        ],
+        "listeMotifArrivee": [
+        ],
+        "listeMotifDepart": [
+        ],
+        "rang": 1,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "5168b9d7-34b9-45d8-b434-88577c26bd72",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVK",
+        "cr": "0087",
+        "ci": "214056",
+        "ch": "00",
+        "horaireObserveArrivee": {
+          "dateHeure": "2015-09-21T15:39:00+0000",
+          "dateHeureEmission": "2018-04-19T15:44:53+0000",
+          "source": "ESCALE"
+        },
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:39:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:56:30",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T15:39:00+0000",
+          "heureLocale": "17:39:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T15:40:30+0000",
+          "heureLocale": "17:40:30",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+        ],
+        "listeHoraireProjeteDepart": [
+        ],
+        "idMotifInterneDepartReference": 3,
+        "idMotifInterneArriveeReference": 3,
+        "listeMotifArrivee": [
+        ],
+        "listeMotifDepart": [
+        ],
+        "rang": 2,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVK",
+        "cr": "0087",
+        "ci": "182014",
+        "ch": "BV",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:51:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:53:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T15:51:00+0000",
+          "heureLocale": "17:51:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T15:53:00+0000",
+          "heureLocale": "17:53:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+        ],
+        "listeHoraireProjeteDepart": [
+        ],
+        "listeMotifArrivee": [
+        ],
+        "listeMotifDepart": [
+        ],
+        "rang": 3,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "6a4a4413-a668-487c-b25d-907ef7e64e75",
+        "cr": "0087",
+        "ci": "713065",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T18:02:00+0200",
+          "heureLocale": "18:02:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T16:04:00+0000",
+          "heureLocale": "18:04:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+        ],
+        "listeHoraireProjeteDepart": [
+        ],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 11,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "2ce15bf7-134d-4cd5-978f-d746d238e008",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVA",
+        "cr": "0087",
+        "ci": "182063",
+        "ch": "BV",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:14:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:16:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T16:14:00+0000",
+          "heureLocale": "18:14:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T16:16:00+0000",
+          "heureLocale": "18:16:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+        ],
+        "listeHoraireProjeteDepart": [
+        ],
+        "listeMotifArrivee": [
+        ],
+        "listeMotifDepart": [
+        ],
+        "rang": 4,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "2ce15bf7-134d-4cd5-978f-d746d238e008",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVA",
+        "cr": "0087",
+        "ci": "182139",
+        "ch": "BV",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:30:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:31:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T16:30:00+0000",
+          "heureLocale": "18:30:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T16:31:00+0000",
+          "heureLocale": "18:31:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+        ],
+        "listeHoraireProjeteDepart": [
+        ],
+        "listeMotifArrivee": [
+        ],
+        "listeMotifDepart": [
+        ],
+        "rang": 5,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "2ce15bf7-134d-4cd5-978f-d746d238e008",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVA",
+        "cr": "0087",
+        "ci": "187914",
+        "ch": "WS",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:39:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T16:39:00+0000",
+          "heureLocale": "18:39:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+        ],
+        "listeHoraireProjeteDepart": [
+        ],
+        "idMotifInterneDepartReference": 3,
+        "idMotifInterneArriveeReference": 3,
+        "listeMotifArrivee": [
+        ],
+        "listeMotifDepart": [
+        ],
+        "rang": 6,
+        "typeArret": "CH"
+      }
+    ],
+    "listeService": [
+      {
+        "code": "CS01",
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2015-09-21"
+          }
+        ],
+        "listePropriete": [
+          {
+            "code": "CP001",
+            "metaPropriete": {
+              "@id": "95352652-200c-430b-8a94-3852677c91ea"
+            },
+            "valeurChaine": "A"
+          },
+          {
+            "code": "CP002",
+            "metaPropriete": {
+              "@id": "350d89f9-8667-4456-9186-765ce07ea238"
+            },
+            "valeurChaine": "A"
+          }
+        ],
+        "metaService": {
+          "@id": "590ecf63-8dcc-46d5-b238-391fd681eba1"
+        },
+        "pointDeParcoursDebut": {
+          "@id": "998484ec-4335-45b6-aad4-8840047b275f"
+        },
+        "pointDeParcoursFin": {
+          "@id": "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+        }
+      }
+    ],
+    "listeSubstitutionCourse": [
+    ],
+    "listeUtilisationSillon": [
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "096231",
+          "sillonTTH": "042522760051"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2015-09-21"
+          }
+        ],
+        "listeJourRegimeFacultatif": [
+        ],
+        "pointDebutUtilisationSillon": {
+          "@id": "998484ec-4335-45b6-aad4-8840047b275f"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+        },
+        "porteur": true
+      },
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "8780",
+          "sillonTTH": "042523700030"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2015-09-21"
+          }
+        ],
+        "listeJourRegimeFacultatif": [
+        ],
+        "pointDebutUtilisationSillon": {
+          "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+        },
+        "porteur": false
+      }
+    ],
+    "numeroCourse": "096231",
+    "statutSillonCourse": "NON_CONNU",
+    "statutOperationnel": "PERTURBEE",
+    "systemeCreateur": "2148",
+    "@id": "e36bcf7e-5f34-4ebe-948e-99a525a89251",
+    "type": "COURSE_OPE"
+  }
+}

--- a/tests/integration/cots_model_maker_test.py
+++ b/tests/integration/cots_model_maker_test.py
@@ -66,6 +66,7 @@ def test_cots_train_delayed(mock_navitia_fixture):
         assert trip_up.vj.navitia_trip_id == 'trip:OCETrainTER-87212027-85000109-3:11859'
         assert trip_up.vj_id == trip_up.vj.id
         assert trip_up.status == 'update'
+        assert trip_up.effect == 'SIGNIFICANT_DELAYS'
 
         # 5 stop times must have been created
         assert len(trip_up.stop_time_updates) == 6
@@ -133,3 +134,5 @@ def test_cots_train_trip_removal(mock_navitia_fixture):
         assert trip_up.status == 'delete'
         # full trip removal : no stop_time to precise
         assert len(trip_up.stop_time_updates) == 0
+        # verify trip_update effect:
+        assert trip_up.effect == 'NO_SERVICE'

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -548,6 +548,7 @@ def test_cots_added_stop_time():
         assert len(RealTimeUpdate.query.all()) == 1
         assert len(TripUpdate.query.all()) == 1
         assert TripUpdate.query.all()[0].status == 'update'
+        assert TripUpdate.query.all()[0].effect == 'SIGNIFICANT_DELAYS'
         assert TripUpdate.query.all()[0].company_id == 'company:OCE:TH'
         assert len(StopTimeUpdate.query.all()) == 7
         assert StopTimeUpdate.query.all()[3].arrival_status == 'add'
@@ -567,6 +568,7 @@ def test_cots_added_stop_time_first_position():
         assert len(RealTimeUpdate.query.all()) == 1
         assert len(TripUpdate.query.all()) == 1
         assert TripUpdate.query.all()[0].status == 'update'
+        assert TripUpdate.query.all()[0].effect == 'SIGNIFICANT_DELAYS'
         assert TripUpdate.query.all()[0].company_id == 'company:OCE:TH'
         assert len(StopTimeUpdate.query.all()) == 7
         assert StopTimeUpdate.query.all()[0].arrival_status == 'none'
@@ -585,8 +587,29 @@ def test_cots_added_stop_time_last_position():
         assert len(RealTimeUpdate.query.all()) == 1
         assert len(TripUpdate.query.all()) == 1
         assert TripUpdate.query.all()[0].status == 'update'
+        assert TripUpdate.query.all()[0].effect == 'SIGNIFICANT_DELAYS'
         assert TripUpdate.query.all()[0].company_id == 'company:OCE:SN'
         assert len(StopTimeUpdate.query.all()) == 7
         assert StopTimeUpdate.query.all()[6].departure_status == 'none'
         assert StopTimeUpdate.query.all()[6].arrival_status == 'add'
         assert StopTimeUpdate.query.all()[6].departure == datetime(2015, 9, 21, 16, 50)
+
+
+def test_cots_add_stop_time_without_delay():
+    """
+    A new stop time is added in the VJ 96231 without delay
+    """
+    cots_add_file = get_fixture_data('cots_train_96231_add_without_delay.json')
+    res = api_post('/cots', data=cots_add_file)
+    assert res == 'OK'
+    with app.app_context():
+        assert len(RealTimeUpdate.query.all()) == 1
+        assert len(TripUpdate.query.all()) == 1
+        assert TripUpdate.query.all()[0].status == 'update'
+        assert TripUpdate.query.all()[0].effect == 'MODIFIED_SERVICE'
+        assert TripUpdate.query.all()[0].company_id == 'company:OCE:TH'
+        assert len(StopTimeUpdate.query.all()) == 7
+        assert StopTimeUpdate.query.all()[3].arrival_status == 'add'
+        assert StopTimeUpdate.query.all()[3].arrival == datetime(2015, 9, 21, 16, 2)
+        assert StopTimeUpdate.query.all()[3].departure_status == 'add'
+        assert StopTimeUpdate.query.all()[3].departure == datetime(2015, 9, 21, 16, 4)

--- a/tests/integration/populate_pb_test.py
+++ b/tests/integration/populate_pb_test.py
@@ -79,6 +79,7 @@ def test_populate_pb_with_one_stop_time():
         assert pb_trip_update.HasExtension(kirin_pb2.trip_message) is False
         assert pb_trip_update.trip.HasExtension(kirin_pb2.contributor) is False
         assert pb_trip_update.trip.HasExtension(kirin_pb2.company_id) is False
+        assert pb_trip_update.HasExtension(kirin_pb2.effect) is False
 
 
 def test_populate_pb_with_two_stop_time():
@@ -126,6 +127,7 @@ def test_populate_pb_with_two_stop_time():
         assert pb_trip_update.HasExtension(kirin_pb2.trip_message) is False
         assert pb_trip_update.trip.HasExtension(kirin_pb2.contributor) is False
         assert pb_trip_update.trip.HasExtension(kirin_pb2.company_id) is False
+        assert pb_trip_update.HasExtension(kirin_pb2.effect) is False
         assert pb_trip_update.trip.schedule_relationship == gtfs_realtime_pb2.TripDescriptor.SCHEDULED
 
         assert len(pb_trip_update.stop_time_update) == 2
@@ -219,6 +221,7 @@ def test_populate_pb_with_deleted_stop_time():
         assert pb_trip_update.HasExtension(kirin_pb2.trip_message) is False
         assert pb_trip_update.trip.HasExtension(kirin_pb2.contributor) is False
         assert pb_trip_update.trip.HasExtension(kirin_pb2.company_id) is False
+        assert pb_trip_update.HasExtension(kirin_pb2.effect) is False
         assert pb_trip_update.trip.schedule_relationship == gtfs_realtime_pb2.TripDescriptor.SCHEDULED
 
         assert len(pb_trip_update.stop_time_update) == 4
@@ -289,6 +292,7 @@ def test_populate_pb_with_cancelation():
         real_time_update = RealTimeUpdate(raw_data=None, connector='ire', contributor='realtime.ire')
         trip_update.contributor = 'kisio-digital'
         trip_update.company_id = 'sncf'
+        trip_update.effect = 'REDUCED_SERVICE'
         real_time_update.trip_updates.append(trip_update)
 
         db.session.add(real_time_update)
@@ -308,6 +312,7 @@ def test_populate_pb_with_cancelation():
         assert pb_trip_update.trip.HasExtension(kirin_pb2.contributor) == True
         assert pb_trip_update.trip.Extensions[kirin_pb2.contributor] == 'kisio-digital'
         assert pb_trip_update.trip.Extensions[kirin_pb2.company_id] == 'sncf'
+        assert pb_trip_update.Extensions[kirin_pb2.effect] == gtfs_realtime_pb2.Alert.REDUCED_SERVICE
 
         assert len(feed_entity.entity[0].trip_update.stop_time_update) == 0
 
@@ -330,6 +335,7 @@ def test_populate_pb_with_full_dataset():
         real_time_update = RealTimeUpdate(raw_data=None, connector='ire', contributor='realtime.ire')
         trip_update.contributor = 'kisio-digital'
         trip_update.company_id = 'keolis'
+        trip_update.effect = 'DETOUR'
         real_time_update.trip_updates.append(trip_update)
 
         db.session.add(real_time_update)
@@ -349,5 +355,6 @@ def test_populate_pb_with_full_dataset():
         assert pb_trip_update.trip.HasExtension(kirin_pb2.contributor) == True
         assert pb_trip_update.trip.Extensions[kirin_pb2.contributor] == 'kisio-digital'
         assert pb_trip_update.trip.Extensions[kirin_pb2.company_id] == 'keolis'
+        assert pb_trip_update.Extensions[kirin_pb2.effect] == gtfs_realtime_pb2.Alert.DETOUR
 
         assert len(feed_entity.entity[0].trip_update.stop_time_update) == 0

--- a/tests/integration/utils_sncf_test.py
+++ b/tests/integration/utils_sncf_test.py
@@ -48,6 +48,8 @@ def check_db_96231_delayed(contributor=None, motif_externe_is_null=False):
         assert db_trip_delayed.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21, tzinfo=utc)
         assert db_trip_delayed.vj_id == db_trip_delayed.vj.id
         assert db_trip_delayed.status == 'update'
+        # Cots contain delayed stop_times only
+        assert db_trip_delayed.effect == 'SIGNIFICANT_DELAYS'
         assert db_trip_delayed.company_id == 'company:OCE:SN'
         # 6 stop times must have been created
         assert len(db_trip_delayed.stop_time_updates) == 6
@@ -112,6 +114,8 @@ def check_db_870154_partial_removal(contributor=None):
         assert db_trip.vj.get_start_timestamp() == datetime(2018, 11, 2, 9, 54, tzinfo=utc)
         assert db_trip.vj_id == db_trip.vj.id
         assert db_trip.status == 'update'
+        # Cots contain deleted as well as delayed stop_times
+        assert db_trip.effect == 'SIGNIFICANT_DELAYS'
         # 12 stop times must have been created
         assert len(db_trip.stop_time_updates) == 12
 
@@ -151,6 +155,8 @@ def check_db_870154_delay():
         db_trip = TripUpdate.find_by_dated_vj('OCE:SN870154F01001', datetime(2018, 11, 2, 9, 54, tzinfo=utc))
         assert db_trip
         assert db_trip.message == u'Régulation du trafic'
+        # Cots contain deleted as well as delayed stop_times
+        assert db_trip.effect == 'SIGNIFICANT_DELAYS'
 
         # only in "delay-case" departure, arrival at 5th (Viviez-Decazeville)
         # and arrival at 6th stops (Capdenac) are deleted with a cause
@@ -336,6 +342,8 @@ def check_db_96231_mixed_statuses_inside_stops(contributor=None):
         assert db_trip_delayed.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21, tzinfo=utc)
         assert db_trip_delayed.vj_id == db_trip_delayed.vj.id
         assert db_trip_delayed.status == 'update'
+        # Cots contain delayed as well as removed stop_times
+        assert db_trip_delayed.effect == 'SIGNIFICANT_DELAYS'
         # 6 stop times must have been created
         assert len(db_trip_delayed.stop_time_updates) == 6
 
@@ -408,6 +416,8 @@ def check_db_96231_mixed_statuses_delay_removal_delay(contributor=None):
         assert db_trip_delayed.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21, tzinfo=utc)
         assert db_trip_delayed.vj_id == db_trip_delayed.vj.id
         assert db_trip_delayed.status == 'update'
+        # Cots contain removed as well as delayed stop_times
+        assert db_trip_delayed.effect == 'SIGNIFICANT_DELAYS'
         # 6 stop times must have been created
         assert len(db_trip_delayed.stop_time_updates) == 6
 
@@ -482,6 +492,7 @@ def check_db_96231_normal(contributor=None):
         assert db_trip_delayed.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21, tzinfo=utc)
         assert db_trip_delayed.vj_id == db_trip_delayed.vj.id
         assert db_trip_delayed.status == 'update'
+        assert db_trip_delayed.effect == 'SIGNIFICANT_DELAYS'
         assert db_trip_delayed.message is None
         # 6 stop times must have been created
         assert len(db_trip_delayed.stop_time_updates) == 6
@@ -543,6 +554,7 @@ def check_db_john_trip_removal():
         assert db_trip1_removal.vj.get_start_timestamp() == datetime(2015, 9, 21, 10, 37, tzinfo=utc)
         assert db_trip1_removal.vj_id == db_trip1_removal.vj.id
         assert db_trip1_removal.status == 'delete'
+        assert db_trip1_removal.effect == 'NO_SERVICE'
         # full trip removal : no stop_time to precise
         assert len(db_trip1_removal.stop_time_updates) == 0
 
@@ -554,6 +566,7 @@ def check_db_john_trip_removal():
         assert db_trip2_removal.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21, tzinfo=utc)
         assert db_trip2_removal.vj_id == db_trip2_removal.vj.id
         assert db_trip2_removal.status == 'delete'
+        assert db_trip2_removal.effect == 'NO_SERVICE'
         # full trip removal : no stop_time to precise
         assert len(db_trip2_removal.stop_time_updates) == 0
 
@@ -571,6 +584,7 @@ def check_db_96231_trip_removal():
         assert db_trip_removal.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21, tzinfo=utc)
         assert db_trip_removal.vj_id == db_trip_removal.vj.id
         assert db_trip_removal.status == 'delete'
+        assert db_trip_removal.effect == 'SIGNIFICANT_DELAYS'
         assert db_trip_removal.message is None
         # full trip removal : no stop_time to precise
         assert len(db_trip_removal.stop_time_updates) == 0
@@ -589,6 +603,7 @@ def check_db_6113_trip_removal():
         assert db_trip_removal.vj.get_start_timestamp() == datetime(2015, 10, 6, 10, 37, tzinfo=utc)
         assert db_trip_removal.vj_id == db_trip_removal.vj.id
         assert db_trip_removal.status == 'delete'
+        assert db_trip_removal.effect == 'NO_SERVICE'
         print db_trip_removal.message
         assert db_trip_removal.message == u'Accident à un Passage à Niveau'
         # full trip removal : no stop_time to precise
@@ -608,6 +623,7 @@ def check_db_6111_trip_removal_pass_midnight():
         assert db_trip_removal.vj.get_start_timestamp() == datetime(2015, 10, 6, 20, 37, tzinfo=utc)
         assert db_trip_removal.vj_id == db_trip_removal.vj.id
         assert db_trip_removal.status == 'delete'
+        assert db_trip_removal.effect == 'NO_SERVICE'
         print db_trip_removal.message
         assert db_trip_removal.message == u'Accident à un Passage à Niveau'
         # full trip removal : no stop_time to precise
@@ -647,6 +663,7 @@ def check_db_96231_partial_removal(contributor=None):
         assert db_trip_partial_removed.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21, tzinfo=utc)
         assert db_trip_partial_removed.vj_id == db_trip_partial_removed.vj.id
         assert db_trip_partial_removed.status == 'update'
+        assert db_trip_partial_removed.effect == 'SIGNIFICANT_DELAYS'
         # 6 stop times must have been created
         assert len(db_trip_partial_removed.stop_time_updates) == 6
 
@@ -719,6 +736,7 @@ def check_db_840427_partial_removal(contributor=None):
         assert db_trip_partial_removed.vj.get_start_timestamp() == datetime(2017, 3, 18, 13, 5, tzinfo=utc)
         assert db_trip_partial_removed.vj_id == db_trip_partial_removed.vj.id
         assert db_trip_partial_removed.status == 'update'
+        assert db_trip_partial_removed.effect == 'DETOUR'
 
         # 7 stop times must have been created
         assert len(db_trip_partial_removed.stop_time_updates) == 7


### PR DESCRIPTION
This PR contains the following modifications:

- Add attribut effect of type enum in the table trip_update.

- Manage effect in kirin as done in kraken. In the next release, the function in kraken should de deleted.

- Existing tests modified and some new tests added.

- For detail please refer to: https://jira.kisio.org/browse/NAVP-1081