### PR TITLE
Datetime overflow bugfix

### DIFF
--- a/kirin/core/handler.py
+++ b/kirin/core/handler.py
@@ -448,7 +448,7 @@ def merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete=False):
         # (after delay it may be inconsistent but it is corrected later in the process)
         # it is not a pass-midnight if after delay it is consistent
         # (in case of stop add, comparing before delay is pointless)
-        date = datetime.date(1, 1, 1)
+        date = datetime.date(2000, 1, 1)
         return (prev_stop_event.time > next_stop_event.time) and \
                (datetime.datetime.combine(date, prev_stop_event.time) + prev_stop_event.delay
                 > datetime.datetime.combine(date, next_stop_event.time) + next_stop_event.delay)

--- a/tests/integration/gtfs_rt_test.py
+++ b/tests/integration/gtfs_rt_test.py
@@ -1833,5 +1833,5 @@ def test_gtfs_pass_midnight_negative_delay_utc_model_builder(pass_midnight_negat
         assert fourth_stop.departure_delay == timedelta(minutes=-1)
         assert fourth_stop.message is None
 
-        # feed = convert_to_gtfsrt(trip_updates)
-        # assert feed.entity[0].trip_update.trip.start_date == u'20120615'  # must be UTC start date
+        feed = convert_to_gtfsrt(trip_updates)
+        assert feed.entity[0].trip_update.trip.start_date == u'20120615'  # must be UTC start date


### PR DESCRIPTION
Bug happened on a VJ where the stop-event passing midnight (UTC time) is brought back to previous day by an early passage (negative delay).

Lead to a situation where time+delay < 0, and the resulting datetime was BC (not valid). So it's more an "underflow" :wink: 
> This situation was tested only when base-schedule stop-event was passing midnight

JIRA: https://jira.kisio.org/browse/NAVP-1255