### PR TITLE
reject cots if added stop_time is earlier than previous

### DIFF
--- a/kirin/cots/model_maker.py
+++ b/kirin/cots/model_maker.py
@@ -312,7 +312,7 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
         highest_st_status = 'nochange'
         pdps = _retrieve_interesting_pdp(get_value(json_train, 'listePointDeParcours'))
 
-        # this dict is used to memoize the last stop_time in order to check the stop_time consistency
+        # this variable is used to memoize the last stop_time's departure in order to check the stop_time consistency
         # ex. stop_time[i].arrival/departure must be greater than stop_time[i-1].departure
         last_stop_time_depart = None
 
@@ -406,6 +406,7 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
 
                 elif cots_stop_time_status == 'DETOURNEMENT':
                     # new stop_time added also?
+                    # TODO: stop_time's consistency should also be tested once the feature is implemented
                     self._record_and_log(logger, 'nouvelleVersion/listePointDeParcours/statutCirculationOPE == '
                                                  '"{}" is not handled (yet)'.format(cots_stop_time_status))
 

--- a/kirin/cots/model_maker.py
+++ b/kirin/cots/model_maker.py
@@ -263,9 +263,11 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
         log_dict.update({'contributor': self.contributor})
         logger.info('metrology', extra=log_dict)
 
-    def _check_stop_time_consistency(self, last_stop_time_depart, projected_stop_time, pdp_code):
-        last_stop_time_depart = last_stop_time_depart if last_stop_time_depart is not None else datetime.fromtimestamp(0,
-                                                                                                           tz.tzutc())
+    @staticmethod
+    def _check_stop_time_consistency(last_stop_time_depart, projected_stop_time, pdp_code):
+        last_stop_time_depart = last_stop_time_depart if last_stop_time_depart is not None else \
+            datetime.fromtimestamp(0,tz.tzutc())
+
         projected_arrival = projected_stop_time.get('Arrivee')
         projected_arrival = projected_arrival if projected_arrival is not None else last_stop_time_depart
 
@@ -275,19 +277,6 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
         if not (projected_departure >= projected_arrival >= last_stop_time_depart):
             raise InvalidArguments('invalid cots: stop_point\'s({}) time is not consistent'
                                    .format(pdp_code))
-
-        # def _project_stop_time_is_consistent():
-        #     return projected_departure >= projected_arrival if (projected_departure and projected_arrival) else True
-        #
-        # def _last_depart_is_earlier_than_projected():
-        #     if last_stop_time_depart:
-        #         return all((last_stop_time_depart < projected_departure if projected_departure else True,
-        #                    last_stop_time_depart < projected_arrival if projected_arrival else True))
-        #     return True
-        #
-        # if not _project_stop_time_is_consistent() or not _last_depart_is_earlier_than_projected():
-        #     raise InvalidArguments('invalid cots: stop_point\'s({}) time is not consistent'
-        #                                    .format(pdp_code))
 
     def _make_trip_update(self, vj, json_train):
         """

--- a/tests/fixtures/cots_train_870154_partial_normal.json
+++ b/tests/fixtures/cots_train_870154_partial_normal.json
@@ -614,13 +614,13 @@
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurArrivee": {
-				"dateHeure": "2018-11-02T10:36:30+0000",
+				"dateHeure": "2018-11-02T11:36:30+0000",
 				"heureLocale": "12:36:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
 			},
 			"horaireVoyageurDepart": {
-				"dateHeure": "2018-11-02T10:37:30+0000",
+				"dateHeure": "2018-11-02T11:37:30+0000",
 				"heureLocale": "12:37:30",
 				"idFuseauHoraire": "Europe/Paris",
 				"nbJoursPasseMinuit": 0
@@ -628,14 +628,14 @@
 			"idMotifInterneArriveeReference": 24,
 			"idMotifInterneDepartReference": 24,
 			"listeHoraireProjeteArrivee": [{
-				"dateHeure": "2018-11-02T10:41:30+0000",
+				"dateHeure": "2018-11-02T11:41:30+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 600,
 				"pronosticIV": 600,
 				"source": "IRE-GOP"
 			}],
 			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2018-11-02T10:42:30+0000",
+				"dateHeure": "2018-11-02T11:42:30+0000",
 				"dateHeureEmission": "2018-11-02T09:00:15+0000",
 				"pronosticBrut": 600,
 				"pronosticIV": 600,

--- a/tests/fixtures/cots_train_96231_add_first.json
+++ b/tests/fixtures/cots_train_96231_add_first.json
@@ -120,7 +120,7 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2015-09-21T14:30:00+0000",
+          "dateHeure": "2015-09-21T14:39:00+0000",
           "heureLocale": "16:30:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -128,12 +128,12 @@
         "horaireProductionArrivee": {
           "idFuseauHoraire": "Europe/Paris",
           "heureIncertaine": false,
-          "heureLocale": "16:29:00",
+          "heureLocale": "16:30:00",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2015-09-21T15:39:00+0000",
-          "heureLocale": "16:29:00",
+          "dateHeure": "2015-09-21T14:30:00+0000",
+          "heureLocale": "16:30:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },

--- a/tests/fixtures/cots_train_96231_add_stop_time_earlier_than_previous.json
+++ b/tests/fixtures/cots_train_96231_add_stop_time_earlier_than_previous.json
@@ -282,7 +282,7 @@
         ],
         "listeMotifArrivee": [],
         "listeMotifDepart": [],
-        "rang": 11,
+        "rang": 4,
         "sourceHoraireProjeteArriveeReference": "IRE-GOP",
         "sourceHoraireProjeteDepartReference": "IRE-GOP",
         "typeArret": "CH"
@@ -355,7 +355,7 @@
         ],
         "listeMotifDepart": [
         ],
-        "rang": 4,
+        "rang": 5,
         "sourceHoraireProjeteArriveeReference": "ESCALE",
         "sourceHoraireProjeteDepartReference": "ESCALE",
         "typeArret": "CH"
@@ -428,7 +428,7 @@
         ],
         "listeMotifDepart": [
         ],
-        "rang": 5,
+        "rang": 6,
         "sourceHoraireProjeteArriveeReference": "ESCALE",
         "sourceHoraireProjeteDepartReference": "ESCALE",
         "typeArret": "CH"
@@ -477,7 +477,7 @@
         ],
         "listeMotifDepart": [
         ],
-        "rang": 6,
+        "rang": 7,
         "sourceHoraireProjeteArriveeReference": "ESCALE",
         "typeArret": "CH"
       }

--- a/tests/fixtures/cots_train_96231_add_stop_time_earlier_than_previous.json
+++ b/tests/fixtures/cots_train_96231_add_stop_time_earlier_than_previous.json
@@ -82,30 +82,6 @@
     "listeMotif": [
     ],
     "listePointDeParcours": [
-            {
-        "@id": "6a4a4413-a668-487c-b25d-907ef7e64e75",
-        "cr": "0087",
-        "ci": "713065",
-        "ch": "BV",
-        "timeZoneLocale": "Europe/Paris",
-        "horaireVoyageurArrivee": {
-        },
-        "horaireVoyageurDepart": {
-          "dateHeure": "2015-09-21T14:20:00+0000",
-          "heureLocale": "16:20:00",
-          "idFuseauHoraire": "Europe/Paris",
-          "nbJoursPasseMinuit": 0,
-          "statutCirculationOPE": "CREATION"
-        },
-        "listeHoraireProjeteArrivee": [
-        ],
-        "listeHoraireProjeteDepart": [
-        ],
-        "listeMotifArrivee": [],
-        "listeMotifDepart": [],
-        "rang": 0,
-        "typeArret": "CH"
-      },
       {
         "@id": "998484ec-4335-45b6-aad4-8840047b275f",
         "arretFacultatif": false,
@@ -122,18 +98,6 @@
         "horaireVoyageurDepart": {
           "dateHeure": "2015-09-21T14:30:00+0000",
           "heureLocale": "16:30:00",
-          "idFuseauHoraire": "Europe/Paris",
-          "nbJoursPasseMinuit": 0
-        },
-        "horaireProductionArrivee": {
-          "idFuseauHoraire": "Europe/Paris",
-          "heureIncertaine": false,
-          "heureLocale": "16:29:00",
-          "nbJoursPasseMinuit": 0
-        },
-        "horaireVoyageurArrivee": {
-          "dateHeure": "2015-09-21T15:39:00+0000",
-          "heureLocale": "16:29:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
@@ -276,6 +240,51 @@
         ],
         "rang": 3,
         "sourceHoraireProjeteDepartReference": "TEST",
+        "typeArret": "CH"
+      },
+      {
+        "@id": "6a4a4413-a668-487c-b25d-907ef7e64e75",
+        "cr": "0087",
+        "ci": "713065",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T14:02:00+0200",
+          "heureLocale": "14:02:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T14:04:00+0000",
+          "heureLocale": "14:04:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2018-10-23T14:50:00+0200",
+            "dateHeureEmission": "2018-10-23T09:22:19+0000",
+            "pronosticBrut": 300,
+            "pronosticIV": 300,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2018-10-23T14:54:00+0200",
+            "dateHeureEmission": "2018-10-23T09:22:19+0000",
+            "pronosticBrut": 300,
+            "pronosticIV": 300,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 11,
+        "sourceHoraireProjeteArriveeReference": "IRE-GOP",
+        "sourceHoraireProjeteDepartReference": "IRE-GOP",
         "typeArret": "CH"
       },
       {

--- a/tests/fixtures/cots_train_96231_delayed.json
+++ b/tests/fixtures/cots_train_96231_delayed.json
@@ -156,7 +156,7 @@
                 ],
                 "listeHoraireProjeteDepart":[
                     {
-                        "dateHeure":"2015-09-21T17:54:30+0000",
+                        "dateHeure":"2015-09-21T15:54:30+0000",
                         "dateHeureEmission":"2018-04-19T15:44:53+0000",
                         "pronosticBrut":830,
                         "pronosticIV":840,
@@ -207,7 +207,7 @@
                     "nbJoursPasseMinuit":0
                 },
                 "horaireVoyageurDepart":{
-                    "dateHeure":"2015-09-21T17:53:00+0000",
+                    "dateHeure":"2015-09-21T15:53:00+0000",
                     "heureLocale":"17:53:00",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0

--- a/tests/fixtures/cots_train_96231_delaylist_at_stop_ko.json
+++ b/tests/fixtures/cots_train_96231_delaylist_at_stop_ko.json
@@ -162,7 +162,7 @@
                         "source":"ESCALE"
                     },
                     {
-                        "dateHeure":"2015-09-21T17:54:30+0000",
+                        "dateHeure":"2015-09-21T15:54:30+0000",
                         "dateHeureEmission":"2018-04-19T15:44:53+0000",
                         "pronosticBrut":830,
                         "pronosticIV":840,
@@ -206,7 +206,7 @@
                     "nbJoursPasseMinuit":0
                 },
                 "horaireVoyageurDepart":{
-                    "dateHeure":"2015-09-21T17:53:00+0000",
+                    "dateHeure":"2015-09-21T15:53:00+0000",
                     "heureLocale":"17:53:00",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0

--- a/tests/fixtures/cots_train_96231_mixed_statuses_inside_stops.json
+++ b/tests/fixtures/cots_train_96231_mixed_statuses_inside_stops.json
@@ -204,7 +204,7 @@
                     "nbJoursPasseMinuit":0
                 },
                 "horaireVoyageurDepart":{
-                    "dateHeure":"2015-09-21T17:53:00+0000",
+                    "dateHeure":"2015-09-21T15:53:00+0000",
                     "heureLocale":"17:53:00",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0

--- a/tests/fixtures/cots_train_96231_normal.json
+++ b/tests/fixtures/cots_train_96231_normal.json
@@ -139,13 +139,13 @@
                 },
                 "horaireVoyageurArrivee":{
                     "dateHeure":"2015-09-21T14:39:00+0000",
-                    "heureLocale":"17:39:00",
+                    "heureLocale":"16:39:00",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0
                 },
                 "horaireVoyageurDepart":{
                     "dateHeure":"2015-09-21T14:40:30+0000",
-                    "heureLocale":"17:40:30",
+                    "heureLocale":"16:40:30",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0
                 },
@@ -199,13 +199,13 @@
                 },
                 "horaireVoyageurArrivee":{
                     "dateHeure":"2015-09-21T14:51:00+0000",
-                    "heureLocale":"17:51:00",
+                    "heureLocale":"16:51:00",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0
                 },
                 "horaireVoyageurDepart":{
                     "dateHeure":"2015-09-21T14:53:00+0000",
-                    "heureLocale":"17:53:00",
+                    "heureLocale":"16:53:00",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0
                 },
@@ -264,13 +264,13 @@
                 },
                 "horaireVoyageurArrivee":{
                     "dateHeure":"2015-09-21T15:14:00+0000",
-                    "heureLocale":"18:14:00",
+                    "heureLocale":"17:14:00",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0
                 },
                 "horaireVoyageurDepart":{
                     "dateHeure":"2015-09-21T15:16:00+0000",
-                    "heureLocale":"18:16:00",
+                    "heureLocale":"17:16:00",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0
                 },
@@ -337,13 +337,13 @@
                 },
                 "horaireVoyageurArrivee":{
                     "dateHeure":"2015-09-21T15:30:00+0000",
-                    "heureLocale":"18:30:00",
+                    "heureLocale":"17:30:00",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0
                 },
                 "horaireVoyageurDepart":{
                     "dateHeure":"2015-09-21T15:31:00+0000",
-                    "heureLocale":"18:31:00",
+                    "heureLocale":"17:31:00",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0
                 },

--- a/tests/fixtures/cots_train_96231_normal.json
+++ b/tests/fixtures/cots_train_96231_normal.json
@@ -121,7 +121,7 @@
                 "ci":"214056",
                 "ch":"00",
                 "horaireObserveArrivee":{
-                    "dateHeure":"2015-09-21T15:39:00+0000",
+                    "dateHeure":"2015-09-21T16:39:00+0000",
                     "dateHeureEmission":"2018-04-19T15:44:53+0000",
                     "source":"ESCALE"
                 },
@@ -138,13 +138,13 @@
                     "nbJoursPasseMinuit":0
                 },
                 "horaireVoyageurArrivee":{
-                    "dateHeure":"2015-09-21T15:39:00+0000",
+                    "dateHeure":"2015-09-21T14:39:00+0000",
                     "heureLocale":"17:39:00",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0
                 },
                 "horaireVoyageurDepart":{
-                    "dateHeure":"2015-09-21T15:40:30+0000",
+                    "dateHeure":"2015-09-21T14:40:30+0000",
                     "heureLocale":"17:40:30",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0
@@ -153,14 +153,14 @@
                 ],
                 "listeHoraireProjeteDepart":[
                     {
-                        "dateHeure":"2015-09-21T15:40:30+0000",
+                        "dateHeure":"2015-09-21T14:40:30+0000",
                         "dateHeureEmission":"2018-04-19T15:44:53+0000",
                         "pronosticBrut":0,
                         "pronosticIV":0,
                         "source":"ESCALE"
                     },
                     {
-                        "dateHeure":"2015-09-21T17:40:30+0000",
+                        "dateHeure":"2015-09-21T14:40:30+0000",
                         "dateHeureEmission":"2018-04-19T15:44:53+0000",
                         "pronosticBrut":0,
                         "pronosticIV":0,
@@ -198,20 +198,20 @@
                     "nbJoursPasseMinuit":0
                 },
                 "horaireVoyageurArrivee":{
-                    "dateHeure":"2015-09-21T15:51:00+0000",
+                    "dateHeure":"2015-09-21T14:51:00+0000",
                     "heureLocale":"17:51:00",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0
                 },
                 "horaireVoyageurDepart":{
-                    "dateHeure":"2015-09-21T17:53:00+0000",
+                    "dateHeure":"2015-09-21T14:53:00+0000",
                     "heureLocale":"17:53:00",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0
                 },
                 "listeHoraireProjeteArrivee":[
                     {
-                        "dateHeure":"2015-09-21T15:51:00+0000",
+                        "dateHeure":"2015-09-21T14:51:00+0000",
                         "dateHeureEmission":"2018-04-19T18:06:00+0000",
                         "pronosticBrut":0,
                         "pronosticIV":0,
@@ -220,14 +220,14 @@
                 ],
                 "listeHoraireProjeteDepart":[
                     {
-                        "dateHeure":"2015-09-21T15:53:00+0000",
+                        "dateHeure":"2015-09-21T14:53:00+0000",
                         "dateHeureEmission":"2018-04-19T15:44:53+0000",
                         "pronosticBrut":0,
                         "pronosticIV":0,
                         "source":"ESCALE"
                     },
                     {
-                        "dateHeure":"2015-09-21T15:53:00+0000",
+                        "dateHeure":"2015-09-21T14:53:00+0000",
                         "dateHeureEmission":"2018-04-19T18:08:00+0000",
                         "pronosticBrut":0,
                         "pronosticIV":0,
@@ -263,27 +263,27 @@
                     "nbJoursPasseMinuit":0
                 },
                 "horaireVoyageurArrivee":{
-                    "dateHeure":"2015-09-21T16:14:00+0000",
+                    "dateHeure":"2015-09-21T15:14:00+0000",
                     "heureLocale":"18:14:00",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0
                 },
                 "horaireVoyageurDepart":{
-                    "dateHeure":"2015-09-21T16:16:00+0000",
+                    "dateHeure":"2015-09-21T15:16:00+0000",
                     "heureLocale":"18:16:00",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0
                 },
                 "listeHoraireProjeteArrivee":[
                     {
-                        "dateHeure":"2015-09-21T16:14:00+0000",
+                        "dateHeure":"2015-09-21T15:14:00+0000",
                         "dateHeureEmission":"2018-04-19T15:44:53+0000",
                         "pronosticBrut":0,
                         "pronosticIV":0,
                         "source":"ESCALE"
                     },
                     {
-                        "dateHeure":"2015-09-21T16:14:00+0000",
+                        "dateHeure":"2015-09-21T15:14:00+0000",
                         "dateHeureEmission":"2018-04-19T15:44:53+0000",
                         "pronosticBrut":0,
                         "pronosticIV":0,
@@ -292,14 +292,14 @@
                 ],
                 "listeHoraireProjeteDepart":[
                     {
-                        "dateHeure":"2015-09-21T16:16:00+0000",
+                        "dateHeure":"2015-09-21T15:16:00+0000",
                         "dateHeureEmission":"2018-04-19T15:44:53+0000",
                         "pronosticBrut":0,
                         "pronosticIV":0,
                         "source":"ESCALE"
                     },
                     {
-                        "dateHeure":"2015-09-21T16:16:00+0000",
+                        "dateHeure":"2015-09-21T15:16:00+0000",
                         "dateHeureEmission":"2018-04-19T15:44:53+0000",
                         "pronosticBrut":0,
                         "pronosticIV":0,
@@ -336,27 +336,27 @@
                     "nbJoursPasseMinuit":0
                 },
                 "horaireVoyageurArrivee":{
-                    "dateHeure":"2015-09-21T16:30:00+0000",
+                    "dateHeure":"2015-09-21T15:30:00+0000",
                     "heureLocale":"18:30:00",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0
                 },
                 "horaireVoyageurDepart":{
-                    "dateHeure":"2015-09-21T16:31:00+0000",
+                    "dateHeure":"2015-09-21T15:31:00+0000",
                     "heureLocale":"18:31:00",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0
                 },
                 "listeHoraireProjeteArrivee":[
                     {
-                        "dateHeure":"2015-09-21T16:30:00+0000",
+                        "dateHeure":"2015-09-21T15:30:00+0000",
                         "dateHeureEmission":"2018-04-19T15:44:53+0000",
                         "pronosticBrut":0,
                         "pronosticIV":0,
                         "source":"ESCALE"
                     },
                     {
-                        "dateHeure":"2015-09-21T16:30:00+0000",
+                        "dateHeure":"2015-09-21T15:30:00+0000",
                         "dateHeureEmission":"2018-04-19T15:44:53+0000",
                         "pronosticBrut":0,
                         "pronosticIV":0,
@@ -365,14 +365,14 @@
                 ],
                 "listeHoraireProjeteDepart":[
                     {
-                        "dateHeure":"2015-09-21T16:31:00+0000",
+                        "dateHeure":"2015-09-21T15:31:00+0000",
                         "dateHeureEmission":"2018-04-19T15:44:53+0000",
                         "pronosticBrut":0,
                         "pronosticIV":0,
                         "source":"ESCALE"
                     },
                     {
-                        "dateHeure":"2015-09-21T16:31:00+0000",
+                        "dateHeure":"2015-09-21T15:31:00+0000",
                         "dateHeureEmission":"2018-04-19T15:44:53+0000",
                         "pronosticBrut":0,
                         "pronosticIV":0,

--- a/tests/fixtures/cots_train_96231_partial_removal.json
+++ b/tests/fixtures/cots_train_96231_partial_removal.json
@@ -188,7 +188,7 @@
                     "nbJoursPasseMinuit":0
                 },
                 "horaireVoyageurDepart":{
-                    "dateHeure":"2015-09-21T17:53:00+0000",
+                    "dateHeure":"2015-09-21T15:53:00+0000",
                     "heureLocale":"17:53:00",
                     "idFuseauHoraire":"Europe/Paris",
                     "nbJoursPasseMinuit":0

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -613,3 +613,19 @@ def test_cots_add_stop_time_without_delay():
         assert StopTimeUpdate.query.all()[3].arrival == datetime(2015, 9, 21, 16, 2)
         assert StopTimeUpdate.query.all()[3].departure_status == 'add'
         assert StopTimeUpdate.query.all()[3].departure == datetime(2015, 9, 21, 16, 4)
+
+
+def test_cots_added_stop_time_earlier_than_previous():
+    """
+    A new stop time is added in the VJ 96231 whose arrival/departure is earlier
+    than the previous one.
+
+    This cots should be rejected
+    """
+    cots_add_file = get_fixture_data('cots_train_96231_add_stop_time_earlier_than_previous.json')
+    res, status = api_post('/cots', data=cots_add_file, check=False)
+    assert status == 400
+    assert res.get('message') == 'Invalid arguments'
+    with app.app_context():
+        assert RealTimeUpdate.query.first().error == \
+               'invalid cost: stop_point\'s(0087-713065-BV) Arrivee time is less than previous departure time'

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -628,4 +628,4 @@ def test_cots_added_stop_time_earlier_than_previous():
     assert res.get('message') == 'Invalid arguments'
     with app.app_context():
         assert RealTimeUpdate.query.first().error == \
-               'invalid cost: stop_point\'s(0087-713065-BV) Arrivee time is less than previous departure time'
+               'invalid cots: stop_point\'s(0087-713065-BV) time is not consistent'


### PR DESCRIPTION
https://jira.kisio.org/browse/NAVP-1096

When a new stop_point is added by COTS and it's stop_time(arrival/departure) is earlier than the previous departure, the cots  will be rejected. 

While without the fix, the VJ is considered as a pass midnight

At the same time, I did some cleaning on integration test's fixtures...