### PR TITLE
Add trip update in bdd and gtfs rt

### DIFF
--- a/kirin/abstract_sncf_model_maker.py
+++ b/kirin/abstract_sncf_model_maker.py
@@ -41,6 +41,7 @@ import six
 from kirin.core import model
 
 TRAIN_ID_FORMAT = 'OCE:SN:{}'
+SNCF_SEARCH_MARGIN = timedelta(hours=1)
 
 
 def make_navitia_empty_vj(headsign):
@@ -120,8 +121,8 @@ class AbstractSNCFKirinModelBuilder(six.with_metaclass(ABCMeta, object)):
         vjs = {}
         # to get the date of the vj we use the start/end of the vj + some tolerance
         # since the SNCF data and navitia data might not be synchronized
-        extended_since_dt = utc_since_dt - timedelta(hours=1)
-        extended_until_dt = utc_until_dt + timedelta(hours=1)
+        extended_since_dt = utc_since_dt - SNCF_SEARCH_MARGIN
+        extended_until_dt = utc_until_dt + SNCF_SEARCH_MARGIN
 
         # using a set to deduplicate
         # one headsign_str (ex: "96320/1") can lead to multiple headsigns (ex: ["96320", "96321"])
@@ -154,7 +155,7 @@ class AbstractSNCFKirinModelBuilder(six.with_metaclass(ABCMeta, object)):
             for nav_vj in navitia_vjs:
 
                 try:
-                    vj = model.VehicleJourney(nav_vj, extended_since_dt, extended_until_dt)
+                    vj = model.VehicleJourney(nav_vj, extended_since_dt, extended_until_dt, vj_start_dt=utc_since_dt)
                     vjs[nav_vj['id']] = vj
                 except Exception as e:
                     logging.getLogger(__name__).exception(

--- a/kirin/abstract_sncf_model_maker.py
+++ b/kirin/abstract_sncf_model_maker.py
@@ -41,6 +41,12 @@ import six
 from kirin.core import model
 
 
+def make_navitia_vj(headsign):
+    navitia_vj = dict()
+    navitia_vj['id'] = 'OCE:SN:{}'.format(headsign)
+    return navitia_vj
+
+
 def to_navitia_str(dt):
     """
     format a datetime to a navitia-readable str
@@ -100,7 +106,7 @@ class AbstractSNCFKirinModelBuilder(six.with_metaclass(ABCMeta, object)):
         self.navitia = nav
         self.contributor = contributor
 
-    def _get_navitia_vjs(self, headsign_str, utc_since_dt, utc_until_dt):
+    def _get_navitia_vjs(self, headsign_str, utc_since_dt, utc_until_dt, status_op='PERTURBEE'):
         """
         Search for navitia's vehicle journeys with given headsigns, in the period provided
         :param utc_since_dt: UTC datetime that starts the search period.
@@ -125,26 +131,30 @@ class AbstractSNCFKirinModelBuilder(six.with_metaclass(ABCMeta, object)):
 
             log.debug('searching for vj {} during period [{} - {}] in navitia'.format(
                             train_number, extended_since_dt, extended_until_dt))
+            # Don't call navitia for an added trip ("statutOperationnel" == "AJOUTEE")
+            is_added = (status_op == 'AJOUTEE')
+            if not is_added:
+                navitia_vjs = self.navitia.vehicle_journeys(q={
+                    'headsign': train_number,
+                    'since': to_navitia_str(extended_since_dt),
+                    'until': to_navitia_str(extended_until_dt),
+                    'depth': '2',  # we need this depth to get the stoptime's stop_area
+                    'show_codes': 'true'  # we need the stop_points CRCICH codes
+                })
 
-            navitia_vjs = self.navitia.vehicle_journeys(q={
-                'headsign': train_number,
-                'since': to_navitia_str(extended_since_dt),
-                'until': to_navitia_str(extended_until_dt),
-                'depth': '2',  # we need this depth to get the stoptime's stop_area
-                'show_codes': 'true'  # we need the stop_points CRCICH codes
-            })
-
-            if not navitia_vjs:
-                logging.getLogger(__name__).info('impossible to find train {t} on [{s}, {u}['
-                                                 .format(t=train_number,
-                                                         s=extended_since_dt,
-                                                         u=extended_until_dt))
-                record_internal_failure('missing train', contributor=self.contributor)
+                if not navitia_vjs:
+                    logging.getLogger(__name__).info('impossible to find train {t} on [{s}, {u}['
+                                                     .format(t=train_number,
+                                                             s=extended_since_dt,
+                                                             u=extended_until_dt))
+                    record_internal_failure('missing train', contributor=self.contributor)
+            else:
+                navitia_vjs = [make_navitia_vj(train_number)]
 
             for nav_vj in navitia_vjs:
 
                 try:
-                    vj = model.VehicleJourney(nav_vj, extended_since_dt, extended_until_dt)
+                    vj = model.VehicleJourney(nav_vj, extended_since_dt, extended_until_dt, is_added)
                     vjs[nav_vj['id']] = vj
                 except Exception as e:
                     logging.getLogger(__name__).exception(

--- a/kirin/abstract_sncf_model_maker.py
+++ b/kirin/abstract_sncf_model_maker.py
@@ -43,10 +43,9 @@ from kirin.core import model
 TRAIN_ID_FORMAT = 'OCE:SN:{}'
 
 
-def make_navitia_vj(headsign):
-    navitia_vj = dict()
-    navitia_vj['id'] = TRAIN_ID_FORMAT.format(headsign)
-    return navitia_vj
+def make_navitia_empty_vj(headsign):
+    headsign = TRAIN_ID_FORMAT.format(headsign)
+    return {"id": headsign, "trip": {"id": headsign}}
 
 
 def to_navitia_str(dt):
@@ -150,12 +149,12 @@ class AbstractSNCFKirinModelBuilder(six.with_metaclass(ABCMeta, object)):
                                                              u=extended_until_dt))
                     record_internal_failure('missing train', contributor=self.contributor)
             else:
-                navitia_vjs = [make_navitia_vj(train_number)]
+                navitia_vjs = [make_navitia_empty_vj(train_number)]
 
             for nav_vj in navitia_vjs:
 
                 try:
-                    vj = model.VehicleJourney(nav_vj, extended_since_dt, extended_until_dt, is_added_trip)
+                    vj = model.VehicleJourney(nav_vj, extended_since_dt, extended_until_dt)
                     vjs[nav_vj['id']] = vj
                 except Exception as e:
                     logging.getLogger(__name__).exception(

--- a/kirin/core/handler.py
+++ b/kirin/core/handler.py
@@ -406,6 +406,7 @@ def merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete=False):
     res_stoptime_updates = []
 
     res.status = new_trip_update.status
+    res.effect = new_trip_update.effect
     if new_trip_update.message is not None or is_new_complete:
         res.message = new_trip_update.message
     res.contributor = new_trip_update.contributor

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -296,14 +296,16 @@ class TripUpdate(db.Model, TimestampMixin):
                                         cascade='all, delete-orphan')
     company_id = db.Column(db.Text, nullable=True)
     effect = db.Column(Db_TripEffect, nullable=True)
+    physical_mode_id = db.Column(db.Text, nullable=True)
 
-    def __init__(self, vj=None, status='none', contributor=None, company_id=None, effect=None):
+    def __init__(self, vj=None, status='none', contributor=None, company_id=None, effect=None, physical_mode_id=None):
         self.created_at = datetime.datetime.utcnow()
         self.vj = vj
         self.status = status
         self.contributor = contributor
         self.company_id = company_id
         self.effect = effect
+        self.physical_mode_id = physical_mode_id
 
     def __repr__(self):
         return '<TripUpdate %r>' % self.vj_id

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -140,7 +140,7 @@ class VehicleJourney(db.Model):
         # For an added trip, we use utc_since_dt as in flux cots re-adjusted where as for existing one
         # compute start_timestamp (in UTC) from first stop_time, to be the closest AFTER provided utc_since_dt.
         if is_added:
-            self.start_timestamp = utc_since_dt - timedelta(hours=1)
+            self.start_timestamp = utc_since_dt
         else:
             first_stop_time = navitia_vj.get('stop_times', [{}])[0]
             start_time = first_stop_time['utc_arrival_time']  # converted in datetime.time() in python wrapper

--- a/kirin/core/populate_pb.py
+++ b/kirin/core/populate_pb.py
@@ -128,6 +128,8 @@ def fill_trip_update(pb_trip_update, trip_update):
         pb_trip.Extensions[kirin_pb2.company_id] = trip_update.company_id
     if trip_update.effect:
         pb_trip_update.Extensions[kirin_pb2.effect] = get_trip_event(trip_update.effect)
+    if trip_update.physical_mode_id:
+        pb_trip_update.vehicle.Extensions[kirin_pb2.physical_mode_id] = trip_update.physical_mode_id
 
     vj = trip_update.vj
     if vj:

--- a/kirin/core/types.py
+++ b/kirin/core/types.py
@@ -31,9 +31,6 @@
 
 from enum import Enum
 from kirin import kirin_pb2
-from datetime import timedelta
-
-COTS_SEARCH_MARGIN = timedelta(hours=1)
 
 
 class ModificationType(Enum):
@@ -103,4 +100,4 @@ def get_mode_filter(indicator=None):
     return {
         'FERRE': 'physical_mode.id=physical_mode:LongDistanceTrain',
         'ROUTIER': 'physical_mode.id=physical_mode:Coach'
-    }.get(indicator, 'all')
+    }.get(indicator, 'physical_mode.id=physical_mode:LongDistanceTrain')

--- a/kirin/core/types.py
+++ b/kirin/core/types.py
@@ -31,6 +31,9 @@
 
 from enum import Enum
 from kirin import kirin_pb2
+from datetime import timedelta
+
+COTS_SEARCH_MARGIN = timedelta(hours=1)
 
 
 class ModificationType(Enum):
@@ -96,28 +99,8 @@ def get_effect_by_stop_time_status(status):
     return status_to_effect.get(status, TripEffect.UNKNOWN_EFFECT.name)
 
 
-def get_railway_mode_filter(mode=None):
+def get_mode_filter(indicator=None):
     return {
-        'LYRIA': 'commercial_mode.id=commercial_mode:lyria',
-        'INTERCITES': 'commercial_mode.id=commercial_mode:intercites - physical_mode.id=physical_mode:LocalTrain',
-        'TER': 'commercial_mode.id=commercial_mode:ter - physical_mode.id=physical_mode:Coach',
-        'TGV': 'commercial_mode.id=commercial_mode:tgv - physical_mode.id=physical_mode:Coach'
-    }.get(mode, 'commercial_mode.id=commercial_mode:lyria')
-
-
-def get_route_mode_filter(mode=None):
-    return {
-        'LYRIA': 'commercial_mode.id=commercial_mode:lyria',
-        'INTERCITES': 'commercial_mode.id=commercial_mode:intercites - physical_mode.id=physical_mode:LocalTrain',
-        'TER': 'commercial_mode.id=commercial_mode:ter - physical_mode.id=physical_mode:LocalTrain',
-        'TGV': 'commercial_mode.id=commercial_mode:tgv - physical_mode.id=physical_mode:LongDistanceTrain'
-    }.get(mode, 'commercial_mode.id=commercial_mode:lyria')
-
-
-def get_mode_filter(indicator=None, mode=None):
-    if indicator is None:
-        return "all"
-    elif indicator == 'FERRE':
-        return get_railway_mode_filter(mode)
-    else:
-        return get_route_mode_filter(mode)
+        'FERRE': 'physical_mode.id=physical_mode:LongDistanceTrain',
+        'ROUTIER': 'physical_mode.id=physical_mode:Coach'
+    }.get(indicator, 'all')

--- a/kirin/core/types.py
+++ b/kirin/core/types.py
@@ -94,3 +94,30 @@ def get_effect_by_stop_time_status(status):
         ModificationType.deleted_for_detour.name: TripEffect.DETOUR.name
     }
     return status_to_effect.get(status, TripEffect.UNKNOWN_EFFECT.name)
+
+
+def get_railway_mode_filter(mode=None):
+    return {
+        'LYRIA': 'commercial_mode.id=commercial_mode:lyria',
+        'INTERCITES': 'commercial_mode.id=commercial_mode:intercites - physical_mode.id=physical_mode:LocalTrain',
+        'TER': 'commercial_mode.id=commercial_mode:ter - physical_mode.id=physical_mode:Coach',
+        'TGV': 'commercial_mode.id=commercial_mode:tgv - physical_mode.id=physical_mode:Coach'
+    }.get(mode, 'commercial_mode.id=commercial_mode:lyria')
+
+
+def get_route_mode_filter(mode=None):
+    return {
+        'LYRIA': 'commercial_mode.id=commercial_mode:lyria',
+        'INTERCITES': 'commercial_mode.id=commercial_mode:intercites - physical_mode.id=physical_mode:LocalTrain',
+        'TER': 'commercial_mode.id=commercial_mode:ter - physical_mode.id=physical_mode:LocalTrain',
+        'TGV': 'commercial_mode.id=commercial_mode:tgv - physical_mode.id=physical_mode:LongDistanceTrain'
+    }.get(mode, 'commercial_mode.id=commercial_mode:lyria')
+
+
+def get_mode_filter(indicator=None, mode=None):
+    if indicator is None:
+        return "all"
+    elif indicator == 'FERRE':
+        return get_railway_mode_filter(mode)
+    else:
+        return get_route_mode_filter(mode)

--- a/kirin/cots/model_maker.py
+++ b/kirin/cots/model_maker.py
@@ -360,7 +360,7 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
         # manage realtime information stop_time by stop_time
         for pdp in pdps:
             # retrieve navitia's stop_point corresponding to the current COTS pdp
-            nav_stop, log_dict = self._get_navitia_stop_point(pdp, vj)
+            nav_stop, log_dict = self._get_navitia_stop_point(pdp, vj.navitia_vj)
             projected_stop_time = {'Arrivee': None, 'Depart': None}  # used to check consistency
 
             if log_dict:
@@ -472,7 +472,7 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
         nav_st, log_dict = get_navitia_stop_time_sncf(cr=get_value(pdp, 'cr'),
                                                       ci=get_value(pdp, 'ci'),
                                                       ch=get_value(pdp, 'ch'),
-                                                      nav_vj=nav_vj.navitia_vj)
+                                                      nav_vj=nav_vj)
         if not nav_st:
             nav_stop, log_dict = self._request_navitia_stop_point(cr=get_value(pdp, 'cr'),
                                                                   ci=get_value(pdp, 'ci'),

--- a/migrations/versions/174583a01aea_add_new_modification_types.py
+++ b/migrations/versions/174583a01aea_add_new_modification_types.py
@@ -1,7 +1,7 @@
 """empty message
 
 Revision ID: 174583a01aea
-Revises: 4d9df787c7a7
+Revises: 45f4c90aa775
 Create Date: 2018-11-28 14:58:50.362398
 
 """

--- a/migrations/versions/51d98b3b8e58_add_physical_mode_id.py
+++ b/migrations/versions/51d98b3b8e58_add_physical_mode_id.py
@@ -1,0 +1,22 @@
+"""empty message
+Add physical_mode_id in trip_update
+Revision ID: 51d98b3b8e58
+Revises: 174583a01aea
+Create Date: 2019-02-11 16:28:16.999441
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '51d98b3b8e58'
+down_revision = '174583a01aea'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('trip_update', sa.Column('physical_mode_id', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('trip_update', 'physical_mode_id')

--- a/tests/fixtures/cots_train_151515_added_trip.json
+++ b/tests/fixtures/cots_train_151515_added_trip.json
@@ -1,0 +1,319 @@
+{
+  "ressource": "courseOPE",
+  "mode": "modification",
+  "evt": [
+    "PERTURBATION"
+  ],
+  "PdPObserveArrivee": [],
+  "PdPObserveDepart": [],
+  "PdPPronosticBrutArrivee": [
+    "0f4666b5-082f-4006-9e06-65702e45fdda",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticBrutDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVArrivee": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPImpacteDepart": [],
+  "PdPImpacteArrivee": [],
+  "nouvelleVersion": {
+    "codeCompagnieTransporteur": "1187",
+    "codeMarqueTransporteur": "TGV",
+    "codeRelation": "671",
+    "codeService": "A2018",
+    "codeSousRelation": "671100",
+    "codeTransporteurResponsable": "1S",
+    "dateDebutService": "2012-09-13",
+    "dateDerniereModification": "2019-01-23T08:35:06+0000",
+    "dateFinService": "2012-12-31",
+    "estDiscontinue": false,
+    "estTechnique": false,
+    "etat": "ACTIVE",
+    "idMotifInterneReference": 8,
+    "idVersion": "c07a8b24-b1bb-454b-9d92-73d40de285ec",
+    "identifiantDansSystemeCreateur": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "indicateurFer": "FERRE",
+    "listeCouplageCourseOPE": [],
+    "listeCodeTransporteurAssocie": [],
+    "listeEvenement": [],
+    "listeJourRegimeDApplication": [
+      {
+        "date": "2012-11-20"
+      }
+    ],
+    "listeJourRegimeFacultatif": [],
+    "listeMotif": [
+      {
+        "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+        "idMotifInterne": 8,
+        "source": "IRE-GOP"
+      }
+    ],
+    "listePointDeParcours": [
+      {
+        "@id": "c1e2630a-d92a-4e0a-9010-a4e11c0fc777",
+        "cr": "0087",
+        "ci": "686667",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T11:00:00+0000",
+          "heureLocale": "12:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T11:00:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 0,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 1,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "1022221f-3223-423a-8541-b32f2878b8d8",
+        "cr": "0087",
+        "ci": "683573",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T12:00:00+0000",
+          "heureLocale": "13:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T12:10:00+0000",
+          "heureLocale": "13:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T12:00:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 0,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T12:10:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 0,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 2,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "1025211f-3543-452a-8d61-bd2f2868bad8",
+        "cr": "0087",
+        "ci": "318964",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T14:00:00+0000",
+          "heureLocale": "15:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T14:10:00+0000",
+          "heureLocale": "15:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T14:00:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 0,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T14:10:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 0,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 3,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "06c8be2a-b35f-4aee-889a-b1965a040289",
+        "cr": "0087",
+        "ci": "319012",
+        "ch": "00",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T15:00:00+0000",
+          "heureLocale": "16:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T15:10:00+0000",
+          "heureLocale": "16:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T15:10:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 0,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T15:10:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 0,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 4,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "0f4666b5-082f-4006-9e06-65702e45fdda",
+        "cr": "0087",
+        "ci": "751008",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T16:00:00+0000",
+          "heureLocale": "17:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T16:00:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 0,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [],
+        "rang": 5,
+        "typeArret": "CH"
+      }
+    ],
+    "listeService": [],
+    "listeSubstitutionCourse": [],
+    "listeUtilisationSillon": [
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "9580-9581",
+          "sillonTTH": "042522910097"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2012-11-20"
+          }
+        ],
+        "listeJourRegimeFacultatif": [],
+        "pointDebutUtilisationSillon": {
+          "@id": "50f31367-af56-4c08-9bf8-423bf3856dfc"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "0f4666b5-082f-4006-9e06-65702e45fdda"
+        },
+        "porteur": true,
+        "rangPRDebutUtilisationSillon": 1,
+        "decalagePasseMinuit": 0,
+        "rangPRFinUtilisationSillon": 210
+      }
+    ],
+    "numeroCourse": "151515",
+    "statutOperationnel": "AJOUTEE",
+    "systemeCreateur": "2148",
+    "type": "COURSE_OPE",
+    "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a"
+  }
+}

--- a/tests/fixtures/cots_train_151515_added_trip_to_normal.json
+++ b/tests/fixtures/cots_train_151515_added_trip_to_normal.json
@@ -109,7 +109,7 @@
         "ch": "BV",
         "timeZoneLocale": "Europe/Paris",
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T14:00:00+0000",
+          "dateHeure": "2012-11-20T16:00:00+0200",
           "heureLocale": "15:00:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0,
@@ -122,7 +122,7 @@
         "rang": 3,
         "typeArret": "CH",
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T14:10:00+0000",
+          "dateHeure": "2012-11-20T16:10:00+0200",
           "heureLocale": "15:10:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0,
@@ -136,7 +136,7 @@
         "ch": "00",
         "timeZoneLocale": "Europe/Paris",
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T15:00:00+0000",
+          "dateHeure": "2012-11-20T17:00:00+0200",
           "heureLocale": "16:00:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0,
@@ -149,7 +149,7 @@
         "rang": 4,
         "typeArret": "CH",
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T15:10:00+0000",
+          "dateHeure": "2012-11-20T17:10:00+0200",
           "heureLocale": "16:10:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0,
@@ -163,7 +163,7 @@
         "ch": "BV",
         "timeZoneLocale": "Europe/Paris",
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T16:00:00+0000",
+          "dateHeure": "2012-11-20T18:00:00+0200",
           "heureLocale": "17:00:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0,

--- a/tests/fixtures/cots_train_151515_added_trip_to_normal.json
+++ b/tests/fixtures/cots_train_151515_added_trip_to_normal.json
@@ -34,6 +34,7 @@
     "estDiscontinue": false,
     "estTechnique": false,
     "etat": "ACTIVE",
+    "idMotifInterneReference": 8,
     "idVersion": "c07a8b24-b1bb-454b-9d92-73d40de285ec",
     "identifiantDansSystemeCreateur": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
     "indicateurFer": "FERRE",
@@ -87,19 +88,19 @@
           "nbJoursPasseMinuit": 0,
           "statutCirculationOPE": "CREATION"
         },
-        "listeHoraireProjeteArrivee": [],
-        "listeHoraireProjeteDepart": [],
-        "listeMotifArrivee": [],
-        "listeMotifDepart": [],
-        "rang": 2,
-        "typeArret": "CH",
         "horaireVoyageurDepart": {
           "dateHeure": "2012-11-20T12:10:00+0000",
           "heureLocale": "13:10:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0,
           "statutCirculationOPE": "CREATION"
-        }
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 2,
+        "typeArret": "CH"
       },
       {
         "@id": "1025211f-3543-452a-8d61-bd2f2868bad8",
@@ -190,15 +191,15 @@
           }
         ],
         "listeJourRegimeFacultatif": [],
+        "porteur": true,
+        "decalagePasseMinuit": 0,
         "pointDebutUtilisationSillon": {
           "@id": "50f31367-af56-4c08-9bf8-423bf3856dfc"
         },
         "pointFinUtilisationSillon": {
           "@id": "0f4666b5-082f-4006-9e06-65702e45fdda"
         },
-        "porteur": true,
         "rangPRDebutUtilisationSillon": 1,
-        "decalagePasseMinuit": 0,
         "rangPRFinUtilisationSillon": 210
       }
     ],
@@ -208,7 +209,6 @@
     "type": "COURSE_OPE",
     "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
     "dateDerniereModification": "2019-01-23T08:35:06+0000",
-    "idMotifInterneReference": 8,
     "codeRelation": "671",
     "codeSousRelation": "671100"
   }

--- a/tests/fixtures/cots_train_151515_added_trip_to_normal.json
+++ b/tests/fixtures/cots_train_151515_added_trip_to_normal.json
@@ -27,17 +27,13 @@
   "nouvelleVersion": {
     "codeCompagnieTransporteur": "1187",
     "codeMarqueTransporteur": "TGV",
-    "codeRelation": "671",
     "codeService": "A2018",
-    "codeSousRelation": "671100",
     "codeTransporteurResponsable": "1S",
     "dateDebutService": "2012-09-13",
-    "dateDerniereModification": "2019-01-23T08:35:06+0000",
     "dateFinService": "2012-12-31",
     "estDiscontinue": false,
     "estTechnique": false,
     "etat": "ACTIVE",
-    "idMotifInterneReference": 8,
     "idVersion": "c07a8b24-b1bb-454b-9d92-73d40de285ec",
     "identifiantDansSystemeCreateur": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
     "indicateurFer": "FERRE",
@@ -72,22 +68,9 @@
           "statutCirculationOPE": "CREATION"
         },
         "listeHoraireProjeteArrivee": [],
-        "listeHoraireProjeteDepart": [
-          {
-            "dateHeure": "2012-11-20T11:00:00+0000",
-            "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 0,
-            "source": "IRE-GOP"
-          }
-        ],
+        "listeHoraireProjeteDepart": [],
         "listeMotifArrivee": [],
-        "listeMotifDepart": [
-          {
-            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
-            "idMotifInterne": 78,
-            "source": "IRE-GOP"
-          }
-        ],
+        "listeMotifDepart": [],
         "rang": 1,
         "typeArret": "CH"
       },
@@ -104,45 +87,19 @@
           "nbJoursPasseMinuit": 0,
           "statutCirculationOPE": "CREATION"
         },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 2,
+        "typeArret": "CH",
         "horaireVoyageurDepart": {
           "dateHeure": "2012-11-20T12:10:00+0000",
           "heureLocale": "13:10:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0,
           "statutCirculationOPE": "CREATION"
-        },
-        "listeHoraireProjeteArrivee": [
-          {
-            "dateHeure": "2012-11-20T12:00:00+0000",
-            "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 0,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeHoraireProjeteDepart": [
-          {
-            "dateHeure": "2012-11-20T12:10:00+0000",
-            "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 0,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeMotifArrivee": [
-          {
-            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
-            "idMotifInterne": 78,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeMotifDepart": [
-          {
-            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
-            "idMotifInterne": 78,
-            "source": "IRE-GOP"
-          }
-        ],
-        "rang": 2,
-        "typeArret": "CH"
+        }
       },
       {
         "@id": "1025211f-3543-452a-8d61-bd2f2868bad8",
@@ -157,45 +114,19 @@
           "nbJoursPasseMinuit": 0,
           "statutCirculationOPE": "CREATION"
         },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 3,
+        "typeArret": "CH",
         "horaireVoyageurDepart": {
           "dateHeure": "2012-11-20T14:10:00+0000",
           "heureLocale": "15:10:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0,
           "statutCirculationOPE": "CREATION"
-        },
-        "listeHoraireProjeteArrivee": [
-          {
-            "dateHeure": "2012-11-20T14:00:00+0000",
-            "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 0,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeHoraireProjeteDepart": [
-          {
-            "dateHeure": "2012-11-20T14:10:00+0000",
-            "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 0,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeMotifArrivee": [
-          {
-            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
-            "idMotifInterne": 78,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeMotifDepart": [
-          {
-            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
-            "idMotifInterne": 78,
-            "source": "IRE-GOP"
-          }
-        ],
-        "rang": 3,
-        "typeArret": "CH"
+        }
       },
       {
         "@id": "06c8be2a-b35f-4aee-889a-b1965a040289",
@@ -210,45 +141,19 @@
           "nbJoursPasseMinuit": 0,
           "statutCirculationOPE": "CREATION"
         },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 4,
+        "typeArret": "CH",
         "horaireVoyageurDepart": {
           "dateHeure": "2012-11-20T15:10:00+0000",
           "heureLocale": "16:10:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0,
           "statutCirculationOPE": "CREATION"
-        },
-        "listeHoraireProjeteArrivee": [
-          {
-            "dateHeure": "2012-11-20T15:10:00+0000",
-            "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 0,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeHoraireProjeteDepart": [
-          {
-            "dateHeure": "2012-11-20T15:10:00+0000",
-            "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 0,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeMotifArrivee": [
-          {
-            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
-            "idMotifInterne": 78,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeMotifDepart": [
-          {
-            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
-            "idMotifInterne": 78,
-            "source": "IRE-GOP"
-          }
-        ],
-        "rang": 4,
-        "typeArret": "CH"
+        }
       },
       {
         "@id": "0f4666b5-082f-4006-9e06-65702e45fdda",
@@ -263,22 +168,9 @@
           "nbJoursPasseMinuit": 0,
           "statutCirculationOPE": "CREATION"
         },
-        "listeHoraireProjeteArrivee": [
-          {
-            "dateHeure": "2012-11-20T16:00:00+0000",
-            "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 0,
-            "source": "IRE-GOP"
-          }
-        ],
+        "listeHoraireProjeteArrivee": [],
         "listeHoraireProjeteDepart": [],
-        "listeMotifArrivee": [
-          {
-            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
-            "idMotifInterne": 78,
-            "source": "IRE-GOP"
-          }
-        ],
+        "listeMotifArrivee": [],
         "listeMotifDepart": [],
         "rang": 5,
         "typeArret": "CH"
@@ -311,9 +203,13 @@
       }
     ],
     "numeroCourse": "151515",
-    "statutOperationnel": "AJOUTEE",
+    "statutOperationnel": "PERTURBEE",
     "systemeCreateur": "2148",
     "type": "COURSE_OPE",
-    "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a"
+    "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "dateDerniereModification": "2019-01-23T08:35:06+0000",
+    "idMotifInterneReference": 8,
+    "codeRelation": "671",
+    "codeSousRelation": "671100"
   }
 }

--- a/tests/fixtures/cots_train_151515_added_trip_with_delay.json
+++ b/tests/fixtures/cots_train_151515_added_trip_with_delay.json
@@ -1,6 +1,6 @@
 {
   "ressource": "courseOPE",
-  "mode": "creation",
+  "mode": "modification",
   "evt": [
     "PERTURBATION"
   ],
@@ -27,17 +27,13 @@
   "nouvelleVersion": {
     "codeCompagnieTransporteur": "1187",
     "codeMarqueTransporteur": "TGV",
-    "codeRelation": "671",
     "codeService": "A2018",
-    "codeSousRelation": "671100",
     "codeTransporteurResponsable": "1S",
     "dateDebutService": "2012-09-13",
-    "dateDerniereModification": "2019-01-23T08:35:06+0000",
     "dateFinService": "2012-12-31",
     "estDiscontinue": false,
     "estTechnique": false,
     "etat": "ACTIVE",
-    "idMotifInterneReference": 8,
     "idVersion": "c07a8b24-b1bb-454b-9d92-73d40de285ec",
     "identifiantDansSystemeCreateur": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
     "indicateurFer": "FERRE",
@@ -74,10 +70,11 @@
         "listeHoraireProjeteArrivee": [],
         "listeHoraireProjeteDepart": [
           {
-            "dateHeure": "2012-11-20T11:00:00+0000",
+            "dateHeure": "2012-11-20T11:15:00+0000",
             "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 0,
-            "source": "IRE-GOP"
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
           }
         ],
         "listeMotifArrivee": [],
@@ -104,27 +101,22 @@
           "nbJoursPasseMinuit": 0,
           "statutCirculationOPE": "CREATION"
         },
-        "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T12:10:00+0000",
-          "heureLocale": "13:10:00",
-          "idFuseauHoraire": "Europe/Paris",
-          "nbJoursPasseMinuit": 0,
-          "statutCirculationOPE": "CREATION"
-        },
         "listeHoraireProjeteArrivee": [
           {
-            "dateHeure": "2012-11-20T12:00:00+0000",
+            "dateHeure": "2012-11-20T12:15:00+0000",
             "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 0,
-            "source": "IRE-GOP"
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
           }
         ],
         "listeHoraireProjeteDepart": [
           {
-            "dateHeure": "2012-11-20T12:10:00+0000",
+            "dateHeure": "2012-11-20T12:25:00+0000",
             "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 0,
-            "source": "IRE-GOP"
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
           }
         ],
         "listeMotifArrivee": [
@@ -142,7 +134,14 @@
           }
         ],
         "rang": 2,
-        "typeArret": "CH"
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T12:10:00+0000",
+          "heureLocale": "13:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
       },
       {
         "@id": "1025211f-3543-452a-8d61-bd2f2868bad8",
@@ -157,27 +156,22 @@
           "nbJoursPasseMinuit": 0,
           "statutCirculationOPE": "CREATION"
         },
-        "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T14:10:00+0000",
-          "heureLocale": "15:10:00",
-          "idFuseauHoraire": "Europe/Paris",
-          "nbJoursPasseMinuit": 0,
-          "statutCirculationOPE": "CREATION"
-        },
         "listeHoraireProjeteArrivee": [
           {
-            "dateHeure": "2012-11-20T14:00:00+0000",
+            "dateHeure": "2012-11-20T14:15:00+0000",
             "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 0,
-            "source": "IRE-GOP"
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
           }
         ],
         "listeHoraireProjeteDepart": [
           {
-            "dateHeure": "2012-11-20T14:10:00+0000",
+            "dateHeure": "2012-11-20T14:25:00+0000",
             "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 0,
-            "source": "IRE-GOP"
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
           }
         ],
         "listeMotifArrivee": [
@@ -195,7 +189,14 @@
           }
         ],
         "rang": 3,
-        "typeArret": "CH"
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T14:10:00+0000",
+          "heureLocale": "15:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
       },
       {
         "@id": "06c8be2a-b35f-4aee-889a-b1965a040289",
@@ -210,27 +211,22 @@
           "nbJoursPasseMinuit": 0,
           "statutCirculationOPE": "CREATION"
         },
-        "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T15:10:00+0000",
-          "heureLocale": "16:10:00",
-          "idFuseauHoraire": "Europe/Paris",
-          "nbJoursPasseMinuit": 0,
-          "statutCirculationOPE": "CREATION"
-        },
         "listeHoraireProjeteArrivee": [
           {
-            "dateHeure": "2012-11-20T15:10:00+0000",
+            "dateHeure": "2012-11-20T15:15:00+0000",
             "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 0,
-            "source": "IRE-GOP"
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
           }
         ],
         "listeHoraireProjeteDepart": [
           {
-            "dateHeure": "2012-11-20T15:10:00+0000",
+            "dateHeure": "2012-11-20T15:25:00+0000",
             "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 0,
-            "source": "IRE-GOP"
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
           }
         ],
         "listeMotifArrivee": [
@@ -248,7 +244,14 @@
           }
         ],
         "rang": 4,
-        "typeArret": "CH"
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T15:10:00+0000",
+          "heureLocale": "16:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
       },
       {
         "@id": "0f4666b5-082f-4006-9e06-65702e45fdda",
@@ -265,10 +268,11 @@
         },
         "listeHoraireProjeteArrivee": [
           {
-            "dateHeure": "2012-11-20T16:00:00+0000",
+            "dateHeure": "2012-11-20T16:15:00+0000",
             "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 0,
-            "source": "IRE-GOP"
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
           }
         ],
         "listeHoraireProjeteDepart": [],
@@ -311,9 +315,13 @@
       }
     ],
     "numeroCourse": "151515",
-    "statutOperationnel": "AJOUTEE",
+    "statutOperationnel": "PERTURBEE",
     "systemeCreateur": "2148",
     "type": "COURSE_OPE",
-    "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a"
+    "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "dateDerniereModification": "2019-01-23T08:35:06+0000",
+    "idMotifInterneReference": 8,
+    "codeRelation": "671",
+    "codeSousRelation": "671100"
   }
 }

--- a/tests/fixtures/cots_train_151515_added_trip_with_delay.json
+++ b/tests/fixtures/cots_train_151515_added_trip_with_delay.json
@@ -34,6 +34,7 @@
     "estDiscontinue": false,
     "estTechnique": false,
     "etat": "ACTIVE",
+    "idMotifInterneReference": 8,
     "idVersion": "c07a8b24-b1bb-454b-9d92-73d40de285ec",
     "identifiantDansSystemeCreateur": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
     "indicateurFer": "FERRE",
@@ -101,6 +102,13 @@
           "nbJoursPasseMinuit": 0,
           "statutCirculationOPE": "CREATION"
         },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T12:10:00+0000",
+          "heureLocale": "13:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
         "listeHoraireProjeteArrivee": [
           {
             "dateHeure": "2012-11-20T12:15:00+0000",
@@ -134,14 +142,7 @@
           }
         ],
         "rang": 2,
-        "typeArret": "CH",
-        "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T12:10:00+0000",
-          "heureLocale": "13:10:00",
-          "idFuseauHoraire": "Europe/Paris",
-          "nbJoursPasseMinuit": 0,
-          "statutCirculationOPE": "CREATION"
-        }
+        "typeArret": "CH"
       },
       {
         "@id": "1025211f-3543-452a-8d61-bd2f2868bad8",
@@ -302,15 +303,15 @@
           }
         ],
         "listeJourRegimeFacultatif": [],
+        "porteur": true,
+        "decalagePasseMinuit": 0,
         "pointDebutUtilisationSillon": {
           "@id": "50f31367-af56-4c08-9bf8-423bf3856dfc"
         },
         "pointFinUtilisationSillon": {
           "@id": "0f4666b5-082f-4006-9e06-65702e45fdda"
         },
-        "porteur": true,
         "rangPRDebutUtilisationSillon": 1,
-        "decalagePasseMinuit": 0,
         "rangPRFinUtilisationSillon": 210
       }
     ],
@@ -320,7 +321,6 @@
     "type": "COURSE_OPE",
     "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
     "dateDerniereModification": "2019-01-23T08:35:06+0000",
-    "idMotifInterneReference": 8,
     "codeRelation": "671",
     "codeSousRelation": "671100"
   }

--- a/tests/fixtures/cots_train_151515_added_trip_with_delay_and_stop_time_added.json
+++ b/tests/fixtures/cots_train_151515_added_trip_with_delay_and_stop_time_added.json
@@ -34,6 +34,7 @@
     "estDiscontinue": false,
     "estTechnique": false,
     "etat": "ACTIVE",
+    "idMotifInterneReference": 8,
     "idVersion": "c07a8b24-b1bb-454b-9d92-73d40de285ec",
     "identifiantDansSystemeCreateur": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
     "indicateurFer": "FERRE",
@@ -101,6 +102,13 @@
           "nbJoursPasseMinuit": 0,
           "statutCirculationOPE": "CREATION"
         },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T11:40:00+0000",
+          "heureLocale": "14:40:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
         "listeHoraireProjeteArrivee": [
           {
             "dateHeure": "2012-11-20T11:45:00+0000",
@@ -134,14 +142,7 @@
           }
         ],
         "rang": 2,
-        "typeArret": "CH",
-        "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T11:40:00+0000",
-          "heureLocale": "14:40:00",
-          "idFuseauHoraire": "Europe/Paris",
-          "nbJoursPasseMinuit": 0,
-          "statutCirculationOPE": "CREATION"
-        }
+        "typeArret": "CH"
       },
       {
         "@id": "1022221f-3223-423a-8541-b32f2878b8d8",
@@ -357,15 +358,15 @@
           }
         ],
         "listeJourRegimeFacultatif": [],
+        "porteur": true,
+        "decalagePasseMinuit": 0,
         "pointDebutUtilisationSillon": {
           "@id": "50f31367-af56-4c08-9bf8-423bf3856dfc"
         },
         "pointFinUtilisationSillon": {
           "@id": "0f4666b5-082f-4006-9e06-65702e45fdda"
         },
-        "porteur": true,
         "rangPRDebutUtilisationSillon": 1,
-        "decalagePasseMinuit": 0,
         "rangPRFinUtilisationSillon": 210
       }
     ],
@@ -375,7 +376,6 @@
     "type": "COURSE_OPE",
     "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
     "dateDerniereModification": "2019-01-23T08:35:06+0000",
-    "idMotifInterneReference": 8,
     "codeRelation": "671",
     "codeSousRelation": "671100"
   }

--- a/tests/fixtures/cots_train_151515_added_trip_with_delay_and_stop_time_added.json
+++ b/tests/fixtures/cots_train_151515_added_trip_with_delay_and_stop_time_added.json
@@ -1,0 +1,382 @@
+{
+  "ressource": "courseOPE",
+  "mode": "modification",
+  "evt": [
+    "PERTURBATION"
+  ],
+  "PdPObserveArrivee": [],
+  "PdPObserveDepart": [],
+  "PdPPronosticBrutArrivee": [
+    "0f4666b5-082f-4006-9e06-65702e45fdda",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticBrutDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVArrivee": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPImpacteDepart": [],
+  "PdPImpacteArrivee": [],
+  "nouvelleVersion": {
+    "codeCompagnieTransporteur": "1187",
+    "codeMarqueTransporteur": "TGV",
+    "codeService": "A2018",
+    "codeTransporteurResponsable": "1S",
+    "dateDebutService": "2012-09-13",
+    "dateFinService": "2012-12-31",
+    "estDiscontinue": false,
+    "estTechnique": false,
+    "etat": "ACTIVE",
+    "idVersion": "c07a8b24-b1bb-454b-9d92-73d40de285ec",
+    "identifiantDansSystemeCreateur": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "indicateurFer": "FERRE",
+    "listeCouplageCourseOPE": [],
+    "listeCodeTransporteurAssocie": [],
+    "listeEvenement": [],
+    "listeJourRegimeDApplication": [
+      {
+        "date": "2012-11-20"
+      }
+    ],
+    "listeJourRegimeFacultatif": [],
+    "listeMotif": [
+      {
+        "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+        "idMotifInterne": 8,
+        "source": "IRE-GOP"
+      }
+    ],
+    "listePointDeParcours": [
+      {
+        "@id": "c1e2630a-d92a-4e0a-9010-a4e11c0fc777",
+        "cr": "0087",
+        "ci": "686667",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T11:00:00+0000",
+          "heureLocale": "12:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T11:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 1,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "1022221f-3223-423a-8541-b32f2878b8d8",
+        "cr": "0087",
+        "ci": "543009",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T11:30:00+0000",
+          "heureLocale": "12:30:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T11:45:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T11:55:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 2,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T11:40:00+0000",
+          "heureLocale": "14:40:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "1022221f-3223-423a-8541-b32f2878b8d8",
+        "cr": "0087",
+        "ci": "683573",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T12:00:00+0000",
+          "heureLocale": "13:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T12:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T12:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 3,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T12:10:00+0000",
+          "heureLocale": "13:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "1025211f-3543-452a-8d61-bd2f2868bad8",
+        "cr": "0087",
+        "ci": "318964",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T14:00:00+0000",
+          "heureLocale": "15:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T14:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T14:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 4,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T14:10:00+0000",
+          "heureLocale": "15:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "06c8be2a-b35f-4aee-889a-b1965a040289",
+        "cr": "0087",
+        "ci": "319012",
+        "ch": "00",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T15:00:00+0000",
+          "heureLocale": "16:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T15:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T15:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 5,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T15:10:00+0000",
+          "heureLocale": "16:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "0f4666b5-082f-4006-9e06-65702e45fdda",
+        "cr": "0087",
+        "ci": "751008",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T16:00:00+0000",
+          "heureLocale": "17:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T16:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [],
+        "rang": 6,
+        "typeArret": "CH"
+      }
+    ],
+    "listeService": [],
+    "listeSubstitutionCourse": [],
+    "listeUtilisationSillon": [
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "9580-9581",
+          "sillonTTH": "042522910097"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2012-11-20"
+          }
+        ],
+        "listeJourRegimeFacultatif": [],
+        "pointDebutUtilisationSillon": {
+          "@id": "50f31367-af56-4c08-9bf8-423bf3856dfc"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "0f4666b5-082f-4006-9e06-65702e45fdda"
+        },
+        "porteur": true,
+        "rangPRDebutUtilisationSillon": 1,
+        "decalagePasseMinuit": 0,
+        "rangPRFinUtilisationSillon": 210
+      }
+    ],
+    "numeroCourse": "151515",
+    "statutOperationnel": "PERTURBEE",
+    "systemeCreateur": "2148",
+    "type": "COURSE_OPE",
+    "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "dateDerniereModification": "2019-01-23T08:35:06+0000",
+    "idMotifInterneReference": 8,
+    "codeRelation": "671",
+    "codeSousRelation": "671100"
+  }
+}

--- a/tests/fixtures/cots_train_151515_added_trip_with_delay_and_stop_time_deleted.json
+++ b/tests/fixtures/cots_train_151515_added_trip_with_delay_and_stop_time_deleted.json
@@ -1,0 +1,327 @@
+{
+  "ressource": "courseOPE",
+  "mode": "modification",
+  "evt": [
+    "PERTURBATION"
+  ],
+  "PdPObserveArrivee": [],
+  "PdPObserveDepart": [],
+  "PdPPronosticBrutArrivee": [
+    "0f4666b5-082f-4006-9e06-65702e45fdda",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticBrutDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVArrivee": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPImpacteDepart": [],
+  "PdPImpacteArrivee": [],
+  "nouvelleVersion": {
+    "codeCompagnieTransporteur": "1187",
+    "codeMarqueTransporteur": "TGV",
+    "codeService": "A2018",
+    "codeTransporteurResponsable": "1S",
+    "dateDebutService": "2012-09-13",
+    "dateFinService": "2012-12-31",
+    "estDiscontinue": false,
+    "estTechnique": false,
+    "etat": "ACTIVE",
+    "idVersion": "c07a8b24-b1bb-454b-9d92-73d40de285ec",
+    "identifiantDansSystemeCreateur": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "indicateurFer": "FERRE",
+    "listeCouplageCourseOPE": [],
+    "listeCodeTransporteurAssocie": [],
+    "listeEvenement": [],
+    "listeJourRegimeDApplication": [
+      {
+        "date": "2012-11-20"
+      }
+    ],
+    "listeJourRegimeFacultatif": [],
+    "listeMotif": [
+      {
+        "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+        "idMotifInterne": 8,
+        "source": "IRE-GOP"
+      }
+    ],
+    "listePointDeParcours": [
+      {
+        "@id": "c1e2630a-d92a-4e0a-9010-a4e11c0fc777",
+        "cr": "0087",
+        "ci": "686667",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T11:00:00+0000",
+          "heureLocale": "12:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T11:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 1,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "1022221f-3223-423a-8541-b32f2878b8d8",
+        "cr": "0087",
+        "ci": "683573",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T12:00:00+0000",
+          "heureLocale": "13:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T12:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T12:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 2,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T12:10:00+0000",
+          "heureLocale": "13:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        }
+      },
+      {
+        "@id": "1025211f-3543-452a-8d61-bd2f2868bad8",
+        "cr": "0087",
+        "ci": "318964",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T14:00:00+0000",
+          "heureLocale": "15:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T14:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T14:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 3,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T14:10:00+0000",
+          "heureLocale": "15:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "06c8be2a-b35f-4aee-889a-b1965a040289",
+        "cr": "0087",
+        "ci": "319012",
+        "ch": "00",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T15:00:00+0000",
+          "heureLocale": "16:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T15:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T15:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 4,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T15:10:00+0000",
+          "heureLocale": "16:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "0f4666b5-082f-4006-9e06-65702e45fdda",
+        "cr": "0087",
+        "ci": "751008",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T16:00:00+0000",
+          "heureLocale": "17:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T16:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [],
+        "rang": 5,
+        "typeArret": "CH"
+      }
+    ],
+    "listeService": [],
+    "listeSubstitutionCourse": [],
+    "listeUtilisationSillon": [
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "9580-9581",
+          "sillonTTH": "042522910097"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2012-11-20"
+          }
+        ],
+        "listeJourRegimeFacultatif": [],
+        "pointDebutUtilisationSillon": {
+          "@id": "50f31367-af56-4c08-9bf8-423bf3856dfc"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "0f4666b5-082f-4006-9e06-65702e45fdda"
+        },
+        "porteur": true,
+        "rangPRDebutUtilisationSillon": 1,
+        "decalagePasseMinuit": 0,
+        "rangPRFinUtilisationSillon": 210
+      }
+    ],
+    "numeroCourse": "151515",
+    "statutOperationnel": "PERTURBEE",
+    "systemeCreateur": "2148",
+    "type": "COURSE_OPE",
+    "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "dateDerniereModification": "2019-01-23T08:35:06+0000",
+    "idMotifInterneReference": 8,
+    "codeRelation": "671",
+    "codeSousRelation": "671100"
+  }
+}

--- a/tests/fixtures/cots_train_151515_added_trip_with_delay_and_stop_time_deleted.json
+++ b/tests/fixtures/cots_train_151515_added_trip_with_delay_and_stop_time_deleted.json
@@ -34,6 +34,7 @@
     "estDiscontinue": false,
     "estTechnique": false,
     "etat": "ACTIVE",
+    "idMotifInterneReference": 8,
     "idVersion": "c07a8b24-b1bb-454b-9d92-73d40de285ec",
     "identifiantDansSystemeCreateur": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
     "indicateurFer": "FERRE",
@@ -101,6 +102,13 @@
           "nbJoursPasseMinuit": 0,
           "statutCirculationOPE": "SUPPRESSION"
         },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T12:10:00+0000",
+          "heureLocale": "13:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
         "listeHoraireProjeteArrivee": [
           {
             "dateHeure": "2012-11-20T12:15:00+0000",
@@ -134,14 +142,7 @@
           }
         ],
         "rang": 2,
-        "typeArret": "CH",
-        "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T12:10:00+0000",
-          "heureLocale": "13:10:00",
-          "idFuseauHoraire": "Europe/Paris",
-          "nbJoursPasseMinuit": 0,
-          "statutCirculationOPE": "SUPPRESSION"
-        }
+        "typeArret": "CH"
       },
       {
         "@id": "1025211f-3543-452a-8d61-bd2f2868bad8",
@@ -302,15 +303,15 @@
           }
         ],
         "listeJourRegimeFacultatif": [],
+        "porteur": true,
+        "decalagePasseMinuit": 0,
         "pointDebutUtilisationSillon": {
           "@id": "50f31367-af56-4c08-9bf8-423bf3856dfc"
         },
         "pointFinUtilisationSillon": {
           "@id": "0f4666b5-082f-4006-9e06-65702e45fdda"
         },
-        "porteur": true,
         "rangPRDebutUtilisationSillon": 1,
-        "decalagePasseMinuit": 0,
         "rangPRFinUtilisationSillon": 210
       }
     ],
@@ -320,7 +321,6 @@
     "type": "COURSE_OPE",
     "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
     "dateDerniereModification": "2019-01-23T08:35:06+0000",
-    "idMotifInterneReference": 8,
     "codeRelation": "671",
     "codeSousRelation": "671100"
   }

--- a/tests/fixtures/cots_train_151515_deleted_trip_with_delay_and_stop_time_added.json
+++ b/tests/fixtures/cots_train_151515_deleted_trip_with_delay_and_stop_time_added.json
@@ -34,6 +34,7 @@
     "estDiscontinue": false,
     "estTechnique": false,
     "etat": "ACTIVE",
+    "idMotifInterneReference": 8,
     "idVersion": "c07a8b24-b1bb-454b-9d92-73d40de285ec",
     "identifiantDansSystemeCreateur": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
     "indicateurFer": "FERRE",
@@ -101,6 +102,13 @@
           "nbJoursPasseMinuit": 0,
           "statutCirculationOPE": "SUPPRESSION"
         },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T11:40:00+0000",
+          "heureLocale": "14:40:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
         "listeHoraireProjeteArrivee": [
           {
             "dateHeure": "2012-11-20T11:45:00+0000",
@@ -134,14 +142,7 @@
           }
         ],
         "rang": 2,
-        "typeArret": "CH",
-        "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T11:40:00+0000",
-          "heureLocale": "14:40:00",
-          "idFuseauHoraire": "Europe/Paris",
-          "nbJoursPasseMinuit": 0,
-          "statutCirculationOPE": "SUPPRESSION"
-        }
+        "typeArret": "CH"
       },
       {
         "@id": "1022221f-3223-423a-8541-b32f2878b8d8",
@@ -357,15 +358,15 @@
           }
         ],
         "listeJourRegimeFacultatif": [],
+        "porteur": true,
+        "decalagePasseMinuit": 0,
         "pointDebutUtilisationSillon": {
           "@id": "50f31367-af56-4c08-9bf8-423bf3856dfc"
         },
         "pointFinUtilisationSillon": {
           "@id": "0f4666b5-082f-4006-9e06-65702e45fdda"
         },
-        "porteur": true,
         "rangPRDebutUtilisationSillon": 1,
-        "decalagePasseMinuit": 0,
         "rangPRFinUtilisationSillon": 210
       }
     ],
@@ -375,7 +376,6 @@
     "type": "COURSE_OPE",
     "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
     "dateDerniereModification": "2019-01-23T08:35:06+0000",
-    "idMotifInterneReference": 8,
     "codeRelation": "671",
     "codeSousRelation": "671100"
   }

--- a/tests/fixtures/cots_train_151515_deleted_trip_with_delay_and_stop_time_added.json
+++ b/tests/fixtures/cots_train_151515_deleted_trip_with_delay_and_stop_time_added.json
@@ -1,0 +1,382 @@
+{
+  "ressource": "courseOPE",
+  "mode": "modification",
+  "evt": [
+    "PERTURBATION"
+  ],
+  "PdPObserveArrivee": [],
+  "PdPObserveDepart": [],
+  "PdPPronosticBrutArrivee": [
+    "0f4666b5-082f-4006-9e06-65702e45fdda",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticBrutDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVArrivee": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPImpacteDepart": [],
+  "PdPImpacteArrivee": [],
+  "nouvelleVersion": {
+    "codeCompagnieTransporteur": "1187",
+    "codeMarqueTransporteur": "TGV",
+    "codeService": "A2018",
+    "codeTransporteurResponsable": "1S",
+    "dateDebutService": "2012-09-13",
+    "dateFinService": "2012-12-31",
+    "estDiscontinue": false,
+    "estTechnique": false,
+    "etat": "ACTIVE",
+    "idVersion": "c07a8b24-b1bb-454b-9d92-73d40de285ec",
+    "identifiantDansSystemeCreateur": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "indicateurFer": "FERRE",
+    "listeCouplageCourseOPE": [],
+    "listeCodeTransporteurAssocie": [],
+    "listeEvenement": [],
+    "listeJourRegimeDApplication": [
+      {
+        "date": "2012-11-20"
+      }
+    ],
+    "listeJourRegimeFacultatif": [],
+    "listeMotif": [
+      {
+        "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+        "idMotifInterne": 8,
+        "source": "IRE-GOP"
+      }
+    ],
+    "listePointDeParcours": [
+      {
+        "@id": "c1e2630a-d92a-4e0a-9010-a4e11c0fc777",
+        "cr": "0087",
+        "ci": "686667",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T11:00:00+0000",
+          "heureLocale": "12:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T11:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 1,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "1022221f-3223-423a-8541-b32f2878b8d8",
+        "cr": "0087",
+        "ci": "543009",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T11:30:00+0000",
+          "heureLocale": "12:30:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T11:45:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T11:55:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 2,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T11:40:00+0000",
+          "heureLocale": "14:40:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        }
+      },
+      {
+        "@id": "1022221f-3223-423a-8541-b32f2878b8d8",
+        "cr": "0087",
+        "ci": "683573",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T12:00:00+0000",
+          "heureLocale": "13:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T12:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T12:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 3,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T12:10:00+0000",
+          "heureLocale": "13:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        }
+      },
+      {
+        "@id": "1025211f-3543-452a-8d61-bd2f2868bad8",
+        "cr": "0087",
+        "ci": "318964",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T14:00:00+0000",
+          "heureLocale": "15:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T14:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T14:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 4,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T14:10:00+0000",
+          "heureLocale": "15:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        }
+      },
+      {
+        "@id": "06c8be2a-b35f-4aee-889a-b1965a040289",
+        "cr": "0087",
+        "ci": "319012",
+        "ch": "00",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T15:00:00+0000",
+          "heureLocale": "16:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T15:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T15:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 5,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T15:10:00+0000",
+          "heureLocale": "16:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        }
+      },
+      {
+        "@id": "0f4666b5-082f-4006-9e06-65702e45fdda",
+        "cr": "0087",
+        "ci": "751008",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T16:00:00+0000",
+          "heureLocale": "17:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T16:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [],
+        "rang": 6,
+        "typeArret": "CH"
+      }
+    ],
+    "listeService": [],
+    "listeSubstitutionCourse": [],
+    "listeUtilisationSillon": [
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "9580-9581",
+          "sillonTTH": "042522910097"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2012-11-20"
+          }
+        ],
+        "listeJourRegimeFacultatif": [],
+        "pointDebutUtilisationSillon": {
+          "@id": "50f31367-af56-4c08-9bf8-423bf3856dfc"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "0f4666b5-082f-4006-9e06-65702e45fdda"
+        },
+        "porteur": true,
+        "rangPRDebutUtilisationSillon": 1,
+        "decalagePasseMinuit": 0,
+        "rangPRFinUtilisationSillon": 210
+      }
+    ],
+    "numeroCourse": "151515",
+    "statutOperationnel": "SUPPRIMEE",
+    "systemeCreateur": "2148",
+    "type": "COURSE_OPE",
+    "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "dateDerniereModification": "2019-01-23T08:35:06+0000",
+    "idMotifInterneReference": 8,
+    "codeRelation": "671",
+    "codeSousRelation": "671100"
+  }
+}

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -967,28 +967,28 @@ def check_add_trip_151515():
     assert trips[0].status == 'add'
     assert trips[0].effect == 'ADDITIONAL_SERVICE'
     assert trips[0].company_id == 'company:OCE:SN'
-    stus = StopTimeUpdate.query.all()
-    assert len(stus) == 5
-    assert stus[0].arrival_status == 'none'
-    assert stus[0].arrival == datetime(2012, 11, 20, 11, 00)
-    assert stus[0].departure_status == 'add'
-    assert stus[0].departure == datetime(2012, 11, 20, 11, 00)
-    assert stus[1].arrival_status == 'add'
-    assert stus[1].arrival == datetime(2012, 11, 20, 12, 00)
-    assert stus[1].departure_status == 'add'
-    assert stus[1].departure == datetime(2012, 11, 20, 12, 10)
-    assert stus[2].arrival_status == 'add'
-    assert stus[2].arrival == datetime(2012, 11, 20, 14, 00)
-    assert stus[2].departure_status == 'add'
-    assert stus[2].departure == datetime(2012, 11, 20, 14, 10)
-    assert stus[3].arrival_status == 'add'
-    assert stus[3].arrival == datetime(2012, 11, 20, 15, 00)
-    assert stus[3].departure_status == 'add'
-    assert stus[3].departure == datetime(2012, 11, 20, 15, 10)
-    assert stus[4].arrival_status == 'add'
-    assert stus[4].arrival == datetime(2012, 11, 20, 16, 00)
-    assert stus[4].departure_status == 'none'
-    assert stus[4].departure == datetime(2012, 11, 20, 16, 00)
+    status = StopTimeUpdate.query.all()
+    assert len(status) == 5
+    assert status[0].arrival_status == 'none'
+    assert status[0].arrival == datetime(2012, 11, 20, 11, 00)
+    assert status[0].departure_status == 'add'
+    assert status[0].departure == datetime(2012, 11, 20, 11, 00)
+    assert status[1].arrival_status == 'add'
+    assert status[1].arrival == datetime(2012, 11, 20, 12, 00)
+    assert status[1].departure_status == 'add'
+    assert status[1].departure == datetime(2012, 11, 20, 12, 10)
+    assert status[2].arrival_status == 'add'
+    assert status[2].arrival == datetime(2012, 11, 20, 14, 00)
+    assert status[2].departure_status == 'add'
+    assert status[2].departure == datetime(2012, 11, 20, 14, 10)
+    assert status[3].arrival_status == 'add'
+    assert status[3].arrival == datetime(2012, 11, 20, 15, 00)
+    assert status[3].departure_status == 'add'
+    assert status[3].departure == datetime(2012, 11, 20, 15, 10)
+    assert status[4].arrival_status == 'add'
+    assert status[4].arrival == datetime(2012, 11, 20, 16, 00)
+    assert status[4].departure_status == 'none'
+    assert status[4].departure == datetime(2012, 11, 20, 16, 00)
 
 
 def test_cots_for_added_trip():

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -959,3 +959,45 @@ def test_chain_add_no_delay_and_add_with_delay_around():
     with app.app_context():
         assert len(RealTimeUpdate.query.all()) == 5
         check_add_no_delays_96231()
+
+
+def check_add_trip_151515():
+    trips = TripUpdate.query.all()
+    assert len(trips) == 1
+    assert trips[0].status == 'add'
+    assert trips[0].effect == 'ADDITIONAL_SERVICE'
+    assert trips[0].company_id == 'company:OCE:SN'
+    stus = StopTimeUpdate.query.all()
+    assert len(stus) == 5
+    assert stus[0].arrival_status == 'none'
+    assert stus[0].arrival == datetime(2012, 11, 20, 11, 00)
+    assert stus[0].departure_status == 'add'
+    assert stus[0].departure == datetime(2012, 11, 20, 11, 00)
+    assert stus[1].arrival_status == 'add'
+    assert stus[1].arrival == datetime(2012, 11, 20, 12, 00)
+    assert stus[1].departure_status == 'add'
+    assert stus[1].departure == datetime(2012, 11, 20, 12, 10)
+    assert stus[2].arrival_status == 'add'
+    assert stus[2].arrival == datetime(2012, 11, 20, 14, 00)
+    assert stus[2].departure_status == 'add'
+    assert stus[2].departure == datetime(2012, 11, 20, 14, 10)
+    assert stus[3].arrival_status == 'add'
+    assert stus[3].arrival == datetime(2012, 11, 20, 15, 00)
+    assert stus[3].departure_status == 'add'
+    assert stus[3].departure == datetime(2012, 11, 20, 15, 10)
+    assert stus[4].arrival_status == 'add'
+    assert stus[4].arrival == datetime(2012, 11, 20, 16, 00)
+    assert stus[4].departure_status == 'none'
+    assert stus[4].departure == datetime(2012, 11, 20, 16, 00)
+
+
+def test_cots_for_added_trip():
+    """
+     A simple trip add with 5 stop_times all existing in navitia
+    """
+    cots_add_file = get_fixture_data('cots_train_151515_added_trip.json')
+    res = api_post('/cots', data=cots_add_file)
+    assert res == 'OK'
+    with app.app_context():
+        assert len(RealTimeUpdate.query.all()) == 1
+        check_add_trip_151515()

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -991,13 +991,58 @@ def check_add_trip_151515():
     assert status[4].departure == datetime(2012, 11, 20, 16, 00)
 
 
+def check_add_trip_151515_with_delay():
+    trips = TripUpdate.query.all()
+    assert len(trips) == 1
+    assert trips[0].status == 'add'
+    assert trips[0].effect == 'ADDITIONAL_SERVICE'
+    assert trips[0].company_id == 'company:OCE:SN'
+    status = StopTimeUpdate.query.all()
+    assert len(status) == 5
+    assert status[0].arrival_status == 'none'
+    assert status[0].arrival == datetime(2012, 11, 20, 11, 15)
+    assert status[0].departure_status == 'add'
+    assert status[0].departure == datetime(2012, 11, 20, 11, 15)
+    assert status[1].arrival_status == 'add'
+    assert status[1].arrival == datetime(2012, 11, 20, 12, 15)
+    assert status[1].departure_status == 'add'
+    assert status[1].departure == datetime(2012, 11, 20, 12, 25)
+    assert status[2].arrival_status == 'add'
+    assert status[2].arrival == datetime(2012, 11, 20, 14, 15)
+    assert status[2].departure_status == 'add'
+    assert status[2].departure == datetime(2012, 11, 20, 14, 25)
+    assert status[3].arrival_status == 'add'
+    assert status[3].arrival == datetime(2012, 11, 20, 15, 15)
+    assert status[3].departure_status == 'add'
+    assert status[3].departure == datetime(2012, 11, 20, 15, 25)
+    assert status[4].arrival_status == 'add'
+    assert status[4].arrival == datetime(2012, 11, 20, 16, 15)
+    assert status[4].departure_status == 'none'
+    assert status[4].departure == datetime(2012, 11, 20, 16, 15)
+
+
 def test_cots_for_added_trip():
     """
-     A simple trip add with 5 stop_times all existing in navitia
+     1. A simple trip add with 5 stop_times all existing in navitia
+     2. Trip modified with 15 minutes delay in each stop_times
     """
     cots_add_file = get_fixture_data('cots_train_151515_added_trip.json')
     res = api_post('/cots', data=cots_add_file)
     assert res == 'OK'
     with app.app_context():
         assert len(RealTimeUpdate.query.all()) == 1
+        check_add_trip_151515()
+
+    cots_add_file = get_fixture_data('cots_train_151515_added_trip_with_delay.json')
+    res = api_post('/cots', data=cots_add_file)
+    assert res == 'OK'
+    with app.app_context():
+        assert len(RealTimeUpdate.query.all()) == 2
+        check_add_trip_151515_with_delay()
+
+    cots_add_file = get_fixture_data('cots_train_151515_added_trip_to_normal.json')
+    res = api_post('/cots', data=cots_add_file)
+    assert res == 'OK'
+    with app.app_context():
+        assert len(RealTimeUpdate.query.all()) == 3
         check_add_trip_151515()

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -1055,32 +1055,32 @@ def check_add_trip_151515_with_delay_and_an_add():
     assert trips[0].status == 'add'
     assert trips[0].effect == 'ADDITIONAL_SERVICE'
     assert trips[0].company_id == 'company:OCE:SN'
-    stop_times = StopTimeUpdate.query.all()
-    assert len(stop_times ) == 6
-    assert stop_times [0].arrival_status == 'none'
-    assert stop_times [0].arrival == datetime(2012, 11, 20, 11, 15)
-    assert stop_times [0].departure_status == 'add'
-    assert stop_times [0].departure == datetime(2012, 11, 20, 11, 15)
-    assert stop_times [1].arrival_status == 'add'
-    assert stop_times [1].arrival == datetime(2012, 11, 20, 11, 45)
-    assert stop_times [1].departure_status == 'add'
-    assert stop_times [1].departure == datetime(2012, 11, 20, 11, 55)
-    assert stop_times [2].arrival_status == 'add'
-    assert stop_times [2].arrival == datetime(2012, 11, 20, 12, 15)
-    assert stop_times [2].departure_status == 'add'
-    assert stop_times [2].departure == datetime(2012, 11, 20, 12, 25)
-    assert stop_times [3].arrival_status == 'add'
-    assert stop_times [3].arrival == datetime(2012, 11, 20, 14, 15)
-    assert stop_times [3].departure_status == 'add'
-    assert stop_times [3].departure == datetime(2012, 11, 20, 14, 25)
-    assert stop_times [4].arrival_status == 'add'
-    assert stop_times [4].arrival == datetime(2012, 11, 20, 15, 15)
-    assert stop_times [4].departure_status == 'add'
-    assert stop_times [4].departure == datetime(2012, 11, 20, 15, 25)
-    assert stop_times [5].arrival_status == 'add'
-    assert stop_times [5].arrival == datetime(2012, 11, 20, 16, 15)
-    assert stop_times [5].departure_status == 'none'
-    assert stop_times [5].departure == datetime(2012, 11, 20, 16, 15)
+    stop_time = StopTimeUpdate.query.all()
+    assert len(stop_time) == 6
+    assert stop_time[0].arrival_status == 'none'
+    assert stop_time[0].arrival == datetime(2012, 11, 20, 11, 15)
+    assert stop_time[0].departure_status == 'add'
+    assert stop_time[0].departure == datetime(2012, 11, 20, 11, 15)
+    assert stop_time[1].arrival_status == 'add'
+    assert stop_time[1].arrival == datetime(2012, 11, 20, 11, 45)
+    assert stop_time[1].departure_status == 'add'
+    assert stop_time[1].departure == datetime(2012, 11, 20, 11, 55)
+    assert stop_time[2].arrival_status == 'add'
+    assert stop_time[2].arrival == datetime(2012, 11, 20, 12, 15)
+    assert stop_time[2].departure_status == 'add'
+    assert stop_time[2].departure == datetime(2012, 11, 20, 12, 25)
+    assert stop_time[3].arrival_status == 'add'
+    assert stop_time[3].arrival == datetime(2012, 11, 20, 14, 15)
+    assert stop_time[3].departure_status == 'add'
+    assert stop_time[3].departure == datetime(2012, 11, 20, 14, 25)
+    assert stop_time[4].arrival_status == 'add'
+    assert stop_time[4].arrival == datetime(2012, 11, 20, 15, 15)
+    assert stop_time[4].departure_status == 'add'
+    assert stop_time[4].departure == datetime(2012, 11, 20, 15, 25)
+    assert stop_time[5].arrival_status == 'add'
+    assert stop_time[5].arrival == datetime(2012, 11, 20, 16, 15)
+    assert stop_time[5].departure_status == 'none'
+    assert stop_time[5].departure == datetime(2012, 11, 20, 16, 15)
 
 
 def test_cots_for_added_trip_chain_type_1():

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -967,28 +967,28 @@ def check_add_trip_151515():
     assert trips[0].status == 'add'
     assert trips[0].effect == 'ADDITIONAL_SERVICE'
     assert trips[0].company_id == 'company:OCE:SN'
-    status = StopTimeUpdate.query.all()
-    assert len(status) == 5
-    assert status[0].arrival_status == 'none'
-    assert status[0].arrival == datetime(2012, 11, 20, 11, 00)
-    assert status[0].departure_status == 'add'
-    assert status[0].departure == datetime(2012, 11, 20, 11, 00)
-    assert status[1].arrival_status == 'add'
-    assert status[1].arrival == datetime(2012, 11, 20, 12, 00)
-    assert status[1].departure_status == 'add'
-    assert status[1].departure == datetime(2012, 11, 20, 12, 10)
-    assert status[2].arrival_status == 'add'
-    assert status[2].arrival == datetime(2012, 11, 20, 14, 00)
-    assert status[2].departure_status == 'add'
-    assert status[2].departure == datetime(2012, 11, 20, 14, 10)
-    assert status[3].arrival_status == 'add'
-    assert status[3].arrival == datetime(2012, 11, 20, 15, 00)
-    assert status[3].departure_status == 'add'
-    assert status[3].departure == datetime(2012, 11, 20, 15, 10)
-    assert status[4].arrival_status == 'add'
-    assert status[4].arrival == datetime(2012, 11, 20, 16, 00)
-    assert status[4].departure_status == 'none'
-    assert status[4].departure == datetime(2012, 11, 20, 16, 00)
+    stop_times = StopTimeUpdate.query.all()
+    assert len(stop_times) == 5
+    assert stop_times[0].arrival_status == 'none'
+    assert stop_times[0].arrival == datetime(2012, 11, 20, 11, 00)
+    assert stop_times[0].departure_status == 'add'
+    assert stop_times[0].departure == datetime(2012, 11, 20, 11, 00)
+    assert stop_times[1].arrival_status == 'add'
+    assert stop_times[1].arrival == datetime(2012, 11, 20, 12, 00)
+    assert stop_times[1].departure_status == 'add'
+    assert stop_times[1].departure == datetime(2012, 11, 20, 12, 10)
+    assert stop_times[2].arrival_status == 'add'
+    assert stop_times[2].arrival == datetime(2012, 11, 20, 14, 00)
+    assert stop_times[2].departure_status == 'add'
+    assert stop_times[2].departure == datetime(2012, 11, 20, 14, 10)
+    assert stop_times[3].arrival_status == 'add'
+    assert stop_times[3].arrival == datetime(2012, 11, 20, 15, 00)
+    assert stop_times[3].departure_status == 'add'
+    assert stop_times[3].departure == datetime(2012, 11, 20, 15, 10)
+    assert stop_times[4].arrival_status == 'add'
+    assert stop_times[4].arrival == datetime(2012, 11, 20, 16, 00)
+    assert stop_times[4].departure_status == 'none'
+    assert stop_times[4].departure == datetime(2012, 11, 20, 16, 00)
 
 
 def check_add_trip_151515_with_delay():
@@ -997,34 +997,97 @@ def check_add_trip_151515_with_delay():
     assert trips[0].status == 'add'
     assert trips[0].effect == 'ADDITIONAL_SERVICE'
     assert trips[0].company_id == 'company:OCE:SN'
-    status = StopTimeUpdate.query.all()
-    assert len(status) == 5
-    assert status[0].arrival_status == 'none'
-    assert status[0].arrival == datetime(2012, 11, 20, 11, 15)
-    assert status[0].departure_status == 'add'
-    assert status[0].departure == datetime(2012, 11, 20, 11, 15)
-    assert status[1].arrival_status == 'add'
-    assert status[1].arrival == datetime(2012, 11, 20, 12, 15)
-    assert status[1].departure_status == 'add'
-    assert status[1].departure == datetime(2012, 11, 20, 12, 25)
-    assert status[2].arrival_status == 'add'
-    assert status[2].arrival == datetime(2012, 11, 20, 14, 15)
-    assert status[2].departure_status == 'add'
-    assert status[2].departure == datetime(2012, 11, 20, 14, 25)
-    assert status[3].arrival_status == 'add'
-    assert status[3].arrival == datetime(2012, 11, 20, 15, 15)
-    assert status[3].departure_status == 'add'
-    assert status[3].departure == datetime(2012, 11, 20, 15, 25)
-    assert status[4].arrival_status == 'add'
-    assert status[4].arrival == datetime(2012, 11, 20, 16, 15)
-    assert status[4].departure_status == 'none'
-    assert status[4].departure == datetime(2012, 11, 20, 16, 15)
+    stop_times = StopTimeUpdate.query.all()
+    assert len(stop_times) == 5
+    assert stop_times[0].arrival_status == 'none'
+    assert stop_times[0].arrival == datetime(2012, 11, 20, 11, 15)
+    assert stop_times[0].departure_status == 'add'
+    assert stop_times[0].departure == datetime(2012, 11, 20, 11, 15)
+    assert stop_times[1].arrival_status == 'add'
+    assert stop_times[1].arrival == datetime(2012, 11, 20, 12, 15)
+    assert stop_times[1].departure_status == 'add'
+    assert stop_times[1].departure == datetime(2012, 11, 20, 12, 25)
+    assert stop_times[2].arrival_status == 'add'
+    assert stop_times[2].arrival == datetime(2012, 11, 20, 14, 15)
+    assert stop_times[2].departure_status == 'add'
+    assert stop_times[2].departure == datetime(2012, 11, 20, 14, 25)
+    assert stop_times[3].arrival_status == 'add'
+    assert stop_times[3].arrival == datetime(2012, 11, 20, 15, 15)
+    assert stop_times[3].departure_status == 'add'
+    assert stop_times[3].departure == datetime(2012, 11, 20, 15, 25)
+    assert stop_times[4].arrival_status == 'add'
+    assert stop_times[4].arrival == datetime(2012, 11, 20, 16, 15)
+    assert stop_times[4].departure_status == 'none'
+    assert stop_times[4].departure == datetime(2012, 11, 20, 16, 15)
 
 
-def test_cots_for_added_trip():
+def check_add_trip_151515_with_delay_and_a_delete():
+    trips = TripUpdate.query.all()
+    assert len(trips) == 1
+    assert trips[0].status == 'add'
+    assert trips[0].effect == 'ADDITIONAL_SERVICE'
+    assert trips[0].company_id == 'company:OCE:SN'
+    stop_times = StopTimeUpdate.query.all()
+    assert len(stop_times) == 5
+    assert stop_times[0].arrival_status == 'none'
+    assert stop_times[0].arrival == datetime(2012, 11, 20, 11, 15)
+    assert stop_times[0].departure_status == 'add'
+    assert stop_times[0].departure == datetime(2012, 11, 20, 11, 15)
+    assert stop_times[1].arrival_status == 'delete'
+    assert stop_times[1].departure_status == 'delete'
+    assert stop_times[2].arrival_status == 'add'
+    assert stop_times[2].arrival == datetime(2012, 11, 20, 14, 15)
+    assert stop_times[2].departure_status == 'add'
+    assert stop_times[2].departure == datetime(2012, 11, 20, 14, 25)
+    assert stop_times[3].arrival_status == 'add'
+    assert stop_times[3].arrival == datetime(2012, 11, 20, 15, 15)
+    assert stop_times[3].departure_status == 'add'
+    assert stop_times[3].departure == datetime(2012, 11, 20, 15, 25)
+    assert stop_times[4].arrival_status == 'add'
+    assert stop_times[4].arrival == datetime(2012, 11, 20, 16, 15)
+    assert stop_times[4].departure_status == 'none'
+    assert stop_times[4].departure == datetime(2012, 11, 20, 16, 15)
+
+
+def check_add_trip_151515_with_delay_and_an_add():
+    trips = TripUpdate.query.all()
+    assert len(trips) == 1
+    assert trips[0].status == 'add'
+    assert trips[0].effect == 'ADDITIONAL_SERVICE'
+    assert trips[0].company_id == 'company:OCE:SN'
+    stop_times = StopTimeUpdate.query.all()
+    assert len(stop_times ) == 6
+    assert stop_times [0].arrival_status == 'none'
+    assert stop_times [0].arrival == datetime(2012, 11, 20, 11, 15)
+    assert stop_times [0].departure_status == 'add'
+    assert stop_times [0].departure == datetime(2012, 11, 20, 11, 15)
+    assert stop_times [1].arrival_status == 'add'
+    assert stop_times [1].arrival == datetime(2012, 11, 20, 11, 45)
+    assert stop_times [1].departure_status == 'add'
+    assert stop_times [1].departure == datetime(2012, 11, 20, 11, 55)
+    assert stop_times [2].arrival_status == 'add'
+    assert stop_times [2].arrival == datetime(2012, 11, 20, 12, 15)
+    assert stop_times [2].departure_status == 'add'
+    assert stop_times [2].departure == datetime(2012, 11, 20, 12, 25)
+    assert stop_times [3].arrival_status == 'add'
+    assert stop_times [3].arrival == datetime(2012, 11, 20, 14, 15)
+    assert stop_times [3].departure_status == 'add'
+    assert stop_times [3].departure == datetime(2012, 11, 20, 14, 25)
+    assert stop_times [4].arrival_status == 'add'
+    assert stop_times [4].arrival == datetime(2012, 11, 20, 15, 15)
+    assert stop_times [4].departure_status == 'add'
+    assert stop_times [4].departure == datetime(2012, 11, 20, 15, 25)
+    assert stop_times [5].arrival_status == 'add'
+    assert stop_times [5].arrival == datetime(2012, 11, 20, 16, 15)
+    assert stop_times [5].departure_status == 'none'
+    assert stop_times [5].departure == datetime(2012, 11, 20, 16, 15)
+
+
+def test_cots_for_added_trip_chain_type_1():
     """
      1. A simple trip add with 5 stop_times all existing in navitia
      2. Trip modified with 15 minutes delay in each stop_times
+     3. Return to normal
     """
     cots_add_file = get_fixture_data('cots_train_151515_added_trip.json')
     res = api_post('/cots', data=cots_add_file)
@@ -1046,3 +1109,81 @@ def test_cots_for_added_trip():
     with app.app_context():
         assert len(RealTimeUpdate.query.all()) == 3
         check_add_trip_151515()
+
+
+def test_cots_for_added_trip_chain_type_2():
+    """
+     1. A simple trip add with 5 stop_times all existing in navitia
+     2. Trip modified with 15 minutes delay in each stop_times
+     3. Trip modified with a stop_time deleted in the above flux cots
+     4. Return to normal
+    """
+    cots_add_file = get_fixture_data('cots_train_151515_added_trip.json')
+    res = api_post('/cots', data=cots_add_file)
+    assert res == 'OK'
+    with app.app_context():
+        assert len(RealTimeUpdate.query.all()) == 1
+        check_add_trip_151515()
+
+    cots_add_file = get_fixture_data('cots_train_151515_added_trip_with_delay.json')
+    res = api_post('/cots', data=cots_add_file)
+    assert res == 'OK'
+    with app.app_context():
+        assert len(RealTimeUpdate.query.all()) == 2
+        check_add_trip_151515_with_delay()
+
+    cots_add_file = get_fixture_data('cots_train_151515_added_trip_with_delay_and_stop_time_deleted.json')
+    res = api_post('/cots', data=cots_add_file)
+    assert res == 'OK'
+    with app.app_context():
+        assert len(RealTimeUpdate.query.all()) == 3
+        check_add_trip_151515_with_delay_and_a_delete()
+
+    cots_add_file = get_fixture_data('cots_train_151515_added_trip_to_normal.json')
+    res = api_post('/cots', data=cots_add_file)
+    assert res == 'OK'
+    with app.app_context():
+        assert len(RealTimeUpdate.query.all()) == 4
+        check_add_trip_151515()
+
+
+def test_cots_for_added_trip_chain_type_3():
+    """
+     1. A simple trip add with 5 stop_times all existing in navitia
+     2. Trip modified with 15 minutes delay in each stop_times
+     3. Trip modified with a new stop_time added in the above flux cots
+     4. Delete the trip with "statutCirculationOPE": "SUPPRESSION" in all stop_times
+     """
+    cots_add_file = get_fixture_data('cots_train_151515_added_trip.json')
+    res = api_post('/cots', data=cots_add_file)
+    assert res == 'OK'
+    with app.app_context():
+        assert len(RealTimeUpdate.query.all()) == 1
+        check_add_trip_151515()
+
+    cots_add_file = get_fixture_data('cots_train_151515_added_trip_with_delay.json')
+    res = api_post('/cots', data=cots_add_file)
+    assert res == 'OK'
+    with app.app_context():
+        assert len(RealTimeUpdate.query.all()) == 2
+        check_add_trip_151515_with_delay()
+
+    cots_add_file = get_fixture_data('cots_train_151515_added_trip_with_delay_and_stop_time_added.json')
+    res = api_post('/cots', data=cots_add_file)
+    assert res == 'OK'
+    with app.app_context():
+        assert len(RealTimeUpdate.query.all()) == 3
+        check_add_trip_151515_with_delay_and_an_add()
+
+    cots_add_file = get_fixture_data('cots_train_151515_deleted_trip_with_delay_and_stop_time_added.json')
+    res = api_post('/cots', data=cots_add_file)
+    assert res == 'OK'
+    with app.app_context():
+        assert len(RealTimeUpdate.query.all()) == 4
+        trips = TripUpdate.query.all()
+        assert len(trips) == 1
+        assert trips[0].status == 'delete'
+        assert trips[0].effect == 'NO_SERVICE'
+        assert trips[0].company_id == 'company:OCE:SN'
+        stop_times = StopTimeUpdate.query.all()
+        assert len(stop_times) == 0

--- a/tests/integration/populate_pb_test.py
+++ b/tests/integration/populate_pb_test.py
@@ -434,8 +434,9 @@ def test_populate_pb_for_added_trip():
     with app.app_context():
         trip_update = TripUpdate()
         vj = VehicleJourney(navitia_vj,
-                            utc.localize(datetime.datetime(2015, 9, 8, 5, 10, 0)),
-                            utc.localize(datetime.datetime(2015, 9, 8, 8, 10, 0)))
+                            utc_since_dt=utc.localize(datetime.datetime(2015, 9, 8, 5, 10, 0)),
+                            utc_until_dt=utc.localize(datetime.datetime(2015, 9, 8, 8, 10, 0)),
+                            vj_start_dt=utc.localize(datetime.datetime(2015, 9, 8, 5, 10, 0)))
         trip_update.vj = vj
         trip_update.status = 'add'
         trip_update.effect = 'ADDITIONAL_SERVICE'

--- a/tests/integration/utils_sncf_test.py
+++ b/tests/integration/utils_sncf_test.py
@@ -589,7 +589,7 @@ def check_db_96231_trip_removal():
         assert db_trip_removal.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21, tzinfo=utc)
         assert db_trip_removal.vj_id == db_trip_removal.vj.id
         assert db_trip_removal.status == 'delete'
-        assert db_trip_removal.effect == 'SIGNIFICANT_DELAYS'
+        assert db_trip_removal.effect == 'NO_SERVICE'
         assert db_trip_removal.message is None
         # full trip removal : no stop_time to precise
         assert len(db_trip_removal.stop_time_updates) == 0

--- a/tests/mock_navitia/__init__.py
+++ b/tests/mock_navitia/__init__.py
@@ -55,6 +55,7 @@ import st_0087_319012_00
 import st_0087_683573_BV
 import st_0087_686667_BV
 import st_0087_751008_BV
+import physical_mode_LongDistanceTrain
 import logging
 
 mocks = [
@@ -83,7 +84,8 @@ mocks = [
     st_0087_686667_BV.response,
     st_0087_683573_BV.response,
     st_0087_319012_00.response,
-    st_0087_318964_BV.response
+    st_0087_318964_BV.response,
+    physical_mode_LongDistanceTrain.response
 ]
 _mock_navitia_call = {}
 for r in mocks:

--- a/tests/mock_navitia/__init__.py
+++ b/tests/mock_navitia/__init__.py
@@ -50,6 +50,11 @@ import st_713666
 import company_1187
 import empty_company_1180
 import company_OCETH
+import st_0087_318964_BV
+import st_0087_319012_00
+import st_0087_683573_BV
+import st_0087_686667_BV
+import st_0087_751008_BV
 import logging
 
 mocks = [
@@ -73,7 +78,12 @@ mocks = [
     st_713666.response,
     company_1187.response,
     empty_company_1180.response,
-    company_OCETH.response
+    company_OCETH.response,
+    st_0087_751008_BV.response,
+    st_0087_686667_BV.response,
+    st_0087_683573_BV.response,
+    st_0087_319012_00.response,
+    st_0087_318964_BV.response
 ]
 _mock_navitia_call = {}
 for r in mocks:

--- a/tests/mock_navitia/__init__.py
+++ b/tests/mock_navitia/__init__.py
@@ -56,6 +56,7 @@ import st_0087_683573_BV
 import st_0087_686667_BV
 import st_0087_751008_BV
 import physical_mode_LongDistanceTrain
+import st_0087_543009_BV
 import logging
 
 mocks = [
@@ -85,7 +86,8 @@ mocks = [
     st_0087_683573_BV.response,
     st_0087_319012_00.response,
     st_0087_318964_BV.response,
-    physical_mode_LongDistanceTrain.response
+    physical_mode_LongDistanceTrain.response,
+    st_0087_543009_BV.response
 ]
 _mock_navitia_call = {}
 for r in mocks:

--- a/tests/mock_navitia/physical_mode_LongDistanceTrain.py
+++ b/tests/mock_navitia/physical_mode_LongDistanceTrain.py
@@ -1,0 +1,51 @@
+# coding=utf-8
+#
+# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+import navitia_response
+
+response = navitia_response.NavitiaResponse()
+
+response.queries = [
+    'physical_modes/?filter=commercial_mode.id=commercial_mode:tgv - physical_mode.id=physical_mode:Coach&count=1'
+]
+
+response.response_code = 200
+
+response.json_response = """
+{
+  "physical_modes": [
+    {
+      "name": "Train grande vitesse",
+      "id": "physical_mode:LongDistanceTrain"
+    }
+  ]
+}
+"""

--- a/tests/mock_navitia/physical_mode_LongDistanceTrain.py
+++ b/tests/mock_navitia/physical_mode_LongDistanceTrain.py
@@ -34,7 +34,7 @@ import navitia_response
 response = navitia_response.NavitiaResponse()
 
 response.queries = [
-    'physical_modes/?filter=commercial_mode.id=commercial_mode:tgv - physical_mode.id=physical_mode:Coach&count=1'
+    'physical_modes/?filter=physical_mode.id=physical_mode:LongDistanceTrain&count=1'
 ]
 
 response.response_code = 200

--- a/tests/mock_navitia/st_0087_318964_BV.py
+++ b/tests/mock_navitia/st_0087_318964_BV.py
@@ -1,0 +1,83 @@
+# coding=utf-8
+#
+# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+import navitia_response
+
+response = navitia_response.NavitiaResponse()
+
+response.queries = [
+    'stop_points/?filter=stop_area.has_code("CR-CI-CH", "0087-318964-BV")&count=1'
+]
+
+response.response_code = 200
+
+response.json_response = """
+{
+"stop_points": [
+    {
+      "name": "gare de Avignon-TGV",
+      "links": [],
+      "coord": {
+        "lat": "43.921963",
+        "lon": "4.78616"
+      },
+      "label": "gare de Avignon-TGV",
+      "equipments": [],
+      "id": "stop_point:OCE:SP:CarTER-87318964",
+      "stop_area": {
+        "codes": [
+          {
+            "type": "CR-CI-CH",
+            "value": "0087-318964-BV"
+          },
+          {
+            "type": "UIC8",
+            "value": "87318964"
+          },
+          {
+            "type": "external_code",
+            "value": "OCE87318964"
+          }
+        ],
+        "name": "gare de Avignon-TGV",
+        "links": [],
+        "coord": {
+          "lat": "43.921963",
+          "lon": "4.78616"
+        },
+        "label": "gare de Avignon-TGV",
+        "timezone": "Europe/Paris",
+        "id": "stop_area:OCE:SA:87318964"
+      }
+    }
+  ]
+}
+"""

--- a/tests/mock_navitia/st_0087_319012_00.py
+++ b/tests/mock_navitia/st_0087_319012_00.py
@@ -1,0 +1,83 @@
+# coding=utf-8
+#
+# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+import navitia_response
+
+response = navitia_response.NavitiaResponse()
+
+response.queries = [
+    'stop_points/?filter=stop_area.has_code("CR-CI-CH", "0087-319012-00")&count=1'
+]
+
+response.response_code = 200
+
+response.json_response = """
+{
+"stop_points": [
+    {
+      "name": "gare de Aix-en-Provence-TGV",
+      "links": [],
+      "coord": {
+        "lat": "43.455151",
+        "lon": "5.317273"
+      },
+      "label": "gare de Aix-en-Provence-TGV",
+      "equipments": [],
+      "id": "stop_point:OCE:SP:CarTER-87319012",
+      "stop_area": {
+        "codes": [
+          {
+            "type": "CR-CI-CH",
+            "value": "0087-319012-00"
+          },
+          {
+            "type": "UIC8",
+            "value": "87319012"
+          },
+          {
+            "type": "external_code",
+            "value": "OCE87319012"
+          }
+        ],
+        "name": "gare de Aix-en-Provence-TGV",
+        "links": [],
+        "coord": {
+          "lat": "43.455151",
+          "lon": "5.317273"
+        },
+        "label": "gare de Aix-en-Provence-TGV",
+        "timezone": "Europe/Paris",
+        "id": "stop_area:OCE:SA:87319012"
+      }
+    }
+  ]
+}
+"""

--- a/tests/mock_navitia/st_0087_543009_BV.py
+++ b/tests/mock_navitia/st_0087_543009_BV.py
@@ -1,0 +1,83 @@
+# coding=utf-8
+#
+# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+import navitia_response
+
+response = navitia_response.NavitiaResponse()
+
+response.queries = [
+    'stop_points/?filter=stop_area.has_code("CR-CI-CH", "0087-543009-BV")&count=1'
+]
+
+response.response_code = 200
+
+response.json_response = """
+{
+"stop_points": [
+    {
+      "name": "gare de Marseille-St-Charles",
+      "links": [],
+      "coord": {
+        "lat": "43.30273",
+        "lon": "5.380659"
+      },
+      "label": "gare de Marseille-St-Charles",
+      "equipments": [],
+      "id": "stop_point:OCE:SP:CarTER-87543009",
+      "stop_area": {
+        "codes": [
+          {
+            "type": "CR-CI-CH",
+            "value": "0087-543009-BV"
+          },
+          {
+            "type": "UIC8",
+            "value": "87751008"
+          },
+          {
+            "type": "external_code",
+            "value": "OCE87751008"
+          }
+        ],
+        "name": "gare de Marseille-St-Charles",
+        "links": [],
+        "coord": {
+          "lat": "43.30273",
+          "lon": "5.380659"
+        },
+        "label": "gare de Orléans",
+        "timezone": "Europe/Paris",
+        "id": "stop_area:OCE:SA:87543009"
+      }
+    }
+  ]
+}
+"""

--- a/tests/mock_navitia/st_0087_683573_BV.py
+++ b/tests/mock_navitia/st_0087_683573_BV.py
@@ -1,0 +1,83 @@
+# coding=utf-8
+#
+# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+import navitia_response
+
+response = navitia_response.NavitiaResponse()
+
+response.queries = [
+    'stop_points/?filter=stop_area.has_code("CR-CI-CH", "0087-683573-BV")&count=1'
+]
+
+response.response_code = 200
+
+response.json_response = """
+{
+"stop_points": [
+    {
+      "name": "gare de Auxerre-St-Gervais",
+      "links": [],
+      "coord": {
+        "lat": "47.797592",
+        "lon": "3.585455"
+      },
+      "label": "gare de Auxerre-St-Gervais",
+      "equipments": [],
+      "id": "stop_point:OCE:SP:CarTER-87683573",
+      "stop_area": {
+        "codes": [
+          {
+            "type": "CR-CI-CH",
+            "value": "0087-683573-BV"
+          },
+          {
+            "type": "UIC8",
+            "value": "87683573"
+          },
+          {
+            "type": "external_code",
+            "value": "OCE87683573"
+          }
+        ],
+        "name": "gare de Auxerre-St-Gervais",
+        "links": [],
+        "coord": {
+          "lat": "47.797592",
+          "lon": "3.585455"
+        },
+        "label": "gare de Auxerre-St-Gervais",
+        "timezone": "Europe/Paris",
+        "id": "stop_area:OCE:SA:87683573"
+      }
+    }
+  ]
+}
+"""

--- a/tests/mock_navitia/st_0087_686667_BV.py
+++ b/tests/mock_navitia/st_0087_686667_BV.py
@@ -1,0 +1,83 @@
+# coding=utf-8
+#
+# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+import navitia_response
+
+response = navitia_response.NavitiaResponse()
+
+response.queries = [
+    'stop_points/?filter=stop_area.has_code("CR-CI-CH", "0087-686667-BV")&count=1'
+]
+
+response.response_code = 200
+
+response.json_response = """
+{
+"stop_points": [
+    {
+      "name": "Bercy",
+      "links": [],
+      "coord": {
+        "lat": "48.838279",
+        "lon": "2.382218"
+      },
+      "label": "Bercy",
+      "equipments": [],
+      "id": "stop_point:RAT:SP:bercy",
+      "stop_area": {
+        "codes": [
+          {
+            "type": "CR-CI-CH",
+            "value": "0087-686667-BV"
+          },
+          {
+            "type": "UIC8",
+            "value": "87686667"
+          },
+          {
+            "type": "external_code",
+            "value": "OCE87686667"
+          }
+        ],
+        "name": "gare de Paris-Bercy",
+        "links": [],
+        "coord": {
+          "lat": "48.839214",
+          "lon": "2.382817"
+        },
+        "label": "gare de Paris-Bercy",
+        "timezone": "Europe/Paris",
+        "id": "stop_area:OCE:SA:87686667"
+      }
+    }
+  ]
+}
+"""

--- a/tests/mock_navitia/st_0087_751008_BV.py
+++ b/tests/mock_navitia/st_0087_751008_BV.py
@@ -1,0 +1,83 @@
+# coding=utf-8
+#
+# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+import navitia_response
+
+response = navitia_response.NavitiaResponse()
+
+response.queries = [
+    'stop_points/?filter=stop_area.has_code("CR-CI-CH", "0087-751008-BV")&count=1'
+]
+
+response.response_code = 200
+
+response.json_response = """
+{
+"stop_points": [
+    {
+      "name": "gare de Marseille-St-Charles",
+      "links": [],
+      "coord": {
+        "lat": "43.30273",
+        "lon": "5.380659"
+      },
+      "label": "gare de Marseille-St-Charles",
+      "equipments": [],
+      "id": "stop_point:OCE:SP:CarTER-87751008",
+      "stop_area": {
+        "codes": [
+          {
+            "type": "CR-CI-CH",
+            "value": "0087-751008-BV"
+          },
+          {
+            "type": "UIC8",
+            "value": "87751008"
+          },
+          {
+            "type": "external_code",
+            "value": "OCE87751008"
+          }
+        ],
+        "name": "gare de Marseille-St-Charles",
+        "links": [],
+        "coord": {
+          "lat": "43.30273",
+          "lon": "5.380659"
+        },
+        "label": "gare de Marseille-St-Charles",
+        "timezone": "Europe/Paris",
+        "id": "stop_area:OCE:SA:87751008"
+      }
+    }
+  ]
+}
+"""


### PR DESCRIPTION
This PR manages an added trip with stop_times and the details are as follows:

- Attribut physical_mode_id added in the table trip_update
- call to navitia to get physical_mode_id using "indicateurFer" and "codeMarqueTransporteur" in the flux cots.
- Extention physical_mode_id added VehicleDescriptor
- Some tests added

Concerned tickets:
https://jira.kisio.org/browse/NAVP-1061
https://jira.kisio.org/browse/NAVP-1062
https://jira.kisio.org/browse/NAVP-1063
