### PR TITLE
Add new contributor table to the db model

### DIFF
--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -312,7 +312,6 @@ class TripUpdate(db.Model, TimestampMixin):  # type: ignore
     message = db.Column(db.Text, nullable=True)
     contributor = db.Column(db.Text, nullable=True)
     db.Index("contributor_idx", contributor)
-    contributor_id = db.Column("contributor_id", postgresql.UUID, db.ForeignKey("contributor.id"))
     stop_time_updates = db.relationship(
         "StopTimeUpdate",
         backref="trip_update",

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -520,14 +520,14 @@ class Contributor(db.Model):  # type: ignore
     """
 
     id = db.Column(db.Text, nullable=False, primary_key=True)
-    coverage = db.Column(db.Text, nullable=False)
-    token = db.Column(db.Text, nullable=True)
+    navitia_coverage = db.Column(db.Text, nullable=False)
+    navitia_token = db.Column(db.Text, nullable=True)
     feed_url = db.Column(db.Text, nullable=True)
     connector_type = db.Column(Db_ConnectorType, nullable=False)
 
-    def __init__(self, id, coverage, connector_type, token=None, feed_url=None):
+    def __init__(self, id, navitia_coverage, connector_type, navitia_token=None, feed_url=None):
         self.id = id
-        self.coverage = coverage
+        self.navitia_coverage = navitia_coverage
         self.connector_type = connector_type
-        self.token = token
+        self.navitia_token = navitia_token
         self.feed_url = feed_url

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -79,6 +79,7 @@ class TimestampMixin(object):
 
 Db_TripEffect = db.Enum(*[e.name for e in TripEffect], name="trip_effect")
 Db_ModificationType = db.Enum(*[t.name for t in ModificationType], name="modification_type")
+Db_connector_type = db.Enum("cots", "gtfs-rt", name="connector_type", metadata=meta)
 
 
 def get_utc_timezoned_timestamp_safe(timestamp):
@@ -434,7 +435,7 @@ class RealTimeUpdate(db.Model, TimestampMixin):  # type: ignore
 
     id = db.Column(postgresql.UUID, default=gen_uuid, primary_key=True)
     received_at = db.Column(db.DateTime, nullable=False)
-    connector = db.Column(db.Enum("cots", "gtfs-rt", name="connector_type"), nullable=False)
+    connector = db.Column(Db_connector_type, nullable=False)
     status = db.Column(db.Enum("OK", "KO", "pending", name="rt_status"), nullable=False)
     db.Index("status_idx", status)
     error = db.Column(db.Text, nullable=True)

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -516,7 +516,7 @@ class RealTimeUpdate(db.Model, TimestampMixin):  # type: ignore
 class Contributor(db.Model):  # type: ignore
     """
     Contributor models a feeder for a specific coverage.
-    It's ID refers to its Kraken's name (eg. 'realtime.bla')
+    Its ID refers to its Kraken's name (eg. 'realtime.bla')
     """
 
     id = db.Column(db.Text, nullable=False, primary_key=True)

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -517,18 +517,17 @@ class RealTimeUpdate(db.Model, TimestampMixin):  # type: ignore
 class Contributor(db.Model):  # type: ignore
     """
     Contributor models a feeder for a specific coverage.
+    It's ID refers to its Kraken's name (eg. 'realtime.bla')
     """
 
-    id = db.Column(postgresql.UUID, default=gen_uuid, primary_key=True)
-    name = db.Column(db.Text, nullable=False)
+    id = db.Column(db.Text, nullable=False, primary_key=True)
     coverage = db.Column(db.Text, nullable=False)
     token = db.Column(db.Text, nullable=True)
     feed_url = db.Column(db.Text, nullable=True)
     connector_type = db.Column(Db_ConnectorType, nullable=False)
 
-    def __init__(self, name, coverage, connector_type, token=None, feed_url=None):
-        self.id = gen_uuid()
-        self.name = name
+    def __init__(self, id, coverage, connector_type, token=None, feed_url=None):
+        self.id = id
         self.coverage = coverage
         self.connector_type = connector_type
         self.token = token

--- a/kirin/core/types.py
+++ b/kirin/core/types.py
@@ -72,6 +72,16 @@ class TripEffect(Enum):
     STOP_MOVED = 9
 
 
+class ConnectorType(Enum):
+    """
+    Represent the type of data provided by a connector.
+
+    """
+
+    cots = "cots"
+    gtfs_rt = "gtfs-rt"
+
+
 def get_higher_status(st1, st2):
     return max([st1, st2], key=get_modification_type_order)
 

--- a/migrations/versions/53647ffeb3c6_add_contributor.py
+++ b/migrations/versions/53647ffeb3c6_add_contributor.py
@@ -19,8 +19,7 @@ from kirin.core import model
 def upgrade():
     op.create_table(
         "contributor",
-        sa.Column("id", postgresql.UUID(), nullable=False),
-        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("id", sa.Text(), nullable=False),
         sa.Column("coverage", sa.Text(), nullable=False),
         sa.Column("token", sa.Text(), nullable=True),
         sa.Column("feed_url", sa.Text(), nullable=True),
@@ -34,12 +33,11 @@ def upgrade():
 
     op.add_column(
         "real_time_update",
-        sa.Column("contributor_id", postgresql.UUID(), sa.ForeignKey("contributor.id"), nullable=True),
+        sa.Column("contributor_id", sa.Text(), sa.ForeignKey("contributor.id"), nullable=True),
     )
 
     op.add_column(
-        "trip_update",
-        sa.Column("contributor_id", postgresql.UUID(), sa.ForeignKey("contributor.id"), nullable=True),
+        "trip_update", sa.Column("contributor_id", sa.Text(), sa.ForeignKey("contributor.id"), nullable=True)
     )
 
 

--- a/migrations/versions/53647ffeb3c6_add_contributor.py
+++ b/migrations/versions/53647ffeb3c6_add_contributor.py
@@ -20,8 +20,8 @@ def upgrade():
     op.create_table(
         "contributor",
         sa.Column("id", sa.Text(), nullable=False),
-        sa.Column("coverage", sa.Text(), nullable=False),
-        sa.Column("token", sa.Text(), nullable=True),
+        sa.Column("navitia_coverage", sa.Text(), nullable=False),
+        sa.Column("navitia_token", sa.Text(), nullable=True),
         sa.Column("feed_url", sa.Text(), nullable=True),
         sa.Column(
             "connector_type",

--- a/migrations/versions/53647ffeb3c6_add_contributor.py
+++ b/migrations/versions/53647ffeb3c6_add_contributor.py
@@ -1,0 +1,45 @@
+"""add contributor
+
+Revision ID: 53647ffeb3c6
+Revises: 4db0c66c3caf
+Create Date: 2019-08-13 12:36:25.829578
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "53647ffeb3c6"
+down_revision = "4db0c66c3caf"
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from kirin.core import model
+
+
+def upgrade():
+    op.create_table(
+        "contributor",
+        sa.Column("id", postgresql.UUID(), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("coverage", sa.Text(), nullable=False),
+        sa.Column("token", sa.Text(), nullable=True),
+        sa.Column("feed_url", sa.Text(), nullable=True),
+        sa.Column("connector_type", model.Db_connector_type, nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.add_column(
+        "real_time_update",
+        sa.Column("contributor_id", postgresql.UUID(), sa.ForeignKey("contributor.id"), nullable=True),
+    )
+
+    op.add_column(
+        "trip_update",
+        sa.Column("contributor_id", postgresql.UUID(), sa.ForeignKey("contributor.id"), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("real_time_update", "contributor_id")
+    op.drop_column("trip_update", "contributor_id")
+    op.drop_table("contributor")

--- a/migrations/versions/53647ffeb3c6_add_contributor.py
+++ b/migrations/versions/53647ffeb3c6_add_contributor.py
@@ -24,7 +24,11 @@ def upgrade():
         sa.Column("coverage", sa.Text(), nullable=False),
         sa.Column("token", sa.Text(), nullable=True),
         sa.Column("feed_url", sa.Text(), nullable=True),
-        sa.Column("connector_type", model.Db_connector_type, nullable=False),
+        sa.Column(
+            "connector_type",
+            sa.Enum("cots", "gtfs-rt", name="connector_type", metadata=model.meta),
+            nullable=False,
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
 

--- a/migrations/versions/53647ffeb3c6_add_contributor.py
+++ b/migrations/versions/53647ffeb3c6_add_contributor.py
@@ -31,17 +31,6 @@ def upgrade():
         sa.PrimaryKeyConstraint("id"),
     )
 
-    op.add_column(
-        "real_time_update",
-        sa.Column("contributor_id", sa.Text(), sa.ForeignKey("contributor.id"), nullable=True),
-    )
-
-    op.add_column(
-        "trip_update", sa.Column("contributor_id", sa.Text(), sa.ForeignKey("contributor.id"), nullable=True)
-    )
-
 
 def downgrade():
-    op.drop_column("real_time_update", "contributor_id")
-    op.drop_column("trip_update", "contributor_id")
     op.drop_table("contributor")

--- a/tests/integration/model_test.py
+++ b/tests/integration/model_test.py
@@ -32,7 +32,8 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 from pytz import utc
 
-from kirin.core.model import VehicleJourney, TripUpdate, StopTimeUpdate, RealTimeUpdate
+from kirin.core.model import VehicleJourney, TripUpdate, StopTimeUpdate, RealTimeUpdate, Contributor
+from kirin.core.types import ConnectorType
 from kirin import db, app
 import datetime
 import pytest
@@ -429,3 +430,19 @@ def test_update_stoptime():
 
         st.update_departure(time=None, status=None, delay=datetime.timedelta(minutes=0))
         assert st.departure_delay == datetime.timedelta(minutes=0)
+
+
+def test_contributor_creation():
+    with app.app_context():
+        cots = Contributor("george", "idf", ConnectorType.cots.value)
+        gtfs_rt = Contributor("gerard", "idf", ConnectorType.gtfs_rt.value)
+
+        db.session.add(cots)
+        db.session.add(gtfs_rt)
+        db.session.commit()
+
+        assert cots.id is not None
+        assert cots != gtfs_rt.id
+        assert cots.name == "george"
+        assert cots.coverage == "idf"
+        assert cots.connector_type == ConnectorType.cots.value

--- a/tests/integration/model_test.py
+++ b/tests/integration/model_test.py
@@ -434,15 +434,13 @@ def test_update_stoptime():
 
 def test_contributor_creation():
     with app.app_context():
-        cots = Contributor("george", "idf", ConnectorType.cots.value)
-        gtfs_rt = Contributor("gerard", "idf", ConnectorType.gtfs_rt.value)
+        contrib = Contributor("realtime.george", "idf", ConnectorType.cots.value)
 
-        db.session.add(cots)
-        db.session.add(gtfs_rt)
+        db.session.add(contrib)
         db.session.commit()
 
-        assert cots.id is not None
-        assert cots != gtfs_rt.id
-        assert cots.name == "george"
-        assert cots.coverage == "idf"
-        assert cots.connector_type == ConnectorType.cots.value
+        assert contrib.id == "realtime.george"
+        assert contrib.coverage == "idf"
+        assert contrib.connector_type == ConnectorType.cots.value
+
+        Contributor("realtime.george", "another-coverage", ConnectorType.cots.value)

--- a/tests/integration/model_test.py
+++ b/tests/integration/model_test.py
@@ -441,7 +441,7 @@ def test_contributor_creation():
         db.session.commit()
 
         assert contrib.id == "realtime.george"
-        assert contrib.coverage == "idf"
+        assert contrib.navitia_coverage == "idf"
         assert contrib.connector_type == ConnectorType.cots.value
 
         contrib_with_same_id = Contributor("realtime.george", "another-coverage", ConnectorType.cots.value)

--- a/tests/integration/model_test.py
+++ b/tests/integration/model_test.py
@@ -37,6 +37,7 @@ from kirin.core.types import ConnectorType
 from kirin import db, app
 import datetime
 import pytest
+import sqlalchemy
 
 
 def create_trip_update(vj_id, trip_id, circulation_date):
@@ -443,4 +444,11 @@ def test_contributor_creation():
         assert contrib.coverage == "idf"
         assert contrib.connector_type == ConnectorType.cots.value
 
-        Contributor("realtime.george", "another-coverage", ConnectorType.cots.value)
+        contrib_with_same_id = Contributor("realtime.george", "another-coverage", ConnectorType.cots.value)
+
+        with pytest.raises(sqlalchemy.orm.exc.FlushError):
+            """
+            Adding a second contributor with the same id should fail
+            """
+            db.session.add(contrib_with_same_id)
+            db.session.commit()


### PR DESCRIPTION
To enable multiple GTFS-RT feeds, we want to upgrade the db model with a new table that will record the new contributors.

The new table `contributor` is defined as follow:

column | type | option
--------- | ----- | -------------- 
"id" | sa.Text() (eg. realtime.sherbrook) | primary_key
"name"| sa.Text() | 
"coverage" | sa.Text() |
"token" | sa.Text() | nullable
"feed_url" | sa.Text() | nullable
"connector_type" | Enum={cots, gtfs-rt} |

The 2 tables `real_time_update` and `trip_update` now take a new foreign key on `contributor.id`. This foreign key is nullable to accommodate the migration.

https://jira.kisio.org/browse/NAVP-1372