### PR TITLE
Add effect in gtfs rt part

### DIFF
--- a/kirin/gtfs_rt/model_maker.py
+++ b/kirin/gtfs_rt/model_maker.py
@@ -144,7 +144,6 @@ class KirinModelBuilder(object):
         """
         vjs = self._get_navitia_vjs(input_trip_update.trip, data_time=data_time)
         trip_updates = []
-        # Initialize stop_time status to nochange
         highest_st_status = 'none'
         for vj in vjs:
             trip_update = model.TripUpdate(vj=vj)

--- a/kirin/gtfs_rt/model_maker.py
+++ b/kirin/gtfs_rt/model_maker.py
@@ -290,8 +290,14 @@ class KirinModelBuilder(object):
         dep_delay = read_delay(input_st_update.departure)
         arr_delay = read_delay(input_st_update.arrival)
         highest_status = 'none'
-        dep_status = 'none' if dep_delay is None else 'update'; highest_status = 'update'
-        arr_status = 'none' if arr_delay is None else 'update'; highest_status = 'update'
+        if dep_delay is None:
+            dep_status = 'none'
+        else:
+            highest_status = dep_status = 'update'
+        if arr_delay is None:
+            arr_status = 'none'
+        else:
+            highest_status = arr_status = 'update'
         st_update = model.StopTimeUpdate(nav_stop, departure_delay=dep_delay, arrival_delay=arr_delay,
                                          dep_status=dep_status, arr_status=arr_status,
                                          order=input_st_update.stop_sequence)

--- a/kirin/gtfs_rt/model_maker.py
+++ b/kirin/gtfs_rt/model_maker.py
@@ -144,10 +144,10 @@ class KirinModelBuilder(object):
         """
         vjs = self._get_navitia_vjs(input_trip_update.trip, data_time=data_time)
         trip_updates = []
-        highest_st_status = ModificationType.none.name
         for vj in vjs:
             trip_update = model.TripUpdate(vj=vj)
             trip_update.contributor = self.contributor
+            highest_st_status = ModificationType.none.name
 
             is_tu_valid = True
             vj_stop_order = len(vj.navitia_vj.get('stop_times', [])) - 1

--- a/kirin/gtfs_rt/model_maker.py
+++ b/kirin/gtfs_rt/model_maker.py
@@ -145,7 +145,7 @@ class KirinModelBuilder(object):
         vjs = self._get_navitia_vjs(input_trip_update.trip, data_time=data_time)
         trip_updates = []
         # Initialize stop_time status to nochange
-        highest_st_status = 'nochange'
+        highest_st_status = 'none'
         for vj in vjs:
             trip_update = model.TripUpdate(vj=vj)
             trip_update.contributor = self.contributor

--- a/kirin/gtfs_rt/model_maker.py
+++ b/kirin/gtfs_rt/model_maker.py
@@ -35,7 +35,7 @@ import pytz
 
 from kirin import core
 from kirin.core import model
-from kirin.core.types import get_higher_status, get_effect_by_stop_time_status
+from kirin.core.types import ModificationType, get_higher_status, get_effect_by_stop_time_status
 from kirin.exceptions import KirinException, InvalidArguments, ObjectNotFound
 from kirin.utils import make_navitia_wrapper, make_rt_update, floor_datetime
 from kirin import new_relic
@@ -144,7 +144,7 @@ class KirinModelBuilder(object):
         """
         vjs = self._get_navitia_vjs(input_trip_update.trip, data_time=data_time)
         trip_updates = []
-        highest_st_status = 'none'
+        highest_st_status = ModificationType.none.name
         for vj in vjs:
             trip_update = model.TripUpdate(vj=vj)
             trip_update.contributor = self.contributor
@@ -168,9 +168,8 @@ class KirinModelBuilder(object):
                         break
 
                     tu_stop.stop_sequence = vj_stop_order
-                    st_update, status = self._make_stoptime_update(tu_stop, vj_stop_point)
+                    st_update = self._make_stoptime_update(tu_stop, vj_stop_point)
                     if st_update is not None:
-                        highest_st_status = get_higher_status(highest_st_status, status)
                         trip_update.stop_time_updates.append(st_update)
                 else:
                     #Initialize stops absent in trip_updates but present in vj
@@ -178,6 +177,8 @@ class KirinModelBuilder(object):
                     if st_update is not None:
                         trip_update.stop_time_updates.append(st_update)
 
+                for status in [st_update.departure_status, st_update.arrival_status]:
+                    highest_st_status = get_higher_status(highest_st_status, status)
                 vj_stop_order -= 1
 
             if is_tu_valid:
@@ -288,17 +289,10 @@ class KirinModelBuilder(object):
                 return datetime.timedelta(seconds=st_event.delay)
         dep_delay = read_delay(input_st_update.departure)
         arr_delay = read_delay(input_st_update.arrival)
-        highest_status = 'none'
-        if dep_delay is None:
-            dep_status = 'none'
-        else:
-            highest_status = dep_status = 'update'
-        if arr_delay is None:
-            arr_status = 'none'
-        else:
-            highest_status = arr_status = 'update'
+        dep_status = ModificationType.none.name if dep_delay is None else ModificationType.update.name
+        arr_status = ModificationType.none.name if arr_delay is None else ModificationType.update.name
         st_update = model.StopTimeUpdate(nav_stop, departure_delay=dep_delay, arrival_delay=arr_delay,
                                          dep_status=dep_status, arr_status=arr_status,
                                          order=input_st_update.stop_sequence)
 
-        return st_update, highest_status
+        return st_update

--- a/tests/integration/gtfs_rt_test.py
+++ b/tests/integration/gtfs_rt_test.py
@@ -141,7 +141,7 @@ def test_gtfs_effect(basic_gtfs_rt_data, basic_gtfs_rt_data_without_delays):
     """
     2 possibilities :
         - if there is no delay field (delay is optional in StopTimeEvent), effect = 'UNKNOWN_EFFECT'
-        - if not effect = 'SIGNIFICANT_DELAYS'
+        - if not, effect = 'SIGNIFICANT_DELAYS'
     """
     with app.app_context():
         data = ''


### PR DESCRIPTION
Following the _Krishna_'s work, effect has to be handled in Gtfs-Rt Kirin part.

It consists to read within the input (realtime protobuf), the delay optional field. delay is contained in StoptimeEvent. If it exist, the effect will become `SIGNIFICANT_DELAYS`, otherwise `UNKNOWN_EFFECT`

@kadhikari, I am not sure if it misses code. Can you check that ?