### PR TITLE
Fix purge

### DIFF
--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -439,8 +439,9 @@ class RealTimeUpdate(db.Model, TimestampMixin):
             outerjoin(associate_realtimeupdate_tripupdate).\
             filter(cls.connector.in_(connectors)).\
             filter(cls.created_at <= until).\
-            filter(associate_realtimeupdate_tripupdate.c.real_time_update_id is None)
+            filter(associate_realtimeupdate_tripupdate.c.real_time_update_id == None)  # '==' works, not 'is'
         cls.query.filter(cls.id.in_(sub_query)).delete(synchronize_session=False)
+
         db.session.commit()
 
     @classmethod

--- a/tests/integration/gtfs_rt_test.py
+++ b/tests/integration/gtfs_rt_test.py
@@ -33,10 +33,11 @@ from datetime import timedelta
 import datetime
 import pytest
 from pytz import utc
-from kirin.core.model import RealTimeUpdate, db, TripUpdate, StopTimeUpdate
+from kirin.core.model import RealTimeUpdate, db, TripUpdate, StopTimeUpdate, VehicleJourney
 from kirin.core.populate_pb import to_posix_time, convert_to_gtfsrt
 from kirin import gtfs_rt
 from kirin.core.types import TripEffect
+from kirin.tasks import purge_trip_update, purge_rt_update
 from tests import mock_navitia
 from tests.check_utils import dumb_nav_wrapper, api_post
 from kirin import gtfs_realtime_pb2, app
@@ -194,6 +195,7 @@ def test_gtfs_model_builder(basic_gtfs_rt_data, basic_gtfs_rt_data_without_delay
         assert len(trip_updates) == 1
         assert trip_updates[0].effect == 'UNKNOWN_EFFECT'
 
+
 def test_gtfs_rt_simple_delay(basic_gtfs_rt_data, mock_rabbitmq):
     """
     test the gtfs-rt post with a simple gtfs-rt
@@ -262,6 +264,48 @@ def test_gtfs_rt_simple_delay(basic_gtfs_rt_data, mock_rabbitmq):
         assert fourth_stop.departure_status == 'none'
         assert fourth_stop.departure == datetime.datetime(2012, 6, 15, 15, 33)
         assert fourth_stop.message is None
+
+
+def test_gtfs_rt_purge(basic_gtfs_rt_data, mock_rabbitmq):
+    """
+    POST a simple gtfs-rt, then test the purge
+    """
+    tester = app.test_client()
+    resp = tester.post('/gtfs_rt', data=basic_gtfs_rt_data.SerializeToString())
+    assert resp.status_code == 200
+
+    with app.app_context():
+        # Check there's really something before purge
+        assert len(RealTimeUpdate.query.all()) == 1
+        assert len(TripUpdate.query.all()) == 1
+        assert len(VehicleJourney.query.all()) == 1
+        assert len(StopTimeUpdate.query.all()) == 4
+        assert db.session.execute('select * from associate_realtimeupdate_tripupdate').rowcount == 1
+
+        # VehicleJourney is old, so it's affected by TripUpdate purge
+        config = {'contributor': app.config.get('GTFS_RT_CONTRIBUTOR'),
+                  'nb_days_to_keep': int(app.config.get('NB_DAYS_TO_KEEP_TRIP_UPDATE'))}
+        purge_trip_update(config)
+
+        assert len(TripUpdate.query.all()) == 0
+        assert len(VehicleJourney.query.all()) == 0
+        assert len(StopTimeUpdate.query.all()) == 0
+        assert db.session.execute('select * from associate_realtimeupdate_tripupdate').rowcount == 0
+        assert len(RealTimeUpdate.query.all()) == 1  # keeping RTU longer for potential debug need
+
+        # Put an old date to RealTimeUpdate object so that RTU purge affects it
+        rtu = RealTimeUpdate.query.all()[0]
+        rtu.created_at = datetime.datetime(2012, 6, 15, 15, 33)
+
+        config = {'nb_days_to_keep': int(app.config.get('NB_DAYS_TO_KEEP_RT_UPDATE')),
+                  'connector': 'gtfs-rt'}
+        purge_rt_update(config)
+
+        assert len(TripUpdate.query.all()) == 0
+        assert len(VehicleJourney.query.all()) == 0
+        assert len(StopTimeUpdate.query.all()) == 0
+        assert db.session.execute('select * from associate_realtimeupdate_tripupdate').rowcount == 0
+        assert len(RealTimeUpdate.query.all()) == 0
 
 
 @pytest.fixture()


### PR DESCRIPTION
After https://jira.kisio.org/browse/NAVITIAII-2753
Purge of TripUpdate (actually all but RealTimeUpdate) was OK, but purge of RealTimeUpdate (where original feed is stored) was KO.

`is None` seems to be causing early interpretation to just `false` for the whole filter.
So with this PR pep8 is :angry:, but SQLAlchemy is :grinning: !

The first version affected by this bug is `0.8.0`.

TODO:
- [x] test one level down to avoid using redis
- [X] create a ticket to add a redis docker for tests (and to come back one level up on this test) : https://jira.kisio.org/browse/NAVP-1336