### PR TITLE
Fix add+delay stop reading

### DIFF
--- a/kirin/core/handler.py
+++ b/kirin/core/handler.py
@@ -194,7 +194,17 @@ def _get_datetime(utc_circulation_date, utc_time):
     return datetime.datetime.combine(utc_circulation_date, utc_time)
 
 
-def _get_update_info_of_stop_time(base_time, input_time, input_status, input_delay):
+def _get_update_info_of_stop_event(base_time, input_time, input_status, input_delay):
+    """
+    Process information for a given stop event: given information available, compute info to be stored in db.
+    :param base_time: datetime in base_schedule
+    :param input_time: datetime in new feed
+    :param input_status: status in new feed
+    :param input_delay: delay in new feed
+    :return: new_time (base-schedule datetime in most case),
+             status (update, delete, ...)
+             delay (new_time + delay = RT datetime)
+    """
     new_time = None
     status = ModificationType.none.name
     delay = datetime.timedelta(0)
@@ -220,14 +230,14 @@ def _get_update_info_of_stop_time(base_time, input_time, input_status, input_del
 
 
 def _make_stop_time_update(base_arrival, base_departure, last_departure, input_st, stop_point, order):
-    dep, dep_status, dep_delay = _get_update_info_of_stop_time(base_departure,
-                                                               input_st.departure,
-                                                               input_st.departure_status,
-                                                               input_st.departure_delay)
-    arr, arr_status, arr_delay = _get_update_info_of_stop_time(base_arrival,
-                                                               input_st.arrival,
-                                                               input_st.arrival_status,
-                                                               input_st.arrival_delay)
+    dep, dep_status, dep_delay = _get_update_info_of_stop_event(base_departure,
+                                                                input_st.departure,
+                                                                input_st.departure_status,
+                                                                input_st.departure_delay)
+    arr, arr_status, arr_delay = _get_update_info_of_stop_event(base_arrival,
+                                                                input_st.arrival,
+                                                                input_st.arrival_status,
+                                                                input_st.arrival_delay)
 
     # in case where arrival/departure time are None
     if arr is None:

--- a/kirin/core/handler.py
+++ b/kirin/core/handler.py
@@ -339,7 +339,7 @@ def make_fake_realtime_stop_time(order, sp_id, new_stu, db_trip_update):
     in the db(for example, the very first 'add'), we use the info of new_stu
     """
     stu = db_trip_update.find_stop(sp_id, order) if db_trip_update else None
-    if stu:
+    if stu and not new_stu.departure and not new_stu.arrival:  # new_stu datetime prevails
         utc_departure = stu.departure
         utc_arrival = stu.arrival
     else:

--- a/kirin/core/handler.py
+++ b/kirin/core/handler.py
@@ -33,7 +33,6 @@ import datetime
 import logging
 import socket
 from collections import namedtuple
-from datetime import timedelta
 from dateutil import parser
 import pytz
 
@@ -218,7 +217,7 @@ def _get_datetime(utc_circulation_date, utc_time):
 def _get_update_info_of_stop_time(base_time, input_status, input_delay):
     new_time = None
     status = ModificationType.none.name
-    delay = timedelta(0)
+    delay = datetime.timedelta(0)
     if input_status == ModificationType.update.name:
         new_time = (base_time + input_delay) if base_time else None
         status = input_status
@@ -350,8 +349,8 @@ def is_new_stop_event_valid(event_name, stop_id, stop_order, nav_stop, db_tu, ne
 def make_fake_realtime_stop_time(order, sp_id, new_stu, db_trip_update):
     """
     Since the wanted stop_point doesn't exist in the base vj (for example, we want to delay/delete a stop_point
-    which is added by a previous disruption), we search the wanted stop_point in db first, if we cannot find it in
-    the db(for example, the very first 'add'), we use the info of new_stu
+    which is added by a previous disruption), we search the wanted stop_point in db first, if we cannot find it
+    in the db(for example, the very first 'add'), we use the info of new_stu
     """
     stu = db_trip_update.find_stop(sp_id, order) if db_trip_update else None
     utc_departure_time, utc_arrival_time = (stu.departure.time(), stu.arrival.time()) if stu else \
@@ -481,7 +480,7 @@ def merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete=False):
             if utc_nav_arrival_time is not None:
                 if is_past_midnight(previous_stop_event, arrival_stop_event):
                     # last departure is after arrival, it's a past-midnight
-                    utc_circulation_date += timedelta(days=1)
+                    utc_circulation_date += datetime.timedelta(days=1)
                 base_arrival = _get_datetime(utc_circulation_date, utc_nav_arrival_time)
 
             # store arrival as previous stop-event
@@ -497,7 +496,7 @@ def merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete=False):
             if utc_nav_departure_time is not None:
                 if is_past_midnight(previous_stop_event, departure_stop_event):
                     # departure is before arrival, it's a past-midnight
-                    utc_circulation_date += timedelta(days=1)
+                    utc_circulation_date += datetime.timedelta(days=1)
                 base_departure = _get_datetime(utc_circulation_date, utc_nav_departure_time)
 
             # store departure as previous stop-event

--- a/kirin/core/handler.py
+++ b/kirin/core/handler.py
@@ -214,12 +214,14 @@ def _get_datetime(utc_circulation_date, utc_time):
     return datetime.datetime.combine(utc_circulation_date, utc_time)
 
 
-def _get_update_info_of_stop_time(base_time, input_status, input_delay):
+def _get_update_info_of_stop_time(base_time, input_time, input_status, input_delay):
     new_time = None
     status = ModificationType.none.name
     delay = datetime.timedelta(0)
     if input_status == ModificationType.update.name:
-        new_time = (base_time + input_delay) if base_time else None
+        new_time = base_time if base_time else None
+        if new_time is not None and input_delay:
+            new_time += input_delay
         status = input_status
         delay = input_delay
     elif input_status in (ModificationType.delete.name, ModificationType.deleted_for_detour.name):
@@ -229,7 +231,9 @@ def _get_update_info_of_stop_time(base_time, input_status, input_delay):
         status = input_status
     elif input_status in (ModificationType.add.name, ModificationType.added_for_detour.name):
         status = input_status
-        new_time = base_time
+        new_time = input_time.replace(tzinfo=None) if input_time else None
+        if new_time is not None and input_delay:
+            new_time += input_delay
     else:
         new_time = base_time
     return new_time, status, delay
@@ -237,9 +241,11 @@ def _get_update_info_of_stop_time(base_time, input_status, input_delay):
 
 def _make_stop_time_update(base_arrival, base_departure, last_departure, input_st, stop_point, order):
     dep, dep_status, dep_delay = _get_update_info_of_stop_time(base_departure,
+                                                               input_st.departure,
                                                                input_st.departure_status,
                                                                input_st.departure_delay)
     arr, arr_status, arr_delay = _get_update_info_of_stop_time(base_arrival,
+                                                               input_st.arrival,
                                                                input_st.arrival_status,
                                                                input_st.arrival_delay)
 

--- a/readme.md
+++ b/readme.md
@@ -238,7 +238,7 @@ Please read [tests readme](https://github.com/CanalTP/kirin/blob/master/tests/re
 ###### pgAdmin
 
 To use pgAdmin, simply `File/add server` then enter any `name` then
-`Host`, `user` and `password` used by Kirin on given platform.   
+`Host`, `user` and `password` used by Kirin on given platform (default kirin / kirin).  
 If you use pgAdmin, you can increase massively the number of characters per column
 (as the feed is big):
 `File/preferences` then `Request editor/Request editor/Maximum number of characters per column`

--- a/tests/fixtures/cots_train_96231_add.json
+++ b/tests/fixtures/cots_train_96231_add.json
@@ -266,8 +266,8 @@
           {
             "dateHeure": "2018-10-23T11:50:00+0000",
             "dateHeureEmission": "2018-10-23T09:22:19+0000",
-            "pronosticBrut": 300,
-            "pronosticIV": 300,
+            "pronosticBrut": 0,
+            "pronosticIV": 0,
             "source": "IRE-GOP"
           }
         ],

--- a/tests/fixtures/cots_train_96231_add_with_delay_departure_after_next_base_stop_time_arrival.json
+++ b/tests/fixtures/cots_train_96231_add_with_delay_departure_after_next_base_stop_time_arrival.json
@@ -1,0 +1,501 @@
+{
+  "ressource": "courseOPE",
+  "mode": "modification",
+  "evt": [
+    "OBS",
+    "PERTURBATION"
+  ],
+  "PdPObserveArrivee": [
+    "5168b9d7-34b9-45d8-b434-88577c26bd72"
+  ],
+  "PdPObserveDepart": [],
+  "PdPPronosticBrutArrivee": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf",
+    "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+  ],
+  "PdPPronosticBrutDepart": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "5168b9d7-34b9-45d8-b434-88577c26bd72",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+  ],
+  "PdPPronosticIVArrivee": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf",
+    "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+  ],
+  "PdPPronosticIVDepart": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "5168b9d7-34b9-45d8-b434-88577c26bd72",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+  ],
+  "PdPImpacteDepart": [],
+  "PdPImpacteArrivee": [],
+  "nouvelleVersion": {
+    "codeCompagnieTransporteur": "1187",
+    "codeMarqueTransporteur": "TGV",
+    "codeRelation": "401",
+    "codeService": "A2018",
+    "codeSousRelation": "401400",
+    "codeTransporteurResponsable": "1A",
+    "codeTypeMoyenTransport": "0",
+    "coursePTA": {
+      "@id": "66e70e61-7b0d-4c60-bde5-c73f1bf4f99e"
+    },
+    "dateDebutService": "2017-12-10",
+    "dateDerniereModification": "2018-04-19T13:46:06+0000",
+    "dateFinService": "2018-12-08",
+    "estDiscontinue": false,
+    "estTechnique": false,
+    "estimationManuelle": false,
+    "etat": "ACTIVE",
+    "idVersion": "cbdb2075-e476-48f1-8dfa-4fa95ba226b9",
+    "identifiantDansSystemeCreateur": "e36bcf7e-5f34-4ebe-948e-99a525a89251",
+    "indicateurFer": "FERRE",
+    "listeCouplageCourseOPE": [
+      {
+        "courseCouplee": {
+          "@id": "8808999b-e31e-444d-bd17-a21adf9c6d35"
+        },
+        "pointDebutCouplage": {
+          "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+        },
+        "pointFinCouplage": {
+          "@id": "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+        }
+      }
+    ],
+    "listeCodeTransporteurAssocie": [],
+    "listeEvenement": [],
+    "listeJourRegimeDApplication": [
+      {
+        "date": "2015-09-21"
+      }
+    ],
+    "listeJourRegimeFacultatif": [],
+    "listeMotif": [],
+    "listePointDeParcours": [
+      {
+        "@id": "998484ec-4335-45b6-aad4-8840047b275f",
+        "arretFacultatif": false,
+        "categorieStatistiqueDepart": "LVK",
+        "cr": "0087",
+        "ci": "212027",
+        "ch": "BV",
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:21:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T15:21:00+0000",
+          "heureLocale": "17:21:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 1,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "5168b9d7-34b9-45d8-b434-88577c26bd72",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVK",
+        "cr": "0087",
+        "ci": "214056",
+        "ch": "00",
+        "horaireObserveArrivee": {
+          "dateHeure": "2015-09-21T15:39:00+0000",
+          "dateHeureEmission": "2018-04-19T15:44:53+0000",
+          "source": "ESCALE"
+        },
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:39:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:56:30",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T15:38:00+0000",
+          "heureLocale": "17:38:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T15:40:00+0000",
+          "heureLocale": "17:40:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2015-09-21T15:54:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 830,
+            "pronosticIV": 840,
+            "source": "TEST"
+          },
+          {
+            "dateHeure": "2015-09-21T15:54:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 830,
+            "pronosticIV": 840,
+            "source": "ESCALE"
+          }
+        ],
+        "idMotifInterneDepartReference": 3,
+        "idMotifInterneArriveeReference": 3,
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 2,
+        "sourceHoraireProjeteDepartReference": "ESCALE",
+        "typeArret": "CH"
+      },
+      {
+        "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVK",
+        "cr": "0087",
+        "ci": "182014",
+        "ch": "BV",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:51:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:53:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T15:51:00+0000",
+          "heureLocale": "17:51:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T15:53:00+0000",
+          "heureLocale": "17:53:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2015-09-21T16:06:00+0000",
+            "dateHeureEmission": "2018-04-19T18:06:00+0000",
+            "pronosticBrut": 900,
+            "pronosticIV": 900,
+            "source": "ESCALE"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2015-09-21T16:08:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 900,
+            "pronosticIV": 900,
+            "source": "ESCALE"
+          }
+        ],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 3,
+        "sourceHoraireProjeteArriveeReference": "ESCALE",
+        "sourceHoraireProjeteDepartReference": "ESCALE",
+        "typeArret": "CH"
+      },
+      {
+        "@id": "6a4a4413-a668-487c-b25d-907ef7e64e75",
+        "cr": "0087",
+        "ci": "713065",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T16:02:00+0000",
+          "heureLocale": "18:02:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T16:04:00+0000",
+          "heureLocale": "18:04:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2015-09-21T16:17:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 900,
+            "pronosticIV": 900,
+            "source": "ESCALE"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2015-09-21T16:19:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 900,
+            "pronosticIV": 900,
+            "source": "ESCALE"
+          }
+        ],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 4,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "2ce15bf7-134d-4cd5-978f-d746d238e008",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVA",
+        "cr": "0087",
+        "ci": "182063",
+        "ch": "BV",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:14:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:16:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T16:14:00+0000",
+          "heureLocale": "18:14:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T16:16:00+0000",
+          "heureLocale": "18:16:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2015-09-21T16:29:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 900,
+            "pronosticIV": 900,
+            "source": "ESCALE"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2015-09-21T16:31:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 900,
+            "pronosticIV": 900,
+            "source": "ESCALE"
+          }
+        ],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 5,
+        "sourceHoraireProjeteArriveeReference": "ESCALE",
+        "sourceHoraireProjeteDepartReference": "ESCALE",
+        "typeArret": "CH"
+      },
+      {
+        "@id": "2ce15bf7-134d-4cd5-978f-d746d238e008",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVA",
+        "cr": "0087",
+        "ci": "182139",
+        "ch": "BV",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:30:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:31:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T16:30:00+0000",
+          "heureLocale": "18:30:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T16:31:00+0000",
+          "heureLocale": "18:31:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [{
+            "dateHeure": "2015-09-21T16:45:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 900,
+            "pronosticIV": 900,
+            "source": "ESCALE"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2015-09-21T16:46:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 900,
+            "pronosticIV": 900,
+            "source": "ESCALE"
+          }
+        ],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 6,
+        "sourceHoraireProjeteArriveeReference": "ESCALE",
+        "sourceHoraireProjeteDepartReference": "ESCALE",
+        "typeArret": "CH"
+      },
+      {
+        "@id": "2ce15bf7-134d-4cd5-978f-d746d238e008",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVA",
+        "cr": "0087",
+        "ci": "187914",
+        "ch": "WS",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:39:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T16:39:00+0000",
+          "heureLocale": "18:39:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2015-09-21T16:54:00+0000",
+            "dateHeureEmission": "2018-04-19T15:44:53+0000",
+            "pronosticBrut": 900,
+            "pronosticIV": 900,
+            "source": "ESCALE"
+          }
+        ],
+        "listeHoraireProjeteDepart": [],
+        "idMotifInterneDepartReference": 3,
+        "idMotifInterneArriveeReference": 3,
+        "sourceHoraireProjeteArriveeReference": "ESCALE",
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 7,
+        "typeArret": "CH"
+      }
+    ],
+    "listeService": [
+      {
+        "code": "CS01",
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2015-09-21"
+          }
+        ],
+        "listePropriete": [
+          {
+            "code": "CP001",
+            "metaPropriete": {
+              "@id": "95352652-200c-430b-8a94-3852677c91ea"
+            },
+            "valeurChaine": "A"
+          },
+          {
+            "code": "CP002",
+            "metaPropriete": {
+              "@id": "350d89f9-8667-4456-9186-765ce07ea238"
+            },
+            "valeurChaine": "A"
+          }
+        ],
+        "metaService": {
+          "@id": "590ecf63-8dcc-46d5-b238-391fd681eba1"
+        },
+        "pointDeParcoursDebut": {
+          "@id": "998484ec-4335-45b6-aad4-8840047b275f"
+        },
+        "pointDeParcoursFin": {
+          "@id": "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+        }
+      }
+    ],
+    "listeSubstitutionCourse": [],
+    "listeUtilisationSillon": [
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "096231",
+          "sillonTTH": "042522760051"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2015-09-21"
+          }
+        ],
+        "listeJourRegimeFacultatif": [],
+        "pointDebutUtilisationSillon": {
+          "@id": "998484ec-4335-45b6-aad4-8840047b275f"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+        },
+        "porteur": true
+      },
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "8780",
+          "sillonTTH": "042523700030"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2015-09-21"
+          }
+        ],
+        "listeJourRegimeFacultatif": [],
+        "pointDebutUtilisationSillon": {
+          "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+        },
+        "porteur": false
+      }
+    ],
+    "numeroCourse": "096231",
+    "statutSillonCourse": "NON_CONNU",
+    "statutOperationnel": "PERTURBEE",
+    "systemeCreateur": "2148",
+    "@id": "e36bcf7e-5f34-4ebe-948e-99a525a89251",
+    "type": "COURSE_OPE"
+  }
+}

--- a/tests/fixtures/cots_train_96231_add_with_departure_after_next_base_stop_time_arrival.json
+++ b/tests/fixtures/cots_train_96231_add_with_departure_after_next_base_stop_time_arrival.json
@@ -141,14 +141,14 @@
         "listeHoraireProjeteArrivee": [],
         "listeHoraireProjeteDepart": [
           {
-            "dateHeure": "2015-09-21T15:54:30+0000",
+            "dateHeure": "2015-09-21T15:54:00+0000",
             "dateHeureEmission": "2018-04-19T15:44:53+0000",
             "pronosticBrut": 830,
             "pronosticIV": 840,
             "source": "TEST"
           },
           {
-            "dateHeure": "2015-09-21T15:55:00+0000",
+            "dateHeure": "2015-09-21T15:54:00+0000",
             "dateHeureEmission": "2018-04-19T15:44:53+0000",
             "pronosticBrut": 830,
             "pronosticIV": 840,

--- a/tests/fixtures/cots_train_96231_added_for_detour.json
+++ b/tests/fixtures/cots_train_96231_added_for_detour.json
@@ -227,7 +227,6 @@
                 "listeMotifDepart":[
                 ],
                 "rang":3,
-                "sourceHoraireProjeteDepartReference":"ESCALE",
                 "typeArret":"CH"
             },
             {
@@ -275,7 +274,6 @@
                 "listeMotifDepart":[
                 ],
                 "rang":3,
-                "sourceHoraireProjeteDepartReference":"ESCALE",
                 "typeArret":"CH"
             },
             {

--- a/tests/fixtures/cots_train_96231_added_for_detour_in_advance.json
+++ b/tests/fixtures/cots_train_96231_added_for_detour_in_advance.json
@@ -227,7 +227,6 @@
                 "listeMotifDepart":[
                 ],
                 "rang":3,
-                "sourceHoraireProjeteDepartReference":"ESCALE",
                 "typeArret":"CH"
             },
             {
@@ -275,7 +274,6 @@
                 "listeMotifDepart":[
                 ],
                 "rang":3,
-                "sourceHoraireProjeteDepartReference":"ESCALE",
                 "typeArret":"CH"
             },
             {

--- a/tests/fixtures/cots_train_96231_no_delay_add_before_add_with_delay.json
+++ b/tests/fixtures/cots_train_96231_no_delay_add_before_add_with_delay.json
@@ -1,0 +1,407 @@
+{
+  "ressource": "courseOPE",
+  "mode": "modification",
+  "evt": [
+    "OBS",
+    "PERTURBATION"
+  ],
+  "PdPObserveArrivee": [
+    "5168b9d7-34b9-45d8-b434-88577c26bd72"
+  ],
+  "PdPObserveDepart": [],
+  "PdPPronosticBrutArrivee": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf",
+    "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+  ],
+  "PdPPronosticBrutDepart": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "5168b9d7-34b9-45d8-b434-88577c26bd72",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+  ],
+  "PdPPronosticIVArrivee": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf",
+    "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+  ],
+  "PdPPronosticIVDepart": [
+    "2ce15bf7-134d-4cd5-978f-d746d238e008",
+    "5168b9d7-34b9-45d8-b434-88577c26bd72",
+    "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+  ],
+  "PdPImpacteDepart": [],
+  "PdPImpacteArrivee": [],
+  "nouvelleVersion": {
+    "codeCompagnieTransporteur": "1187",
+    "codeMarqueTransporteur": "TGV",
+    "codeRelation": "401",
+    "codeService": "A2018",
+    "codeSousRelation": "401400",
+    "codeTransporteurResponsable": "1A",
+    "codeTypeMoyenTransport": "0",
+    "coursePTA": {
+      "@id": "66e70e61-7b0d-4c60-bde5-c73f1bf4f99e"
+    },
+    "dateDebutService": "2017-12-10",
+    "dateDerniereModification": "2018-04-19T13:46:06+0000",
+    "dateFinService": "2018-12-08",
+    "estDiscontinue": false,
+    "estTechnique": false,
+    "estimationManuelle": false,
+    "etat": "ACTIVE",
+    "idVersion": "cbdb2075-e476-48f1-8dfa-4fa95ba226b9",
+    "identifiantDansSystemeCreateur": "e36bcf7e-5f34-4ebe-948e-99a525a89251",
+    "indicateurFer": "FERRE",
+    "listeCouplageCourseOPE": [
+      {
+        "courseCouplee": {
+          "@id": "8808999b-e31e-444d-bd17-a21adf9c6d35"
+        },
+        "pointDebutCouplage": {
+          "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+        },
+        "pointFinCouplage": {
+          "@id": "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+        }
+      }
+    ],
+    "listeCodeTransporteurAssocie": [],
+    "listeEvenement": [],
+    "listeJourRegimeDApplication": [
+      {
+        "date": "2015-09-21"
+      }
+    ],
+    "listeJourRegimeFacultatif": [],
+    "listeMotif": [],
+    "listePointDeParcours": [
+      {
+        "@id": "998484ec-4335-45b6-aad4-8840047b275f",
+        "arretFacultatif": false,
+        "categorieStatistiqueDepart": "LVK",
+        "cr": "0087",
+        "ci": "212027",
+        "ch": "BV",
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:21:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T15:21:00+0000",
+          "heureLocale": "17:21:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 1,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "5168b9d7-34b9-45d8-b434-88577c26bd72",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVK",
+        "cr": "0087",
+        "ci": "214056",
+        "ch": "00",
+        "horaireObserveArrivee": {
+          "dateHeure": "2015-09-21T15:39:00+0000",
+          "dateHeureEmission": "2018-04-19T15:44:53+0000",
+          "source": "ESCALE"
+        },
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:39:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:56:30",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T15:38:00+0000",
+          "heureLocale": "17:38:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T15:40:00+0000",
+          "heureLocale": "17:40:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "idMotifInterneDepartReference": 3,
+        "idMotifInterneArriveeReference": 3,
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 2,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVK",
+        "cr": "0087",
+        "ci": "182014",
+        "ch": "BV",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:51:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "17:53:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T15:51:00+0000",
+          "heureLocale": "17:51:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T15:53:00+0000",
+          "heureLocale": "17:53:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 3,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "6a4a4413-a668-487c-b25d-907ef7e64e75",
+        "cr": "0087",
+        "ci": "713065",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T16:02:00+0000",
+          "heureLocale": "18:02:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T16:04:00+0000",
+          "heureLocale": "18:04:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 4,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "2ce15bf7-134d-4cd5-978f-d746d238e008",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVA",
+        "cr": "0087",
+        "ci": "182063",
+        "ch": "BV",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:14:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:16:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T16:14:00+0000",
+          "heureLocale": "18:14:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T16:16:00+0000",
+          "heureLocale": "18:16:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 5,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "2ce15bf7-134d-4cd5-978f-d746d238e008",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVA",
+        "cr": "0087",
+        "ci": "182139",
+        "ch": "BV",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:30:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireProductionDepart": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:31:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T16:30:00+0000",
+          "heureLocale": "18:30:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2015-09-21T16:31:00+0000",
+          "heureLocale": "18:31:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 6,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "2ce15bf7-134d-4cd5-978f-d746d238e008",
+        "arretFacultatif": false,
+        "categorieStatistiqueArrivee": "LVK",
+        "categorieStatistiqueDepart": "LVA",
+        "cr": "0087",
+        "ci": "187914",
+        "ch": "WS",
+        "horaireProductionArrivee": {
+          "idFuseauHoraire": "Europe/Paris",
+          "heureIncertaine": false,
+          "heureLocale": "18:39:00",
+          "nbJoursPasseMinuit": 0
+        },
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2015-09-21T16:39:00+0000",
+          "heureLocale": "18:39:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "idMotifInterneDepartReference": 3,
+        "idMotifInterneArriveeReference": 3,
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 7,
+        "typeArret": "CH"
+      }
+    ],
+    "listeService": [
+      {
+        "code": "CS01",
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2015-09-21"
+          }
+        ],
+        "listePropriete": [
+          {
+            "code": "CP001",
+            "metaPropriete": {
+              "@id": "95352652-200c-430b-8a94-3852677c91ea"
+            },
+            "valeurChaine": "A"
+          },
+          {
+            "code": "CP002",
+            "metaPropriete": {
+              "@id": "350d89f9-8667-4456-9186-765ce07ea238"
+            },
+            "valeurChaine": "A"
+          }
+        ],
+        "metaService": {
+          "@id": "590ecf63-8dcc-46d5-b238-391fd681eba1"
+        },
+        "pointDeParcoursDebut": {
+          "@id": "998484ec-4335-45b6-aad4-8840047b275f"
+        },
+        "pointDeParcoursFin": {
+          "@id": "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+        }
+      }
+    ],
+    "listeSubstitutionCourse": [],
+    "listeUtilisationSillon": [
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "096231",
+          "sillonTTH": "042522760051"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2015-09-21"
+          }
+        ],
+        "listeJourRegimeFacultatif": [],
+        "pointDebutUtilisationSillon": {
+          "@id": "998484ec-4335-45b6-aad4-8840047b275f"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+        },
+        "porteur": true
+      },
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "8780",
+          "sillonTTH": "042523700030"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2015-09-21"
+          }
+        ],
+        "listeJourRegimeFacultatif": [],
+        "pointDebutUtilisationSillon": {
+          "@id": "a9d59792-a5b5-471b-a477-cca0be7aa2bf"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "25fcd3ea-f655-4444-9ef8-d2da9fba9c10"
+        },
+        "porteur": false
+      }
+    ],
+    "numeroCourse": "096231",
+    "statutSillonCourse": "NON_CONNU",
+    "statutOperationnel": "PERTURBEE",
+    "systemeCreateur": "2148",
+    "@id": "e36bcf7e-5f34-4ebe-948e-99a525a89251",
+    "type": "COURSE_OPE"
+  }
+}

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -792,7 +792,45 @@ def test_cots_added_stop_time_earlier_than_previous():
                'invalid cots: stop_point\'s(0087-713065-BV) time is not consistent'
 
 
-def test_cots_added_stop_time_with_delays():
+def check_add_with_delays_96231():
+    trips = TripUpdate.query.all()
+    assert len(trips) == 1
+    assert trips[0].status == 'update'
+    assert trips[0].effect == 'MODIFIED_SERVICE'
+    assert trips[0].company_id == 'company:OCE:SN'
+    stus = StopTimeUpdate.query.all()
+    assert len(stus) == 7
+    assert stus[0].arrival_status == 'none'
+    assert stus[0].arrival == datetime(2015, 9, 21, 15, 21)
+    assert stus[0].departure_status == 'none'
+    assert stus[0].departure == datetime(2015, 9, 21, 15, 21)
+    assert stus[1].arrival_status == 'none'
+    assert stus[1].arrival == datetime(2015, 9, 21, 15, 38)
+    assert stus[1].departure_status == 'update'
+    assert stus[1].departure == datetime(2015, 9, 21, 15, 54)
+    assert stus[2].arrival_status == 'update'
+    assert stus[2].arrival == datetime(2015, 9, 21, 16, 6)
+    assert stus[2].departure_status == 'update'
+    assert stus[2].departure == datetime(2015, 9, 21, 16, 8)
+    assert stus[3].arrival_status == 'add'
+    assert stus[3].arrival == datetime(2015, 9, 21, 16, 17)
+    assert stus[3].departure_status == 'add'
+    assert stus[3].departure == datetime(2015, 9, 21, 16, 19)
+    assert stus[4].arrival_status == 'update'
+    assert stus[4].arrival == datetime(2015, 9, 21, 16, 29)
+    assert stus[4].departure_status == 'update'
+    assert stus[4].departure == datetime(2015, 9, 21, 16, 31)
+    assert stus[5].arrival_status == 'update'
+    assert stus[5].arrival == datetime(2015, 9, 21, 16, 45)
+    assert stus[5].departure_status == 'update'
+    assert stus[5].departure == datetime(2015, 9, 21, 16, 46)
+    assert stus[6].arrival_status == 'update'
+    assert stus[6].arrival == datetime(2015, 9, 21, 16, 54)
+    assert stus[6].departure_status == 'none'
+    assert stus[6].departure == datetime(2015, 9, 21, 16, 54)
+
+
+def test_cots_add_stop_time_with_delays_around():
     """
     A new stop time is added in the VJ 96231 with a delay as explained below
 
@@ -806,25 +844,10 @@ def test_cots_added_stop_time_with_delays():
     Arrival and departure datetime of newly added stop_time compared to the existing stop_times with delay.
     To test you can modify arrival and departure of added stop_time = (713065) in Flux-cots
     """
+
     cots_add_file = get_fixture_data('cots_train_96231_add_with_departure_after_next_base_stop_time_arrival.json')
     res = api_post('/cots', data=cots_add_file)
     assert res == 'OK'
     with app.app_context():
         assert len(RealTimeUpdate.query.all()) == 1
-        assert len(TripUpdate.query.all()) == 1
-        assert TripUpdate.query.all()[0].status == 'update'
-        assert TripUpdate.query.all()[0].effect == 'MODIFIED_SERVICE'
-        assert TripUpdate.query.all()[0].company_id == 'company:OCE:SN'
-        assert len(StopTimeUpdate.query.all()) == 7
-        assert StopTimeUpdate.query.all()[2].arrival_status == 'update'
-        assert StopTimeUpdate.query.all()[2].arrival == datetime(2015, 9, 21, 16, 6)
-        assert StopTimeUpdate.query.all()[2].departure_status == 'update'
-        assert StopTimeUpdate.query.all()[2].departure == datetime(2015, 9, 21, 16, 8)
-        assert StopTimeUpdate.query.all()[3].arrival_status == 'add'
-        assert StopTimeUpdate.query.all()[3].arrival == datetime(2015, 9, 21, 16, 17)
-        assert StopTimeUpdate.query.all()[3].departure_status == 'add'
-        assert StopTimeUpdate.query.all()[3].departure == datetime(2015, 9, 21, 16, 19)
-        assert StopTimeUpdate.query.all()[6].arrival_status == 'update'
-        assert StopTimeUpdate.query.all()[6].arrival == datetime(2015, 9, 21, 16, 54)
-        assert StopTimeUpdate.query.all()[6].departure_status == 'none'
-        assert StopTimeUpdate.query.all()[6].departure == datetime(2015, 9, 21, 16, 54)
+        check_add_with_delays_96231()

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -561,7 +561,7 @@ def test_cots_added_stop_time():
         assert StopTimeUpdate.query.all()[3].arrival_status == 'add'
         assert StopTimeUpdate.query.all()[3].arrival == datetime(2015, 9, 21, 16, 2)
         assert StopTimeUpdate.query.all()[3].departure_status == 'add'
-        assert StopTimeUpdate.query.all()[3].departure == datetime(2015, 9, 21, 16, 4)
+        assert StopTimeUpdate.query.all()[3].departure == datetime(2015, 9, 21, 16, 9)  # 16:04 + 5 min delay
 
 
 def test_cots_added_and_deleted_stop_time():
@@ -592,7 +592,7 @@ def test_cots_added_and_deleted_stop_time():
         assert StopTimeUpdate.query.all()[3].arrival_status == 'add'
         assert StopTimeUpdate.query.all()[3].arrival == datetime(2015, 9, 21, 16, 2)
         assert StopTimeUpdate.query.all()[3].departure_status == 'add'
-        assert StopTimeUpdate.query.all()[3].departure == datetime(2015, 9, 21, 16, 4)
+        assert StopTimeUpdate.query.all()[3].departure == datetime(2015, 9, 21, 16, 9)  # 16:04 + 5 min delay
         created_at_for_add = StopTimeUpdate.query.all()[3].created_at
 
     # At this point the trip_update is valid. Adding a new Stop_time in data base


### PR DESCRIPTION
Mostly corrects the way model is filled when reading an ADDED stop (for detour or not).
JIRA: https://jira.kisio.org/browse/NAVP-1153

:mag_right: Please review by commit, should be simpler (read their descriptions).

TODO (`do_not_merge` is for that):
- [x] run locally on artemis
  > :heavy_check_mark: Runs OK after 2 corrections **to merge** when merging this PR:  
  https://github.com/CanalTP/artemis/pull/296  
  https://github.com/CanalTP/artemis_references/pull/158
- [x] more hand-test with data provided in JIRA ticket.  
  > :heavy_check_mark: just the last departure's status is a bit weird (like it was the case already), but it's not a real stop-event, so...
- [x] add tests on simple "add+delay" feed, and on chaining "add, then add+delay" (if not already tested)
  > detected a chaining bug, added correction for that