### PR TITLE
fix delete the previously added stop_time

### DIFF
--- a/kirin/core/handler.py
+++ b/kirin/core/handler.py
@@ -411,9 +411,9 @@ def merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete=False):
                 else:
                     # selection of extra iterable stop-times
                     sp_id = new_stu.stop_id
-                    if is_new_stop_event_valid(event_name='arrival', stop_id=sp_id.encode('utf-8'), stop_order=order,
+                    if is_new_stop_event_valid(event_name='arrival', stop_id=sp_id, stop_order=order,
                                                nav_stop=None, db_tu=db_trip_update, new_stu=new_stu) or \
-                            is_new_stop_event_valid(event_name='departure', stop_id=sp_id.encode('utf-8'), stop_order=order,
+                            is_new_stop_event_valid(event_name='departure', stop_id=sp_id, stop_order=order,
                                                     nav_stop=None, db_tu=db_trip_update, new_stu=new_stu):
                         # It is an added stop_time or a modification on a previously added stop_time, create a
                         # new "fake" Navitia stop time (even if it's not in navitia kirin needs to iterate on it)

--- a/kirin/core/handler.py
+++ b/kirin/core/handler.py
@@ -447,8 +447,7 @@ def merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete=False):
 
         # we compute the arrival time and departure time on base schedule and take past mid-night into
         # consideration
-        base_arrival = utc_nav_arrival_time
-        base_departure = utc_nav_departure_time
+        base_arrival = base_departure = None
         stop_id = navitia_stop.get('stop_point', {}).get('id')
         new_st = new_trip_update.find_stop(stop_id, nav_order)
 

--- a/kirin/core/handler.py
+++ b/kirin/core/handler.py
@@ -411,9 +411,9 @@ def merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete=False):
                 else:
                     # selection of extra iterable stop-times
                     sp_id = new_stu.stop_id
-                    if is_new_stop_event_valid(event_name='arrival', stop_id=sp_id, stop_order=order,
+                    if is_new_stop_event_valid(event_name='arrival', stop_id=sp_id.encode('utf-8'), stop_order=order,
                                                nav_stop=None, db_tu=db_trip_update, new_stu=new_stu) or \
-                            is_new_stop_event_valid(event_name='departure', stop_id=sp_id, stop_order=order,
+                            is_new_stop_event_valid(event_name='departure', stop_id=sp_id.encode('utf-8'), stop_order=order,
                                                     nav_stop=None, db_tu=db_trip_update, new_stu=new_stu):
                         # It is an added stop_time or a modification on a previously added stop_time, create a
                         # new "fake" Navitia stop time (even if it's not in navitia kirin needs to iterate on it)

--- a/kirin/core/handler.py
+++ b/kirin/core/handler.py
@@ -447,7 +447,8 @@ def merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete=False):
 
         # we compute the arrival time and departure time on base schedule and take past mid-night into
         # consideration
-        base_arrival = base_departure = None
+        base_arrival = utc_nav_arrival_time
+        base_departure = utc_nav_departure_time
         stop_id = navitia_stop.get('stop_point', {}).get('id')
         new_st = new_trip_update.find_stop(stop_id, nav_order)
 

--- a/kirin/core/handler.py
+++ b/kirin/core/handler.py
@@ -417,12 +417,19 @@ def merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete=False):
                                                     nav_stop=None, db_tu=db_trip_update, new_stu=new_stu):
                         # It is an added stop_time or a modification on a previously added stop_time, create a
                         # new "fake" Navitia stop time (even if it's not in navitia kirin needs to iterate on it)
-                        added_st = {
-                            'stop_point': new_stu.navitia_stop,
-                            'utc_departure_time': extract_str_utc_time(new_stu.departure),
-                            'utc_arrival_time': extract_str_utc_time(new_stu.arrival),
-                        }
-                        yield order, added_st
+                        stu = None
+                        if db_trip_update:
+                            stu = db_trip_update.find_stop(sp_id, order)
+                        if stu is None:
+                            utc_departure_time = extract_str_utc_time(new_stu.departure)
+                            utc_arrival_time = extract_str_utc_time(new_stu.arrival)
+                        else:
+                            utc_departure_time = stu.departure.time()
+                            utc_arrival_time = stu.arrival.time()
+
+                        yield order, {'stop_point': new_stu.navitia_stop,
+                                      'utc_departure_time': utc_departure_time,
+                                      'utc_arrival_time': utc_arrival_time}
         else:
             # Iterate on the theoretical VJ if the new trip update doesn't list all stop_times
             for order, vj_st in enumerate(navitia_vj.get('stop_times', [])):

--- a/tests/fixtures/cots_train_96231_add_first_then_delete.json
+++ b/tests/fixtures/cots_train_96231_add_first_then_delete.json
@@ -1,0 +1,562 @@
+{
+  "ressource": "courseOPE",
+  "mode": "modification",
+  "evt": [
+    "OBS",
+    "PERTURBATION"
+  ],
+  "PdPObserveArrivee": [
+    "5168b9d7-34b9-45d8-b434-88577c26bd72"
+  ],
+  "PdPObserveDepart": [
+  ],
+  "PdPPronosticBrutArrivee": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf",
+    "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+  ],
+  "PdPPronosticBrutDepart": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "5168b9d7-34b9-45d8-b434-88577c26bd72",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+  ],
+  "PdPPronosticIVArrivee": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf",
+    "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+  ],
+  "PdPPronosticIVDepart": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "5168b9d7-34b9-45d8-b434-88577c26bd72",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+  ],
+  "PdPImpacteDepart": [
+  ],
+  "PdPImpacteArrivee": [
+  ],
+  "nouvelleVersion": {
+    "codeCompagnieTransporteur": "OCETH",
+    "codeMarqueTransporteur": "TGV",
+    "codeRelation": "401",
+    "codeService": "A2018",
+    "codeSousRelation": "401400",
+    "codeTransporteurResponsable": "1A",
+    "codeTypeMoyenTransport": "0",
+    "coursePTA": {
+      "@id": "66e70e61-7b0d-4c60-bde5-c73f1bf4f99e"
+    },
+    "dateDebutService": "2017-12-10",
+    "dateDerniereModification": "2018-04-19T13:46:06+0000",
+    "dateFinService": "2018-12-08",
+    "estDiscontinue": false,
+    "estTechnique": false,
+    "estimationManuelle": false,
+    "etat": "ACTIVE",
+    "idVersion": "cbdb2075-e476-48f1-8dfa-4fa95ba226b9",
+    "identifiantDansSystemeCreateur": "e36bcf7e-5f34-4ebe-948e-99a525a89251",
+    "indicateurFer": "FERRE",
+    "listeCouplageCourseOPE": [
+      {
+        "courseCouplee": {
+          "@id": "8808999b-e31e-444d-bd17-a21adf9c6d35"
+        },
+        "pointDebutCouplage": {
+          "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+        },
+        "pointFinCouplage": {
+          "@id": "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+        }
+      }
+    ],
+    "listeCodeTransporteurAssocie": [
+    ],
+    "listeEvenement": [
+    ],
+    "listeJourRegimeDApplication": [
+      {
+        "date": "2015-09-21"
+      }
+    ],
+    "listeJourRegimeFacultatif": [
+    ],
+    "listeMotif": [
+    ],
+    "listePointDeParcours": [
+            {
+        "@id": "6a4a4413-a668-487c-b25d-907ef7e64e75",
+        "cr": "0087",
+        "ci": "713065",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T14:20:00+0000",
+          "heureLocale": "16:20:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
+        "listeHoraireProjeteArrivee": [
+        ],
+        "listeHoraireProjeteDepart": [
+        ],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 0,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "998484ec-4335-45b6-aad4-8840047b275f",
+        "arretFacultatif": false,
+        "categorieStatistiqueDepart": "LVK",
+        "cr": "0087",
+        "ci": "212027",
+        "ch": "BV",
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "16:30:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T14:30:00+0000",
+          "heureLocale": "16:30:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "16:30:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T14:30:00+0000",
+          "heureLocale": "16:30:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+        ],
+        "listeHoraireProjeteDepart": [
+        ],
+        "listeMotifArrivee": [
+        ],
+        "listeMotifDepart": [
+        ],
+        "rang": 1,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "5168b9d7-34b9-45d8-b434-88577c26bd72",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVK",
+        "cr": "0087",
+        "ci": "214056",
+        "ch": "00",
+        "horaireObserveArrivee": {
+          "dateHeure": "2015-09-21T15:39:00+0000",
+          "dateHeureEmission": "2018-04-19T15:44:53+0000",
+          "source": "ESCALE"
+        },
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:39:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:56:30",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T15:39:00+0000",
+          "heureLocale": "17:39:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T15:40:30+0000",
+          "heureLocale": "17:40:30",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2015-09-21T15:40:30+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "ESCALE"
+          },
+          {
+            "dateHeure": "2015-09-21T17:40:30+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "TEST"
+          }
+        ],
+        "idMotifInterneDepartReference": 3,
+        "idMotifInterneArriveeReference": 3,
+        "listeMotifArrivee": [
+        ],
+        "listeMotifDepart": [
+        ],
+        "rang": 2,
+        "sourceHoraireProjeteDepartReference": "ESCALE",
+        "typeArret": "CH"
+      },
+      {
+        "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVK",
+        "cr": "0087",
+        "ci": "182014",
+        "ch": "BV",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:51:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:53:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T15:51:00+0000",
+          "heureLocale": "17:51:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T15:53:00+0000",
+          "heureLocale": "17:53:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2015-09-21T15:51:00+0000",
+            "dateHeureEmission": "2018-04-19T18:06:00+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "TEST"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2015-09-21T15:53:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "ESCALE"
+          },
+          {
+            "dateHeure": "2015-09-21T15:53:00+0000",
+            "dateHeureEmission": "2018-04-19T18:08:00+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "TEST"
+          }
+        ],
+        "listeMotifArrivee": [
+        ],
+        "listeMotifDepart": [
+        ],
+        "rang": 3,
+        "sourceHoraireProjeteDepartReference": "TEST",
+        "typeArret": "CH"
+      },
+      {
+        "@id": "2ce15bf7-134d-4cd5-978f-d746d238e008",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVA",
+        "cr": "0087",
+        "ci": "182063",
+        "ch": "BV",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:14:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:16:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T16:14:00+0000",
+          "heureLocale": "18:14:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T16:16:00+0000",
+          "heureLocale": "18:16:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2015-09-21T16:14:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "ESCALE"
+          },
+          {
+            "dateHeure": "2015-09-21T16:14:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "TEST"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2015-09-21T16:16:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "ESCALE"
+          },
+          {
+            "dateHeure": "2015-09-21T16:16:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "TEST"
+          }
+        ],
+        "listeMotifArrivee": [
+        ],
+        "listeMotifDepart": [
+        ],
+        "rang": 4,
+        "sourceHoraireProjeteArriveeReference": "ESCALE",
+        "sourceHoraireProjeteDepartReference": "ESCALE",
+        "typeArret": "CH"
+      },
+      {
+        "@id": "2ce15bf7-134d-4cd5-978f-d746d238e008",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVA",
+        "cr": "0087",
+        "ci": "182139",
+        "ch": "BV",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:30:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:31:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T16:30:00+0000",
+          "heureLocale": "18:30:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T16:31:00+0000",
+          "heureLocale": "18:31:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2015-09-21T16:30:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "ESCALE"
+          },
+          {
+            "dateHeure": "2015-09-21T16:30:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "TEST"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2015-09-21T16:31:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "ESCALE"
+          },
+          {
+            "dateHeure": "2015-09-21T16:31:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "TEST"
+          }
+        ],
+        "listeMotifArrivee": [
+        ],
+        "listeMotifDepart": [
+        ],
+        "rang": 5,
+        "sourceHoraireProjeteArriveeReference": "ESCALE",
+        "sourceHoraireProjeteDepartReference": "ESCALE",
+        "typeArret": "CH"
+      },
+      {
+        "@id": "2ce15bf7-134d-4cd5-978f-d746d238e008",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVA",
+        "cr": "0087",
+        "ci": "187914",
+        "ch": "WS",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:39:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T16:39:00+0000",
+          "heureLocale": "18:39:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2015-09-21T16:39:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "ESCALE"
+          },
+          {
+            "dateHeure": "2015-09-21T16:39:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
+            "source": "TEST"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+        ],
+        "idMotifInterneDepartReference": 3,
+        "idMotifInterneArriveeReference": 3,
+        "listeMotifArrivee": [
+        ],
+        "listeMotifDepart": [
+        ],
+        "rang": 6,
+        "sourceHoraireProjeteArriveeReference": "ESCALE",
+        "typeArret": "CH"
+      }
+    ],
+    "listeService": [
+      {
+        "code": "CS01",
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2015-09-21"
+          }
+        ],
+        "listePropriete": [
+          {
+            "code": "CP001",
+            "metaPropriete": {
+              "@id": "95352652-200c-430b-8a94-3852677c91ea"
+            },
+            "valeurChaine": "A"
+          },
+          {
+            "code": "CP002",
+            "metaPropriete": {
+              "@id": "350d89f9-8667-4456-9186-765ce07ea238"
+            },
+            "valeurChaine": "A"
+          }
+        ],
+        "metaService": {
+          "@id": "590ecf63-8dcc-46d5-b238-391fd681eba1"
+        },
+        "pointDeParcoursDebut": {
+          "@id": "998484ec-4335-45b6-aad4-8840047b275f"
+        },
+        "pointDeParcoursFin": {
+          "@id": "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+        }
+      }
+    ],
+    "listeSubstitutionCourse": [
+    ],
+    "listeUtilisationSillon": [
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "096231",
+          "sillonTTH": "042522760051"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2015-09-21"
+          }
+        ],
+        "listeJourRegimeFacultatif": [
+        ],
+        "pointDebutUtilisationSillon": {
+          "@id": "998484ec-4335-45b6-aad4-8840047b275f"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+        },
+        "porteur": true
+      },
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "8780",
+          "sillonTTH": "042523700030"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2015-09-21"
+          }
+        ],
+        "listeJourRegimeFacultatif": [
+        ],
+        "pointDebutUtilisationSillon": {
+          "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+        },
+        "porteur": false
+      }
+    ],
+    "numeroCourse": "096231",
+    "statutSillonCourse": "NON_CONNU",
+    "statutOperationnel": "PERTURBEE",
+    "systemeCreateur": "2148",
+    "@id": "e36bcf7e-5f34-4ebe-948e-99a525a89251",
+    "type": "COURSE_OPE"
+  }
+}

--- a/tests/fixtures/cots_train_96231_delete_previously_added_first_stop.json
+++ b/tests/fixtures/cots_train_96231_delete_previously_added_first_stop.json
@@ -125,18 +125,6 @@
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
-        "horaireProductionArrivee": {
-          "idFuseauHoraire": "Europe/Paris",
-          "heureIncertaine": false,
-          "heureLocale": "16:30:00",
-          "nbJoursPasseMinuit": 0
-        },
-        "horaireVoyageurArrivee": {
-          "dateHeure": "2015-09-21T14:30:00+0000",
-          "heureLocale": "16:30:00",
-          "idFuseauHoraire": "Europe/Paris",
-          "nbJoursPasseMinuit": 0
-        },
         "listeHoraireProjeteArrivee": [
         ],
         "listeHoraireProjeteDepart": [

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -607,9 +607,7 @@ def test_cots_added_and_deleted_stop_time():
         assert TripUpdate.query.all()[0].company_id == 'company:OCE:SN'
         assert len(StopTimeUpdate.query.all()) == 7
         assert StopTimeUpdate.query.all()[3].arrival_status == 'delete'
-        assert StopTimeUpdate.query.all()[3].arrival == datetime(2015, 9, 21, 16, 2)
         assert StopTimeUpdate.query.all()[3].departure_status == 'delete'
-        assert StopTimeUpdate.query.all()[3].departure == datetime(2015, 9, 21, 16, 4)
 
         created_at_for_delete = StopTimeUpdate.query.all()[3].created_at
 
@@ -627,7 +625,6 @@ def test_cots_added_and_deleted_stop_time():
         assert TripUpdate.query.all()[0].company_id == 'company:OCE:SN'
         assert len(StopTimeUpdate.query.all()) == 7
         assert StopTimeUpdate.query.all()[3].arrival_status == 'delete'
-        assert StopTimeUpdate.query.all()[3].arrival == datetime(2015, 9, 21, 16, 2)
         assert StopTimeUpdate.query.all()[3].departure_status == 'delete'
         # No change is stored in db (nothing sent to navitia) as the state is the same
         # It has already been deleted, so it is not allowed to deleted once again.

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -626,6 +626,7 @@ def test_cots_added_and_deleted_stop_time():
         assert len(StopTimeUpdate.query.all()) == 7
         assert StopTimeUpdate.query.all()[3].arrival_status == 'delete'
         assert StopTimeUpdate.query.all()[3].departure_status == 'delete'
+        # No change is stored in db (nothing sent to navitia) as the state is the same
         assert StopTimeUpdate.query.all()[3].created_at == created_at_for_delete
 
     cots_delayed_file = get_fixture_data('cots_train_96231_deleted_and_delayed.json')
@@ -663,6 +664,10 @@ def test_cots_added_stop_time_first_position_then_delete_it():
         assert StopTimeUpdate.query.all()[0].arrival_status == 'none'
         assert StopTimeUpdate.query.all()[0].departure_status == 'add'
         assert StopTimeUpdate.query.all()[0].departure == datetime(2015, 9, 21, 14, 20)
+        assert StopTimeUpdate.query.all()[1].arrival_status == 'none'
+        assert StopTimeUpdate.query.all()[1].departure_status == 'none'
+        assert StopTimeUpdate.query.all()[1].departure == datetime(2015, 9, 21, 15, 21)
+        assert StopTimeUpdate.query.all()[1].arrival == datetime(2015, 9, 21, 15, 21)
 
     # we remove the added first stop time
     cots_del_file = get_fixture_data('cots_train_96231_delete_previously_added_first_stop.json')
@@ -680,7 +685,6 @@ def test_cots_added_stop_time_first_position_then_delete_it():
         assert StopTimeUpdate.query.all()[0].departure == datetime(2015, 9, 21, 14, 20)
         # Here is the real departure
         assert StopTimeUpdate.query.all()[1].arrival_status == 'none'
-        assert StopTimeUpdate.query.all()[1].departure_status == 'none'
         assert StopTimeUpdate.query.all()[1].departure_status == 'none'
         assert StopTimeUpdate.query.all()[1].departure == datetime(2015, 9, 21, 15, 21)
 

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -626,8 +626,6 @@ def test_cots_added_and_deleted_stop_time():
         assert len(StopTimeUpdate.query.all()) == 7
         assert StopTimeUpdate.query.all()[3].arrival_status == 'delete'
         assert StopTimeUpdate.query.all()[3].departure_status == 'delete'
-        # No change is stored in db (nothing sent to navitia) as the state is the same
-        # It has already been deleted, so it is not allowed to deleted once again.
         assert StopTimeUpdate.query.all()[3].created_at == created_at_for_delete
 
     cots_delayed_file = get_fixture_data('cots_train_96231_deleted_and_delayed.json')
@@ -646,6 +644,7 @@ def test_cots_added_and_deleted_stop_time():
         # when delete and delays exist, effect=REDUCED_SERVICE, because REDUCED_SERVICE > SIGNIFICANT_DELAYS
         assert db_trip_delayed.effect == 'REDUCED_SERVICE'
         assert len(db_trip_delayed.stop_time_updates) == 7
+
 
 def test_cots_added_stop_time_first_position_then_delete_it():
     """
@@ -666,7 +665,7 @@ def test_cots_added_stop_time_first_position_then_delete_it():
         assert StopTimeUpdate.query.all()[0].departure == datetime(2015, 9, 21, 14, 20)
 
     # we remove the added first stop time
-    cots_del_file = get_fixture_data('cots_train_96231_add_first_then_delete.json')
+    cots_del_file = get_fixture_data('cots_train_96231_delete_previously_added_first_stop.json')
     res = api_post('/cots', data=cots_del_file)
     assert res == 'OK'
     with app.app_context():
@@ -679,6 +678,11 @@ def test_cots_added_stop_time_first_position_then_delete_it():
         assert StopTimeUpdate.query.all()[0].arrival_status == 'none'
         assert StopTimeUpdate.query.all()[0].departure_status == 'delete'
         assert StopTimeUpdate.query.all()[0].departure == datetime(2015, 9, 21, 14, 20)
+        # Here is the real departure
+        assert StopTimeUpdate.query.all()[1].arrival_status == 'none'
+        assert StopTimeUpdate.query.all()[1].departure_status == 'none'
+        assert StopTimeUpdate.query.all()[1].departure_status == 'none'
+        assert StopTimeUpdate.query.all()[1].departure == datetime(2015, 9, 21, 15, 21)
 
 
 def test_cots_added_stop_time_last_position():

--- a/tests/mock_navitia/vj_96231.py
+++ b/tests/mock_navitia/vj_96231.py
@@ -34,7 +34,8 @@ import navitia_response
 response = navitia_response.NavitiaResponse()
 
 response.queries = [
-    'vehicle_journeys/?depth=2&since=20150921T133000+0000&headsign=96231&show_codes=true&until=20150921T173900+0000'
+    'vehicle_journeys/?depth=2&since=20150921T133000+0000&headsign=96231&show_codes=true&until=20150921T173900+0000',
+    'vehicle_journeys/?depth=2&since=20150921T132000+0000&headsign=96231&show_codes=true&until=20150921T173900+0000'
 ]
 
 response.response_code = 200


### PR DESCRIPTION
When it comes a deletion of a previously added stop_time at the beginning of a VJ ('add' then 'delete'), Kraken rejects the gtfs-rt, because `arrival` of the first stop_time is 0(timestamp).

In this PR, I just take the arrival/departure which was previously stored in the db.

 