### PR TITLE
Handle deletion of an added stop_time

### DIFF
--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -334,6 +334,20 @@ class TripUpdate(db.Model, TimestampMixin):
         return next((st for st in self.stop_time_updates
                      if st.stop_id == stop_id), None)
 
+    def deleteable(self, stop_id):
+        """
+        Stop_time is deleteable only if last stop_time.departure_status or stop_time.arrival_status is not
+        deleted
+        """
+        last = None
+        for st in self.stop_time_updates:
+            if  st.stop_id == stop_id:
+                last = st
+        if last is not None:
+            return not last.departure_status in ('delete', 'deleted_for_detour') \
+                    or last.arrival_status in ('delete', 'deleted_for_detour')
+        else:
+            return False
 
 class RealTimeUpdate(db.Model, TimestampMixin):
     """

--- a/kirin/core/populate_pb.py
+++ b/kirin/core/populate_pb.py
@@ -98,7 +98,7 @@ def fill_stop_times(pb_stop_time, stop_time):
 
     '''
     TODO: kirin_pb2.stop_time_event_relationship needs to be removed once
-    kirin_pb2.stop_time_event_status is deployed on production 
+    kirin_pb2.stop_time_event_status is deployed on production
     '''
     pb_stop_time.departure.Extensions[kirin_pb2.stop_time_event_relationship] = \
         get_st_event(stop_time.departure_status)

--- a/tests/cots_rt_test.py
+++ b/tests/cots_rt_test.py
@@ -5,7 +5,7 @@
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.
 #
-# Hope you'll enjoy and contribute to this project
+# Hope you'll enjoy and contribute to this project,
 #     powered by Canal TP (www.canaltp.fr).
 # Help us simplify mobility and open public transport:
 #     a non ending quest to the responsive locomotion way of traveling!

--- a/tests/cots_rt_test.py
+++ b/tests/cots_rt_test.py
@@ -5,7 +5,8 @@
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.
 #
-# Hope you'll enjoy and contribute to this project     powered by Canal TP (www.canaltp.fr).
+# Hope you'll enjoy and contribute to this project
+#     powered by Canal TP (www.canaltp.fr).
 # Help us simplify mobility and open public transport:
 #     a non ending quest to the responsive locomotion way of traveling!
 #

--- a/tests/cots_rt_test.py
+++ b/tests/cots_rt_test.py
@@ -5,8 +5,7 @@
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.
 #
-# Hope you'll enjoy and contribute to this project,
-#     powered by Canal TP (www.canaltp.fr).
+# Hope you'll enjoy and contribute to this project     powered by Canal TP (www.canaltp.fr).
 # Help us simplify mobility and open public transport:
 #     a non ending quest to the responsive locomotion way of traveling!
 #

--- a/tests/fixtures/cots_train_96231_deleted.json
+++ b/tests/fixtures/cots_train_96231_deleted.json
@@ -1,0 +1,571 @@
+{
+  "ressource": "courseOPE",
+  "mode": "modification",
+  "evt": [
+    "OBS",
+    "PERTURBATION"
+  ],
+  "PdPObserveArrivee": [
+    "5168b9d7-34b9-45d8-b434-88577c26bd72"
+  ],
+  "PdPObserveDepart": [
+  ],
+  "PdPPronosticBrutArrivee": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf",
+    "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+  ],
+  "PdPPronosticBrutDepart": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "5168b9d7-34b9-45d8-b434-88577c26bd72",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+  ],
+  "PdPPronosticIVArrivee": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf",
+    "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+  ],
+  "PdPPronosticIVDepart": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "5168b9d7-34b9-45d8-b434-88577c26bd72",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+  ],
+  "PdPImpacteDepart": [
+  ],
+  "PdPImpacteArrivee": [
+  ],
+  "nouvelleVersion": {
+    "codeCompagnieTransporteur": "OCETH",
+    "codeMarqueTransporteur": "TGV",
+    "codeRelation": "401",
+    "codeService": "A2018",
+    "codeSousRelation": "401400",
+    "codeTransporteurResponsable": "1A",
+    "codeTypeMoyenTransport": "0",
+    "coursePTA": {
+      "@id": "66e70e61-7b0d-4c60-bde5-c73f1bf4f99e"
+    },
+    "dateDebutService": "2017-12-10",
+    "dateDerniereModification": "2018-04-19T13:46:06+0000",
+    "dateFinService": "2018-12-08",
+    "estDiscontinue": false,
+    "estTechnique": false,
+    "estimationManuelle": false,
+    "etat": "ACTIVE",
+    "idVersion": "cbdb2075-e476-48f1-8dfa-4fa95ba226b9",
+    "identifiantDansSystemeCreateur": "e36bcf7e-5f34-4ebe-948e-99a525a89251",
+    "indicateurFer": "FERRE",
+    "listeCouplageCourseOPE": [
+      {
+        "courseCouplee": {
+          "@id": "8808999b-e31e-444d-bd17-a21adf9c6d35"
+        },
+        "pointDebutCouplage": {
+          "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+        },
+        "pointFinCouplage": {
+          "@id": "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+        }
+      }
+    ],
+    "listeCodeTransporteurAssocie": [
+    ],
+    "listeEvenement": [
+    ],
+    "listeJourRegimeDApplication": [
+      {
+        "date": "2015-09-21"
+      }
+    ],
+    "listeJourRegimeFacultatif": [
+    ],
+    "listeMotif": [
+    ],
+    "listePointDeParcours": [
+      {
+        "@id": "998484ec-4335-45b6-aad4-8840047b275f",
+        "arretFacultatif": false,
+        "categorieStatistiqueDepart": "LVK",
+        "cr": "0087",
+        "ci": "212027",
+        "ch": "BV",
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "16:30:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T14:30:00+0000",
+          "heureLocale": "16:30:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+        ],
+        "listeHoraireProjeteDepart": [
+        ],
+        "listeMotifArrivee": [
+        ],
+        "listeMotifDepart": [
+        ],
+        "rang": 1,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "5168b9d7-34b9-45d8-b434-88577c26bd72",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVK",
+        "cr": "0087",
+        "ci": "214056",
+        "ch": "00",
+        "horaireObserveArrivee": {
+          "dateHeure": "2015-09-21T15:39:00+0000",
+          "dateHeureEmission": "2018-04-19T15:44:53+0000",
+          "source": "ESCALE"
+        },
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:39:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:56:30",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T15:39:00+0000",
+          "heureLocale": "17:39:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T15:40:30+0000",
+          "heureLocale": "17:40:30",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2015-09-21T15:40:30+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "ESCALE"
+          },
+          {
+            "dateHeure": "2015-09-21T17:40:30+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "TEST"
+          }
+        ],
+        "idMotifInterneDepartReference": 3,
+        "idMotifInterneArriveeReference": 3,
+        "listeMotifArrivee": [
+        ],
+        "listeMotifDepart": [
+        ],
+        "rang": 2,
+        "sourceHoraireProjeteDepartReference": "ESCALE",
+        "typeArret": "CH"
+      },
+      {
+        "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVK",
+        "cr": "0087",
+        "ci": "182014",
+        "ch": "BV",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:51:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:53:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T15:51:00+0000",
+          "heureLocale": "17:51:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T15:53:00+0000",
+          "heureLocale": "17:53:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2015-09-21T15:51:00+0000",
+            "dateHeureEmission": "2018-04-19T18:06:00+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "TEST"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2015-09-21T15:53:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "ESCALE"
+          },
+          {
+            "dateHeure": "2015-09-21T15:53:00+0000",
+            "dateHeureEmission": "2018-04-19T18:08:00+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "TEST"
+          }
+        ],
+        "listeMotifArrivee": [
+        ],
+        "listeMotifDepart": [
+        ],
+        "rang": 3,
+        "sourceHoraireProjeteDepartReference": "TEST",
+        "typeArret": "CH"
+      },
+      {
+        "@id": "6a4a4413-a668-487c-b25d-907ef7e64e75",
+        "cr": "0087",
+        "ci": "713065",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T18:02:00+0200",
+          "heureLocale": "18:02:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T16:04:00+0000",
+          "heureLocale": "18:04:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2018-10-23T11:50:00+0000",
+            "dateHeureEmission": "2018-10-23T09:22:19+0000",
+            "pronosticBrut": 300,
+            "pronosticIV": 300,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2018-10-23T11:54:00+0000",
+            "dateHeureEmission": "2018-10-23T09:22:19+0000",
+            "pronosticBrut": 300,
+            "pronosticIV": 300,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 4,
+        "sourceHoraireProjeteArriveeReference": "IRE-GOP",
+        "sourceHoraireProjeteDepartReference": "IRE-GOP",
+        "typeArret": "CH"
+      },
+      {
+        "@id": "2ce15bf7-134d-4cd5-978f-d746d238e008",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVA",
+        "cr": "0087",
+        "ci": "182063",
+        "ch": "BV",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:14:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:16:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T16:14:00+0000",
+          "heureLocale": "18:14:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T16:16:00+0000",
+          "heureLocale": "18:16:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2015-09-21T16:14:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "ESCALE"
+          },
+          {
+            "dateHeure": "2015-09-21T16:14:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "TEST"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2015-09-21T16:16:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "ESCALE"
+          },
+          {
+            "dateHeure": "2015-09-21T16:16:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "TEST"
+          }
+        ],
+        "listeMotifArrivee": [
+        ],
+        "listeMotifDepart": [
+        ],
+        "rang": 5,
+        "sourceHoraireProjeteArriveeReference": "ESCALE",
+        "sourceHoraireProjeteDepartReference": "ESCALE",
+        "typeArret": "CH"
+      },
+      {
+        "@id": "2ce15bf7-134d-4cd5-978f-d746d238e008",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVA",
+        "cr": "0087",
+        "ci": "182139",
+        "ch": "BV",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:30:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:31:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T16:30:00+0000",
+          "heureLocale": "18:30:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T16:31:00+0000",
+          "heureLocale": "18:31:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2015-09-21T16:30:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "ESCALE"
+          },
+          {
+            "dateHeure": "2015-09-21T16:30:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "TEST"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2015-09-21T16:31:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "ESCALE"
+          },
+          {
+            "dateHeure": "2015-09-21T16:31:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "TEST"
+          }
+        ],
+        "listeMotifArrivee": [
+        ],
+        "listeMotifDepart": [
+        ],
+        "rang": 6,
+        "sourceHoraireProjeteArriveeReference": "ESCALE",
+        "sourceHoraireProjeteDepartReference": "ESCALE",
+        "typeArret": "CH"
+      },
+      {
+        "@id": "2ce15bf7-134d-4cd5-978f-d746d238e008",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVA",
+        "cr": "0087",
+        "ci": "187914",
+        "ch": "WS",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:39:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T16:39:00+0000",
+          "heureLocale": "18:39:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2015-09-21T16:39:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "ESCALE"
+          },
+          {
+            "dateHeure": "2015-09-21T16:39:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "TEST"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+        ],
+        "idMotifInterneDepartReference": 3,
+        "idMotifInterneArriveeReference": 3,
+        "listeMotifArrivee": [
+        ],
+        "listeMotifDepart": [
+        ],
+        "rang": 7,
+        "sourceHoraireProjeteArriveeReference": "ESCALE",
+        "typeArret": "CH"
+      }
+    ],
+    "listeService": [
+      {
+        "code": "CS01",
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2015-09-21"
+          }
+        ],
+        "listePropriete": [
+          {
+            "code": "CP001",
+            "metaPropriete": {
+              "@id": "95352652-200c-430b-8a94-3852677c91ea"
+            },
+            "valeurChaine": "A"
+          },
+          {
+            "code": "CP002",
+            "metaPropriete": {
+              "@id": "350d89f9-8667-4456-9186-765ce07ea238"
+            },
+            "valeurChaine": "A"
+          }
+        ],
+        "metaService": {
+          "@id": "590ecf63-8dcc-46d5-b238-391fd681eba1"
+        },
+        "pointDeParcoursDebut": {
+          "@id": "998484ec-4335-45b6-aad4-8840047b275f"
+        },
+        "pointDeParcoursFin": {
+          "@id": "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+        }
+      }
+    ],
+    "listeSubstitutionCourse": [
+    ],
+    "listeUtilisationSillon": [
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "096231",
+          "sillonTTH": "042522760051"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2015-09-21"
+          }
+        ],
+        "listeJourRegimeFacultatif": [
+        ],
+        "pointDebutUtilisationSillon": {
+          "@id": "998484ec-4335-45b6-aad4-8840047b275f"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+        },
+        "porteur": true
+      },
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "8780",
+          "sillonTTH": "042523700030"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2015-09-21"
+          }
+        ],
+        "listeJourRegimeFacultatif": [
+        ],
+        "pointDebutUtilisationSillon": {
+          "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+        },
+        "porteur": false
+      }
+    ],
+    "numeroCourse": "096231",
+    "statutSillonCourse": "NON_CONNU",
+    "statutOperationnel": "PERTURBEE",
+    "systemeCreateur": "2148",
+    "@id": "e36bcf7e-5f34-4ebe-948e-99a525a89251",
+    "type": "COURSE_OPE"
+  }
+}

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -559,10 +559,10 @@ def test_cots_added_and_deleted_stop_time():
 
     """
     Aim : Highlighting the deleted mechanism.
-          Deleted is possible only if the stop_time was added before
+          Delete is possible only if the stop_time was there added before
     """
 
-    # If added wasn't done before delete will not work
+    # If add wasn't done before, the deletion will not work
 
     cots_deleted_file = get_fixture_data('cots_train_96231_deleted.json')
     res = api_post('/cots', data=cots_deleted_file)
@@ -587,7 +587,7 @@ def test_cots_added_and_deleted_stop_time():
         assert StopTimeUpdate.query.all()[3].departure == datetime(2015, 9, 21, 16, 4)
         created_at_for_add =  StopTimeUpdate.query.all()[3].created_at
 
-    # At this point the trip_update is valid. We added new Stop_time in data base
+    # At this point the trip_update is valid. We adde new Stop_time in data base
 
     cots_deleted_file = get_fixture_data('cots_train_96231_deleted.json')
     res = api_post('/cots', data=cots_deleted_file)
@@ -596,7 +596,7 @@ def test_cots_added_and_deleted_stop_time():
         assert len(RealTimeUpdate.query.all()) == 3
         assert len(TripUpdate.query.all()) == 1
         assert TripUpdate.query.all()[0].status == 'update'
-        assert TripUpdate.query.all()[0].effect == 'MODIFIED_SERVICE'
+        assert TripUpdate.query.all()[0].effect == 'REDUCED_SERVICE'
         assert TripUpdate.query.all()[0].company_id == 'company:OCE:TH'
         assert len(StopTimeUpdate.query.all()) == 7
         assert StopTimeUpdate.query.all()[3].arrival_status == 'delete'
@@ -614,7 +614,7 @@ def test_cots_added_and_deleted_stop_time():
         assert len(RealTimeUpdate.query.all()) == 4
         assert len(TripUpdate.query.all()) == 1
         assert TripUpdate.query.all()[0].status == 'update'
-        assert TripUpdate.query.all()[0].effect == 'MODIFIED_SERVICE'
+        assert TripUpdate.query.all()[0].effect == 'REDUCED_SERVICE'
         assert TripUpdate.query.all()[0].company_id == 'company:OCE:TH'
         assert len(StopTimeUpdate.query.all()) == 7
         assert StopTimeUpdate.query.all()[3].arrival_status == 'delete'

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -558,13 +558,24 @@ def test_cots_added_stop_time():
 def test_cots_added_and_deleted_stop_time():
 
     """
-
+    Aim : Highlighting the deleted mechanism.
+          Deleted is possible only if the stop_time was added before
     """
+
+    # If added wasn't done before delete will not work
+
+    cots_deleted_file = get_fixture_data('cots_train_96231_deleted.json')
+    res = api_post('/cots', data=cots_deleted_file)
+    assert res == 'OK'
+    with app.app_context():
+        assert len(RealTimeUpdate.query.all()) == 1
+        assert len(TripUpdate.query.all()) == 0
+
     cots_add_file = get_fixture_data('cots_train_96231_add.json')
     res = api_post('/cots', data=cots_add_file)
     assert res == 'OK'
     with app.app_context():
-        assert len(RealTimeUpdate.query.all()) == 1
+        assert len(RealTimeUpdate.query.all()) == 2
         assert len(TripUpdate.query.all()) == 1
         assert TripUpdate.query.all()[0].status == 'update'
         assert TripUpdate.query.all()[0].effect == 'MODIFIED_SERVICE'
@@ -582,7 +593,7 @@ def test_cots_added_and_deleted_stop_time():
     res = api_post('/cots', data=cots_deleted_file)
     assert res == 'OK'
     with app.app_context():
-        assert len(RealTimeUpdate.query.all()) == 2
+        assert len(RealTimeUpdate.query.all()) == 3
         assert len(TripUpdate.query.all()) == 1
         assert TripUpdate.query.all()[0].status == 'update'
         assert TripUpdate.query.all()[0].effect == 'MODIFIED_SERVICE'
@@ -600,7 +611,7 @@ def test_cots_added_and_deleted_stop_time():
     res = api_post('/cots', data=cots_deleted_file)
     assert res == 'OK'
     with app.app_context():
-        assert len(RealTimeUpdate.query.all()) == 3
+        assert len(RealTimeUpdate.query.all()) == 4
         assert len(TripUpdate.query.all()) == 1
         assert TripUpdate.query.all()[0].status == 'update'
         assert TripUpdate.query.all()[0].effect == 'MODIFIED_SERVICE'

--- a/tests/integration/populate_pb_test.py
+++ b/tests/integration/populate_pb_test.py
@@ -389,6 +389,15 @@ def test_populate_pb_added_for_detour_stop_times_status():
     assert pb_stop_time.departure.Extensions[kirin_pb2.stop_time_event_status] == kirin_pb2.ADDED_FOR_DETOUR
     assert pb_stop_time.arrival.Extensions[kirin_pb2.stop_time_event_status] == kirin_pb2.ADDED_FOR_DETOUR
 
+def test_populate_pb_added_stop_times_status():
+    st_added_status = StopTimeUpdate({'id': 'id1'}, dep_status='add', arr_status='add')
+    pb_stop_time = gtfs_realtime_pb2.TripUpdate.StopTimeUpdate()
+
+    fill_stop_times(pb_stop_time, st_added_status)
+
+    assert pb_stop_time.departure.Extensions[kirin_pb2.stop_time_event_status] == kirin_pb2.ADDED
+    assert pb_stop_time.arrival.Extensions[kirin_pb2.stop_time_event_status] == kirin_pb2.ADDED
+
 def test_populate_pb_skipped_for_detour_stop_times_status():
     st_added_status = StopTimeUpdate({'id': 'id1'}, dep_status='deleted_for_detour', arr_status='deleted_for_detour')
     pb_stop_time = gtfs_realtime_pb2.TripUpdate.StopTimeUpdate()
@@ -397,3 +406,13 @@ def test_populate_pb_skipped_for_detour_stop_times_status():
 
     assert pb_stop_time.departure.Extensions[kirin_pb2.stop_time_event_status] == kirin_pb2.DELETED_FOR_DETOUR
     assert pb_stop_time.arrival.Extensions[kirin_pb2.stop_time_event_status] == kirin_pb2.DELETED_FOR_DETOUR
+
+def test_populate_pb_deleted_stop_times_status():
+    st_added_status = StopTimeUpdate({'id': 'id1'}, dep_status='delete', arr_status='delete')
+    pb_stop_time = gtfs_realtime_pb2.TripUpdate.StopTimeUpdate()
+
+    fill_stop_times(pb_stop_time, st_added_status)
+
+    assert pb_stop_time.departure.Extensions[kirin_pb2.stop_time_event_status] == kirin_pb2.DELETED
+    assert pb_stop_time.arrival.Extensions[kirin_pb2.stop_time_event_status] == kirin_pb2.DELETED
+

--- a/tests/integration/utils_sncf_test.py
+++ b/tests/integration/utils_sncf_test.py
@@ -659,7 +659,7 @@ def check_db_96231_partial_removal(contributor=None):
         assert db_trip_partial_removed.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21, tzinfo=utc)
         assert db_trip_partial_removed.vj_id == db_trip_partial_removed.vj.id
         assert db_trip_partial_removed.status == 'update'
-        assert db_trip_partial_removed.effect == 'SIGNIFICANT_DELAYS'
+        assert db_trip_partial_removed.effect == 'REDUCED_SERVICE'
         # 6 stop times must have been created
         assert len(db_trip_partial_removed.stop_time_updates) == 6
 


### PR DESCRIPTION
Target :
We receive a COTS data feed with "SUPPRESSION".
Delete stop_time if stop_time was already added. If not, the deletion is broken

JIRA : https://jira.kisio.org/browse/NAVP-1095