### PR TITLE
Full naive datetime

### DIFF
--- a/kirin/abstract_sncf_model_maker.py
+++ b/kirin/abstract_sncf_model_maker.py
@@ -35,7 +35,7 @@ from datetime import timedelta
 import jmespath
 
 from kirin.utils import record_internal_failure, to_navitia_utc_str
-from kirin.exceptions import ObjectNotFound, InvalidArguments
+from kirin.exceptions import ObjectNotFound, InvalidArguments, InternalException
 from abc import ABCMeta
 import six
 from kirin.core import model
@@ -132,8 +132,8 @@ class AbstractSNCFKirinModelBuilder(six.with_metaclass(ABCMeta, object)):
         if (naive_utc_since_dt is None) or (naive_utc_until_dt is None):
             return []
 
-        assert naive_utc_since_dt.tzinfo is None
-        assert naive_utc_until_dt.tzinfo is None
+        if naive_utc_since_dt.tzinfo is not None or naive_utc_until_dt.tzinfo is not None:
+            raise InternalException("Invalid datetime provided: must be naive (and UTC)")
 
         vjs = {}
         # to get the date of the vj we use the start/end of the vj + some tolerance

--- a/kirin/abstract_sncf_model_maker.py
+++ b/kirin/abstract_sncf_model_maker.py
@@ -132,6 +132,9 @@ class AbstractSNCFKirinModelBuilder(six.with_metaclass(ABCMeta, object)):
         if (naive_utc_since_dt is None) or (naive_utc_until_dt is None):
             return []
 
+        assert naive_utc_since_dt.tzinfo is None
+        assert naive_utc_until_dt.tzinfo is None
+
         vjs = {}
         # to get the date of the vj we use the start/end of the vj + some tolerance
         # since the SNCF data and navitia data might not be synchronized

--- a/kirin/abstract_sncf_model_maker.py
+++ b/kirin/abstract_sncf_model_maker.py
@@ -34,7 +34,7 @@ from datetime import timedelta
 
 import jmespath
 
-from kirin.utils import record_internal_failure
+from kirin.utils import record_internal_failure, to_navitia_utc_str
 from kirin.exceptions import ObjectNotFound, InvalidArguments
 from abc import ABCMeta
 import six
@@ -60,13 +60,6 @@ class ActionOnTrip(Enum):
 def make_navitia_empty_vj(headsign):
     headsign = TRAIN_ID_FORMAT.format(headsign)
     return {"id": headsign, "trip": {"id": headsign}}
-
-
-def to_navitia_str(dt):
-    """
-    format a datetime to a navitia-readable str
-    """
-    return dt.strftime("%Y%m%dT%H%M%S%z")
 
 
 def headsigns(str_headsign):
@@ -159,8 +152,8 @@ class AbstractSNCFKirinModelBuilder(six.with_metaclass(ABCMeta, object)):
             navitia_vjs = self.navitia.vehicle_journeys(
                 q={
                     "headsign": train_number,
-                    "since": to_navitia_str(extended_since_dt),
-                    "until": to_navitia_str(extended_until_dt),
+                    "since": to_navitia_utc_str(extended_since_dt),
+                    "until": to_navitia_utc_str(extended_until_dt),
                     "depth": "2",  # we need this depth to get the stoptime's stop_area
                     "show_codes": "true",  # we need the stop_points CRCICH codes
                 }

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -122,6 +122,11 @@ class VehicleJourney(db.Model):  # type: ignore
             typically the "until" parameter of the search in navitia.
         :param naive_vj_start_dt: naive UTC datetime of the first stop_time of vj.
         """
+        assert naive_utc_since_dt.tzinfo is None
+        assert naive_utc_until_dt.tzinfo is None
+        if naive_vj_start_dt is not None:
+            assert naive_vj_start_dt.tzinfo is None
+
         self.id = gen_uuid()
         if "trip" in navitia_vj and "id" in navitia_vj["trip"]:
             self.navitia_trip_id = navitia_vj["trip"]["id"]

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -113,7 +113,7 @@ class VehicleJourney(db.Model):  # type: ignore
         navitia_trip_id, start_timestamp, name="vehicle_journey_navitia_trip_id_start_timestamp_idx"
     )
 
-    def __init__(self, navitia_vj, utc_since_dt, utc_until_dt, vj_start_dt=None):
+    def __init__(self, navitia_vj, naive_utc_since_dt, naive_utc_until_dt, naive_vj_start_dt=None):
         """
         Create a circulation (VJ on a given day) from:
             * the navitia VJ (circulation times without a specific day)
@@ -131,11 +131,11 @@ class VehicleJourney(db.Model):  # type: ignore
               actual start-timestamp:        |                |                | 03T02:00       |
 
         :param navitia_vj: json dict of navitia's response when looking for a VJ.
-        :param utc_since_dt: UTC datetime BEFORE start of considered circulation,
+        :param naive_utc_since_dt: naive UTC datetime BEFORE start of considered circulation,
             typically the "since" parameter of the search in navitia.
-        :param utc_until_dt: UTC datetime AFTER start of considered circulation,
+        :param naive_utc_until_dt: naive UTC datetime AFTER start of considered circulation,
             typically the "until" parameter of the search in navitia.
-        :param vj_start_dt: UTC datetime of the first stop_time of vj.
+        :param naive_vj_start_dt: naive UTC datetime of the first stop_time of vj.
         """
         self.id = gen_uuid()
         if "trip" in navitia_vj and "id" in navitia_vj["trip"]:
@@ -143,8 +143,8 @@ class VehicleJourney(db.Model):  # type: ignore
 
         # For an added trip, we use vj_start_dt as in flux cots where as for existing one
         # compute start_timestamp (in UTC) from first stop_time, to be the closest AFTER provided utc_since_dt.
-        if not navitia_vj.get("stop_times", None) and vj_start_dt:
-            self.start_timestamp = vj_start_dt
+        if not navitia_vj.get("stop_times", None) and naive_vj_start_dt:
+            self.start_timestamp = naive_vj_start_dt
         else:
             first_stop_time = navitia_vj.get("stop_times", [{}])[0]
             start_time = first_stop_time["utc_arrival_time"]  # converted in datetime.time() in python wrapper
@@ -156,12 +156,12 @@ class VehicleJourney(db.Model):  # type: ignore
 
             # if since = 20010102T2300 and start_time = 0200, actual start_timestamp = 20010103T0200.
             # So adding one day to start_timestamp obtained (20010102T0200) if it's before since.
-            if self.start_timestamp < utc_since_dt:
+            if self.start_timestamp < naive_utc_since_dt:
                 self.start_timestamp += timedelta(days=1)
             # simple consistency check (for now): the start timestamp must also be BEFORE utc_until_dt
-            if utc_until_dt < self.start_timestamp:
+            if naive_utc_until_dt < self.start_timestamp:
                 msg = "impossible to calculate the circulation date of vj: {} on period [{}, {}]".format(
-                    navitia_vj.get("id"), utc_since_dt, utc_until_dt
+                    navitia_vj.get("id"), naive_utc_since_dt, naive_utc_until_dt
                 )
                 raise ObjectNotFound(msg)
 

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -38,7 +38,7 @@ import datetime
 import sqlalchemy
 from sqlalchemy import desc
 from kirin.core.types import ModificationType, TripEffect, ConnectorType
-from kirin.exceptions import ObjectNotFound
+from kirin.exceptions import ObjectNotFound, InternalException
 
 db = SQLAlchemy()
 
@@ -122,10 +122,12 @@ class VehicleJourney(db.Model):  # type: ignore
             typically the "until" parameter of the search in navitia.
         :param naive_vj_start_dt: naive UTC datetime of the first stop_time of vj.
         """
-        assert naive_utc_since_dt.tzinfo is None
-        assert naive_utc_until_dt.tzinfo is None
-        if naive_vj_start_dt is not None:
-            assert naive_vj_start_dt.tzinfo is None
+        if (
+            naive_utc_since_dt.tzinfo is not None
+            or naive_utc_until_dt.tzinfo is not None
+            or (naive_vj_start_dt is not None and naive_vj_start_dt.tzinfo is not None)
+        ):
+            raise InternalException("Invalid datetime provided: must be naive (and UTC)")
 
         self.id = gen_uuid()
         if "trip" in navitia_vj and "id" in navitia_vj["trip"]:

--- a/kirin/exceptions.py
+++ b/kirin/exceptions.py
@@ -58,6 +58,11 @@ class MessageNotPublished(KirinException):
     message = "impossible to publish message on network"
 
 
+class InternalException(KirinException):
+    code = 500
+    message = "an internal error occurred"
+
+
 class SubServiceError(KirinException):
     code = 404
     message = "object not found (error on sub-service)"

--- a/kirin/exceptions.py
+++ b/kirin/exceptions.py
@@ -45,7 +45,7 @@ class KirinException(HTTPException):
 
 class InvalidArguments(KirinException):
     code = 400
-    message = "Invalid arguments"
+    message = "invalid arguments"
 
 
 class ObjectNotFound(KirinException):

--- a/kirin/gtfs_rt/model_maker.py
+++ b/kirin/gtfs_rt/model_maker.py
@@ -36,7 +36,7 @@ import six
 from kirin import core
 from kirin.core import model
 from kirin.core.types import ModificationType, get_higher_status, get_effect_by_stop_time_status
-from kirin.exceptions import KirinException
+from kirin.exceptions import KirinException, InternalException
 from kirin.utils import make_rt_update, floor_datetime, to_navitia_utc_str
 from kirin.utils import record_internal_failure, record_call
 from kirin import app
@@ -199,8 +199,8 @@ class KirinModelBuilder(object):
         :param naive_utc_until_dt: naive UTC datetime that ends the search period.
             Typically the supposed datetime of last base-schedule stop_time.
         """
-        assert naive_utc_since_dt.tzinfo is None
-        assert naive_utc_until_dt.tzinfo is None
+        if naive_utc_since_dt.tzinfo is not None or naive_utc_until_dt.tzinfo is not None:
+            raise InternalException("Invalid datetime provided: must be naive (and UTC)")
         navitia_vjs = self.navitia.vehicle_journeys(
             q={
                 "filter": "vehicle_journey.has_code({}, {})".format(self.stop_code_key, vj_source_code),

--- a/kirin/gtfs_rt/model_maker.py
+++ b/kirin/gtfs_rt/model_maker.py
@@ -33,7 +33,6 @@ import datetime
 import logging
 
 import six
-from pytz import utc
 from kirin import core
 from kirin.core import model
 from kirin.core.types import ModificationType, get_higher_status, get_effect_by_stop_time_status
@@ -93,7 +92,7 @@ class KirinModelBuilder(object):
 
         The TripUpdates are not yet associated with the RealTimeUpdate
         """
-        utc_data_time = utc.localize(datetime.datetime.utcfromtimestamp(data.header.timestamp))
+        utc_data_time = datetime.datetime.utcfromtimestamp(data.header.timestamp)
         self.log.debug(
             "Start processing GTFS-rt: timestamp = {} ({})".format(data.header.timestamp, utc_data_time)
         )

--- a/kirin/gtfs_rt/model_maker.py
+++ b/kirin/gtfs_rt/model_maker.py
@@ -38,7 +38,7 @@ from kirin import core
 from kirin.core import model
 from kirin.core.types import ModificationType, get_higher_status, get_effect_by_stop_time_status
 from kirin.exceptions import KirinException
-from kirin.utils import make_rt_update, floor_datetime
+from kirin.utils import make_rt_update, floor_datetime, to_navitia_utc_str
 from kirin.utils import record_internal_failure, record_call
 from kirin import app
 import itertools
@@ -74,11 +74,6 @@ def handle(proto, navitia_wrapper, contributor):
     )
     record_call("Simple feed publication", **log_dict)
     logging.getLogger(__name__).info("Simple feed publication", extra=log_dict)
-
-
-def to_str(date):
-    # the date is in UTC, thus we don't have to care about the coverage's timezone
-    return date.strftime("%Y%m%dT%H%M%SZ")
 
 
 class KirinModelBuilder(object):
@@ -200,8 +195,8 @@ class KirinModelBuilder(object):
         navitia_vjs = self.navitia.vehicle_journeys(
             q={
                 "filter": "vehicle_journey.has_code({}, {})".format(self.stop_code_key, vj_source_code),
-                "since": to_str(utc_since_dt),
-                "until": to_str(utc_until_dt),
+                "since": to_navitia_utc_str(naive_utc_since_dt),
+                "until": to_navitia_utc_str(naive_utc_until_dt),
                 "depth": "2",  # we need this depth to get the stoptime's stop_area
             }
         )

--- a/kirin/gtfs_rt/model_maker.py
+++ b/kirin/gtfs_rt/model_maker.py
@@ -199,6 +199,8 @@ class KirinModelBuilder(object):
         :param naive_utc_until_dt: naive UTC datetime that ends the search period.
             Typically the supposed datetime of last base-schedule stop_time.
         """
+        assert naive_utc_since_dt.tzinfo is None
+        assert naive_utc_until_dt.tzinfo is None
         navitia_vjs = self.navitia.vehicle_journeys(
             q={
                 "filter": "vehicle_journey.has_code({}, {})".format(self.stop_code_key, vj_source_code),

--- a/kirin/utils.py
+++ b/kirin/utils.py
@@ -37,6 +37,8 @@ from aniso8601 import parse_date
 from pythonjsonlogger import jsonlogger
 from flask.globals import current_app
 import navitia_wrapper
+from pytz import utc
+
 from kirin import new_relic
 from redis.exceptions import ConnectionError
 from contextlib import contextmanager
@@ -81,6 +83,14 @@ def make_navitia_wrapper():
     token = current_app.config.get(str("NAVITIA_TOKEN"))
     instance = current_app.config[str("NAVITIA_INSTANCE")]
     return navitia_wrapper.Navitia(url=url, token=token).instance(instance)
+
+
+def to_navitia_utc_str(naive_utc_dt):
+    """
+    format a naive UTC datetime to a navitia-readable UTC-aware str
+    (to avoid managing coverage's timezone)
+    """
+    return utc.localize(naive_utc_dt).strftime("%Y%m%dT%H%M%S%z")
 
 
 def make_rt_update(data, connector, contributor, status="OK"):

--- a/kirin/utils.py
+++ b/kirin/utils.py
@@ -89,6 +89,7 @@ def to_navitia_utc_str(naive_utc_dt):
     format a naive UTC datetime to a navitia-readable UTC-aware str
     (to avoid managing coverage's timezone)
     """
+    assert naive_utc_dt.tzinfo is None
     return utc.localize(naive_utc_dt).strftime("%Y%m%dT%H%M%S%z")
 
 

--- a/kirin/utils.py
+++ b/kirin/utils.py
@@ -88,7 +88,8 @@ def make_navitia_wrapper():
 def to_navitia_utc_str(naive_utc_dt):
     """
     format a naive UTC datetime to a navitia-readable UTC-aware str
-    (to avoid managing coverage's timezone)
+    (to avoid managing coverage's timezone,
+    as Navitia considers datetime without timezone as local to the coverage)
     """
     if naive_utc_dt.tzinfo is not None:
         raise InternalException("Invalid datetime provided: must be naive (and UTC)")

--- a/kirin/utils.py
+++ b/kirin/utils.py
@@ -31,7 +31,6 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 import logging
 
-import pytz
 import six
 from aniso8601 import parse_date
 from pythonjsonlogger import jsonlogger
@@ -118,19 +117,6 @@ def record_call(status, **kwargs):
     params = {"status": status}
     params.update(kwargs)
     new_relic.record_custom_event("kirin_status", params)
-
-
-def get_timezone(stop_time):
-    # TODO: we must use the coverage timezone, not the stop_area timezone, as they can be different.
-    # We don't have this information now but we should have it in the near future
-    str_tz = stop_time.get("stop_point", {}).get("stop_area", {}).get("timezone")
-    if not str_tz:
-        raise Exception("impossible to convert local to utc without the timezone")
-
-    tz = pytz.timezone(str_tz)
-    if not tz:
-        raise Exception("impossible to find timezone: '{}'".format(str_tz))
-    return tz
 
 
 def should_retry_exception(exception):

--- a/kirin/utils.py
+++ b/kirin/utils.py
@@ -42,6 +42,7 @@ from kirin import new_relic
 from redis.exceptions import ConnectionError
 from contextlib import contextmanager
 from kirin.core import model
+from kirin.exceptions import InternalException
 
 
 def floor_datetime(datetime):
@@ -89,7 +90,8 @@ def to_navitia_utc_str(naive_utc_dt):
     format a naive UTC datetime to a navitia-readable UTC-aware str
     (to avoid managing coverage's timezone)
     """
-    assert naive_utc_dt.tzinfo is None
+    if naive_utc_dt.tzinfo is not None:
+        raise InternalException("Invalid datetime provided: must be naive (and UTC)")
     return utc.localize(naive_utc_dt).strftime("%Y%m%dT%H%M%S%z")
 
 

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -30,7 +30,6 @@
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
 from datetime import datetime
-from pytz import utc
 
 import pytest
 
@@ -164,7 +163,7 @@ def test_cots_delayed_simple_post(mock_rabbitmq):
         assert len(TripUpdate.query.all()) == 1
         assert len(StopTimeUpdate.query.all()) == 6
         db_trip_delayed = TripUpdate.find_by_dated_vj(
-            "trip:OCETrainTER-87212027-85000109-3:11859", datetime(2015, 9, 21, 15, 21, tzinfo=utc)
+            "trip:OCETrainTER-87212027-85000109-3:11859", datetime(2015, 9, 21, 15, 21)
         )
         assert db_trip_delayed.stop_time_updates[4].message is None
     db_trip_delayed = check_db_96231_delayed()

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -139,7 +139,7 @@ def test_save_bad_raw_cots():
     bad_cots = get_fixture_data("bad_cots.json")
     res = api_post("/cots", data=bad_cots, check=False)
     assert res[1] == 400
-    assert res[0]["message"] == "Invalid arguments"
+    assert res[0]["message"] == "invalid arguments"
     with app.app_context():
         assert len(RealTimeUpdate.query.all()) == 1
         assert RealTimeUpdate.query.first().status == "KO"
@@ -574,7 +574,7 @@ def test_wrong_planned_stop_time_reference_post():
     res, status = api_post("/cots", check=False, data=cots_file)
 
     assert status == 400
-    assert res.get("message") == "Invalid arguments"
+    assert res.get("message") == "invalid arguments"
     assert "error" in res
     assert 'invalid json, impossible to find source "ESCALE" in any json dict of list:' in res.get("error")
 
@@ -834,7 +834,7 @@ def test_cots_added_stop_time_earlier_than_previous():
     cots_add_file = get_fixture_data("cots_train_96231_add_stop_time_earlier_than_previous.json")
     res, status = api_post("/cots", data=cots_add_file, check=False)
     assert status == 400
-    assert res.get("message") == "Invalid arguments"
+    assert res.get("message") == "invalid arguments"
     with app.app_context():
         assert (
             RealTimeUpdate.query.first().error
@@ -1370,7 +1370,7 @@ def test_cots_add_trip_existing_in_navitia():
     cots_add_file = get_fixture_data("cots_train_6113_add_trip_present_in_navitia.json")
     res, status = api_post("/cots", check=False, data=cots_add_file)
     assert status == 400
-    assert res.get("message") == "Invalid arguments"
+    assert res.get("message") == "invalid arguments"
     assert "error" in res
     assert "Invalid action, trip 6113 already present in navitia" in res.get("error")
 

--- a/tests/integration/gtfs_rt_test.py
+++ b/tests/integration/gtfs_rt_test.py
@@ -33,7 +33,6 @@ from copy import deepcopy
 from datetime import timedelta
 import datetime
 import pytest
-from pytz import utc
 from kirin.core.model import RealTimeUpdate, db, TripUpdate, StopTimeUpdate, VehicleJourney
 from kirin.core.populate_pb import to_posix_time, convert_to_gtfsrt
 from kirin import gtfs_rt
@@ -444,7 +443,7 @@ def test_gtfs_rt_pass_midnight(pass_midnight_gtfs_rt_data, mock_rabbitmq):
 
         assert trip_update
 
-        assert trip_update.vj.get_start_timestamp() == datetime.datetime(2012, 6, 16, 3, 30, tzinfo=utc)
+        assert trip_update.vj.get_start_timestamp() == datetime.datetime(2012, 6, 16, 3, 30)
 
         # using navitia's time in UTC, and the stop is in sherbrooke, so UTC-4h
         first_stop = trip_update.stop_time_updates[0]
@@ -597,7 +596,7 @@ def test_gtfs_rt_pass_midnight_utc(pass_midnight_utc_gtfs_rt_data, mock_rabbitmq
 
         assert trip_update
 
-        assert trip_update.vj.get_start_timestamp() == datetime.datetime(2012, 6, 15, 23, 30, tzinfo=utc)
+        assert trip_update.vj.get_start_timestamp() == datetime.datetime(2012, 6, 15, 23, 30)
 
         # using navitia's time in UTC
         first_stop = trip_update.stop_time_updates[0]
@@ -1254,7 +1253,7 @@ def test_gtfs_lollipop_model_builder_with_post(lollipop_gtfs_rt_data):
 
             assert trip_update
 
-            assert trip_update.vj.get_start_timestamp() == datetime.datetime(2012, 6, 15, 14, 00, tzinfo=utc)
+            assert trip_update.vj.get_start_timestamp() == datetime.datetime(2012, 6, 15, 14, 00)
 
             first_stop = trip_update.stop_time_updates[0]
             assert first_stop.stop_id == "StopR1"
@@ -1445,7 +1444,7 @@ def test_gtfs_lollipop_with_second_passage_model_builder_with_post(lollipop_gtfs
 
             assert trip_update
 
-            assert trip_update.vj.get_start_timestamp() == datetime.datetime(2012, 6, 15, 14, 00, tzinfo=utc)
+            assert trip_update.vj.get_start_timestamp() == datetime.datetime(2012, 6, 15, 14, 00)
 
             first_stop = trip_update.stop_time_updates[0]
             assert first_stop.stop_id == "StopR1"
@@ -1645,7 +1644,7 @@ def test_gtfs_start_midnight_model_builder_with_post(gtfs_rt_data_with_vj_starti
 
             assert trip_update
 
-            assert trip_update.vj.get_start_timestamp() == datetime.datetime(2017, 12, 12, 5, 0, tzinfo=utc)
+            assert trip_update.vj.get_start_timestamp() == datetime.datetime(2017, 12, 12, 5, 0)
 
             first_stop = trip_update.stop_time_updates[0]
             assert first_stop.stop_id == "StopR1"
@@ -1710,7 +1709,7 @@ def test_gtfs_start_midnight_utc_model_builder_with_post(gtfs_rt_data_with_vj_st
 
             assert trip_update
 
-            assert trip_update.vj.get_start_timestamp() == datetime.datetime(2017, 12, 12, 00, 00, tzinfo=utc)
+            assert trip_update.vj.get_start_timestamp() == datetime.datetime(2017, 12, 12, 00, 00)
 
             first_stop = trip_update.stop_time_updates[0]
             assert first_stop.stop_id == "StopR1"

--- a/tests/integration/handle_test.py
+++ b/tests/integration/handle_test.py
@@ -32,7 +32,6 @@ from __future__ import absolute_import, print_function, unicode_literals, divisi
 from datetime import timedelta
 
 import pytest
-from pytz import utc
 
 from kirin.core.handler import handle
 from kirin.core.model import RealTimeUpdate, TripUpdate, VehicleJourney, StopTimeUpdate
@@ -50,8 +49,8 @@ def create_trip_update(id, trip_id, circulation_date, stops, status="update"):
                     {"utc_arrival_time": datetime.time(8, 10), "stop_point": {"stop_area": {"timezone": "UTC"}}}
                 ],
             },
-            utc.localize(datetime.datetime.combine(circulation_date, datetime.time(7, 10))),
-            utc.localize(datetime.datetime.combine(circulation_date, datetime.time(9, 10))),
+            datetime.datetime.combine(circulation_date, datetime.time(7, 10)),
+            datetime.datetime.combine(circulation_date, datetime.time(9, 10)),
         ),
         status,
     )
@@ -166,9 +165,7 @@ def navitia_vj():
 
 def _create_db_vj(navitia_vj):
     return VehicleJourney(
-        navitia_vj,
-        utc.localize(datetime.datetime(2015, 9, 8, 7, 10, 0)),
-        utc.localize(datetime.datetime(2015, 9, 8, 11, 5, 0)),
+        navitia_vj, datetime.datetime(2015, 9, 8, 7, 10, 0), datetime.datetime(2015, 9, 8, 11, 5, 0)
     )
 
 
@@ -265,9 +262,7 @@ def test_past_midnight():
     }
     with app.app_context():
         vj = VehicleJourney(
-            navitia_vj,
-            utc.localize(datetime.datetime(2015, 9, 8, 21, 15, 0)),
-            utc.localize(datetime.datetime(2015, 9, 9, 4, 20, 0)),
+            navitia_vj, datetime.datetime(2015, 9, 8, 21, 15, 0), datetime.datetime(2015, 9, 9, 4, 20, 0)
         )
         trip_update = TripUpdate(vj, status="update")
         st = StopTimeUpdate({"id": "sa:2"}, departure_delay=timedelta(minutes=31), dep_status="update", order=1)

--- a/tests/integration/model_test.py
+++ b/tests/integration/model_test.py
@@ -30,7 +30,6 @@
 # www.navitia.io
 
 from __future__ import absolute_import, print_function, unicode_literals, division
-from pytz import utc
 
 from kirin.core.model import VehicleJourney, TripUpdate, StopTimeUpdate, RealTimeUpdate, Contributor
 from kirin.core.types import ConnectorType
@@ -49,8 +48,8 @@ def create_trip_update(vj_id, trip_id, circulation_date):
                 {"utc_arrival_time": datetime.time(8, 0), "stop_point": {"stop_area": {"timezone": "UTC"}}}
             ],
         },
-        utc.localize(datetime.datetime.combine(circulation_date, datetime.time(7, 0))),
-        utc.localize(datetime.datetime.combine(circulation_date, datetime.time(9, 0))),
+        datetime.datetime.combine(circulation_date, datetime.time(7, 0)),
+        datetime.datetime.combine(circulation_date, datetime.time(9, 0)),
     )
     vj.id = vj_id
     trip_update.vj = vj

--- a/tests/integration/populate_pb_test.py
+++ b/tests/integration/populate_pb_test.py
@@ -31,8 +31,6 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 from datetime import timedelta
 
-from pytz import utc
-
 from kirin.core.model import RealTimeUpdate, TripUpdate, VehicleJourney, StopTimeUpdate
 from kirin.core.populate_pb import convert_to_gtfsrt, to_posix_time, fill_stop_times
 import datetime
@@ -67,9 +65,7 @@ def test_populate_pb_with_one_stop_time():
     with app.app_context():
         trip_update = TripUpdate()
         vj = VehicleJourney(
-            navitia_vj,
-            utc.localize(datetime.datetime(2015, 9, 8, 5, 10, 0)),
-            utc.localize(datetime.datetime(2015, 9, 8, 8, 10, 0)),
+            navitia_vj, datetime.datetime(2015, 9, 8, 5, 10, 0), datetime.datetime(2015, 9, 8, 8, 10, 0)
         )
         trip_update.vj = vj
         st = StopTimeUpdate({"id": "sa:1"}, departure=_dt("8:15"), arrival=None)
@@ -122,9 +118,7 @@ def test_populate_pb_with_two_stop_time():
     with app.app_context():
         trip_update = TripUpdate()
         vj = VehicleJourney(
-            navitia_vj,
-            utc.localize(datetime.datetime(2015, 9, 8, 5, 10, 0)),
-            utc.localize(datetime.datetime(2015, 9, 8, 8, 10, 0)),
+            navitia_vj, datetime.datetime(2015, 9, 8, 5, 10, 0), datetime.datetime(2015, 9, 8, 8, 10, 0)
         )
         trip_update.vj = vj
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
@@ -228,9 +222,7 @@ def test_populate_pb_with_deleted_stop_time():
     with app.app_context():
         trip_update = TripUpdate()
         vj = VehicleJourney(
-            navitia_vj,
-            utc.localize(datetime.datetime(2015, 9, 8, 5, 11, 0)),
-            utc.localize(datetime.datetime(2015, 9, 8, 10, 10, 0)),
+            navitia_vj, datetime.datetime(2015, 9, 8, 5, 11, 0), datetime.datetime(2015, 9, 8, 10, 10, 0)
         )
         trip_update.vj = vj
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
@@ -362,9 +354,7 @@ def test_populate_pb_with_cancelation():
     with app.app_context():
         trip_update = TripUpdate()
         vj = VehicleJourney(
-            navitia_vj,
-            utc.localize(datetime.datetime(2015, 9, 8, 7, 10, 0)),
-            utc.localize(datetime.datetime(2015, 9, 8, 11, 5, 0)),
+            navitia_vj, datetime.datetime(2015, 9, 8, 7, 10, 0), datetime.datetime(2015, 9, 8, 11, 5, 0)
         )
         trip_update.vj = vj
         trip_update.status = "delete"
@@ -409,9 +399,7 @@ def test_populate_pb_with_full_dataset():
     with app.app_context():
         trip_update = TripUpdate()
         vj = VehicleJourney(
-            navitia_vj,
-            utc.localize(datetime.datetime(2015, 9, 8, 7, 10, 0)),
-            utc.localize(datetime.datetime(2015, 9, 8, 9, 10, 0)),
+            navitia_vj, datetime.datetime(2015, 9, 8, 7, 10, 0), datetime.datetime(2015, 9, 8, 9, 10, 0)
         )
         trip_update.vj = vj
         trip_update.status = "delete"
@@ -508,9 +496,9 @@ def test_populate_pb_for_added_trip():
         trip_update = TripUpdate()
         vj = VehicleJourney(
             navitia_vj,
-            utc_since_dt=utc.localize(datetime.datetime(2015, 9, 8, 5, 10, 0)),
-            utc_until_dt=utc.localize(datetime.datetime(2015, 9, 8, 8, 10, 0)),
-            vj_start_dt=utc.localize(datetime.datetime(2015, 9, 8, 5, 10, 0)),
+            naive_utc_since_dt=datetime.datetime(2015, 9, 8, 5, 10, 0),
+            naive_utc_until_dt=datetime.datetime(2015, 9, 8, 8, 10, 0),
+            naive_vj_start_dt=datetime.datetime(2015, 9, 8, 5, 10, 0),
         )
         trip_update.vj = vj
         trip_update.status = "add"

--- a/tests/integration/test_end_point.py
+++ b/tests/integration/test_end_point.py
@@ -29,7 +29,6 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
-from pytz import utc
 
 from tests.check_utils import api_get
 from kirin.core import model
@@ -77,8 +76,8 @@ def setup_database():
                     {"utc_arrival_time": time(9, 0), "stop_point": {"stop_area": {"timezone": "Europe/Paris"}}}
                 ],
             },
-            utc.localize(datetime(2015, 11, 4, 8, 0, 0)),
-            utc.localize(datetime(2015, 11, 4, 10, 0, 0)),
+            datetime(2015, 11, 4, 8, 0, 0),
+            datetime(2015, 11, 4, 10, 0, 0),
         )
         vj2 = model.VehicleJourney(
             {
@@ -87,8 +86,8 @@ def setup_database():
                     {"utc_arrival_time": time(9, 0), "stop_point": {"stop_area": {"timezone": "Europe/Paris"}}}
                 ],
             },
-            utc.localize(datetime(2015, 11, 4, 8, 0, 0)),
-            utc.localize(datetime(2015, 11, 4, 10, 0, 0)),
+            datetime(2015, 11, 4, 8, 0, 0),
+            datetime(2015, 11, 4, 10, 0, 0),
         )
         vj3 = model.VehicleJourney(
             {
@@ -97,8 +96,8 @@ def setup_database():
                     {"utc_arrival_time": time(9, 0), "stop_point": {"stop_area": {"timezone": "Europe/Paris"}}}
                 ],
             },
-            utc.localize(datetime(2015, 11, 4, 8, 0, 0)),
-            utc.localize(datetime(2015, 11, 4, 10, 0, 0)),
+            datetime(2015, 11, 4, 8, 0, 0),
+            datetime(2015, 11, 4, 10, 0, 0),
         )
         tu1 = model.TripUpdate(vj1, contributor="realtime.cots")
         tu2 = model.TripUpdate(vj2, contributor="realtime.cots")

--- a/tests/integration/utils_sncf_test.py
+++ b/tests/integration/utils_sncf_test.py
@@ -33,7 +33,6 @@ from __future__ import absolute_import, print_function, unicode_literals, divisi
 from kirin import app
 from kirin.core.model import RealTimeUpdate, TripUpdate, StopTimeUpdate
 from datetime import timedelta, datetime
-from pytz import utc
 
 
 def check_db_96231_delayed(motif_externe_is_null=False):
@@ -42,12 +41,12 @@ def check_db_96231_delayed(motif_externe_is_null=False):
         assert len(TripUpdate.query.all()) >= 1
         assert len(StopTimeUpdate.query.all()) >= 6
         db_trip_delayed = TripUpdate.find_by_dated_vj(
-            "trip:OCETrainTER-87212027-85000109-3:11859", datetime(2015, 9, 21, 15, 21, tzinfo=utc)
+            "trip:OCETrainTER-87212027-85000109-3:11859", datetime(2015, 9, 21, 15, 21)
         )
         assert db_trip_delayed
 
         assert db_trip_delayed.vj.navitia_trip_id == "trip:OCETrainTER-87212027-85000109-3:11859"
-        assert db_trip_delayed.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21, tzinfo=utc)
+        assert db_trip_delayed.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21)
         assert db_trip_delayed.vj_id == db_trip_delayed.vj.id
         assert db_trip_delayed.status == "update"
         # Cots contain delayed stop_times only
@@ -114,11 +113,11 @@ def check_db_870154_partial_removal(contributor=None):
         assert len(RealTimeUpdate.query.all()) >= 1
         assert len(TripUpdate.query.all()) == 1
         assert len(StopTimeUpdate.query.all()) == 12
-        db_trip = TripUpdate.find_by_dated_vj("OCE:SN870154F01001", datetime(2018, 11, 2, 9, 54, tzinfo=utc))
+        db_trip = TripUpdate.find_by_dated_vj("OCE:SN870154F01001", datetime(2018, 11, 2, 9, 54))
         assert db_trip
 
         assert db_trip.vj.navitia_trip_id == "OCE:SN870154F01001"
-        assert db_trip.vj.get_start_timestamp() == datetime(2018, 11, 2, 9, 54, tzinfo=utc)
+        assert db_trip.vj.get_start_timestamp() == datetime(2018, 11, 2, 9, 54)
         assert db_trip.vj_id == db_trip.vj.id
         assert db_trip.status == "update"
         # Cots contain deleted as well as delayed stop_times
@@ -159,7 +158,7 @@ def check_db_870154_delay():
         assert len(RealTimeUpdate.query.all()) >= 1
         assert len(TripUpdate.query.all()) == 1
         assert len(StopTimeUpdate.query.all()) == 12
-        db_trip = TripUpdate.find_by_dated_vj("OCE:SN870154F01001", datetime(2018, 11, 2, 9, 54, tzinfo=utc))
+        db_trip = TripUpdate.find_by_dated_vj("OCE:SN870154F01001", datetime(2018, 11, 2, 9, 54))
         assert db_trip
         assert db_trip.message == "Régulation du trafic"
         # Cots contain deleted as well as delayed stop_times
@@ -249,7 +248,7 @@ def check_db_870154_normal():
         assert len(RealTimeUpdate.query.all()) >= 1
         assert len(TripUpdate.query.all()) == 1
         assert len(StopTimeUpdate.query.all()) == 12
-        db_trip = TripUpdate.find_by_dated_vj("OCE:SN870154F01001", datetime(2018, 11, 2, 9, 54, tzinfo=utc))
+        db_trip = TripUpdate.find_by_dated_vj("OCE:SN870154F01001", datetime(2018, 11, 2, 9, 54))
         assert db_trip
         assert db_trip.message is None
 
@@ -343,11 +342,11 @@ def check_db_870154_normal():
 def check_db_96231_mixed_statuses_inside_stops(contributor=None):
     with app.app_context():
         db_trip_delayed = TripUpdate.find_by_dated_vj(
-            "trip:OCETrainTER-87212027-85000109-3:11859", datetime(2015, 9, 21, 15, 21, tzinfo=utc)
+            "trip:OCETrainTER-87212027-85000109-3:11859", datetime(2015, 9, 21, 15, 21)
         )
         assert db_trip_delayed
         assert db_trip_delayed.vj.navitia_trip_id == "trip:OCETrainTER-87212027-85000109-3:11859"
-        assert db_trip_delayed.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21, tzinfo=utc)
+        assert db_trip_delayed.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21)
         assert db_trip_delayed.vj_id == db_trip_delayed.vj.id
         assert db_trip_delayed.status == "update"
         # Cots contain delayed as well as removed stop_times
@@ -418,11 +417,11 @@ def check_db_96231_mixed_statuses_inside_stops(contributor=None):
 def check_db_96231_mixed_statuses_delay_removal_delay(contributor=None):
     with app.app_context():
         db_trip_delayed = TripUpdate.find_by_dated_vj(
-            "trip:OCETrainTER-87212027-85000109-3:11859", datetime(2015, 9, 21, 15, 21, tzinfo=utc)
+            "trip:OCETrainTER-87212027-85000109-3:11859", datetime(2015, 9, 21, 15, 21)
         )
         assert db_trip_delayed
         assert db_trip_delayed.vj.navitia_trip_id == "trip:OCETrainTER-87212027-85000109-3:11859"
-        assert db_trip_delayed.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21, tzinfo=utc)
+        assert db_trip_delayed.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21)
         assert db_trip_delayed.vj_id == db_trip_delayed.vj.id
         assert db_trip_delayed.status == "update"
         # Cots contain removed as well as delayed stop_times
@@ -494,12 +493,12 @@ def check_db_96231_normal(contributor=None):
         assert len(TripUpdate.query.all()) >= 1
         assert len(StopTimeUpdate.query.all()) >= 6
         db_trip_delayed = TripUpdate.find_by_dated_vj(
-            "trip:OCETrainTER-87212027-85000109-3:11859", datetime(2015, 9, 21, 15, 21, tzinfo=utc)
+            "trip:OCETrainTER-87212027-85000109-3:11859", datetime(2015, 9, 21, 15, 21)
         )
         assert db_trip_delayed
 
         assert db_trip_delayed.vj.navitia_trip_id == "trip:OCETrainTER-87212027-85000109-3:11859"
-        assert db_trip_delayed.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21, tzinfo=utc)
+        assert db_trip_delayed.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21)
         assert db_trip_delayed.vj_id == db_trip_delayed.vj.id
         assert db_trip_delayed.status == "update"
         assert db_trip_delayed.effect == "SIGNIFICANT_DELAYS"
@@ -557,12 +556,12 @@ def check_db_john_trip_removal():
         assert len(TripUpdate.query.all()) >= 2
         assert len(StopTimeUpdate.query.all()) >= 0
         db_trip1_removal = TripUpdate.find_by_dated_vj(
-            "trip:OCETGV-87686006-87751008-2:25768", datetime(2015, 9, 21, 13, 37, tzinfo=utc)
+            "trip:OCETGV-87686006-87751008-2:25768", datetime(2015, 9, 21, 13, 37)
         )
         assert db_trip1_removal
 
         assert db_trip1_removal.vj.navitia_trip_id == "trip:OCETGV-87686006-87751008-2:25768"
-        assert db_trip1_removal.vj.get_start_timestamp() == datetime(2015, 9, 21, 13, 37, tzinfo=utc)
+        assert db_trip1_removal.vj.get_start_timestamp() == datetime(2015, 9, 21, 13, 37)
         assert db_trip1_removal.vj_id == db_trip1_removal.vj.id
         assert db_trip1_removal.status == "delete"
         assert db_trip1_removal.effect == "NO_SERVICE"
@@ -570,12 +569,12 @@ def check_db_john_trip_removal():
         assert len(db_trip1_removal.stop_time_updates) == 0
 
         db_trip2_removal = TripUpdate.find_by_dated_vj(
-            "trip:OCETrainTER-87212027-85000109-3:11859", datetime(2015, 9, 21, 15, 21, tzinfo=utc)
+            "trip:OCETrainTER-87212027-85000109-3:11859", datetime(2015, 9, 21, 15, 21)
         )
         assert db_trip2_removal
 
         assert db_trip2_removal.vj.navitia_trip_id == "trip:OCETrainTER-87212027-85000109-3:11859"
-        assert db_trip2_removal.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21, tzinfo=utc)
+        assert db_trip2_removal.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21)
         assert db_trip2_removal.vj_id == db_trip2_removal.vj.id
         assert db_trip2_removal.status == "delete"
         assert db_trip2_removal.effect == "NO_SERVICE"
@@ -589,12 +588,12 @@ def check_db_96231_trip_removal():
         assert len(TripUpdate.query.all()) >= 1
         assert len(StopTimeUpdate.query.all()) >= 0
         db_trip_removal = TripUpdate.find_by_dated_vj(
-            "trip:OCETrainTER-87212027-85000109-3:11859", datetime(2015, 9, 21, 15, 21, tzinfo=utc)
+            "trip:OCETrainTER-87212027-85000109-3:11859", datetime(2015, 9, 21, 15, 21)
         )
         assert db_trip_removal
 
         assert db_trip_removal.vj.navitia_trip_id == "trip:OCETrainTER-87212027-85000109-3:11859"
-        assert db_trip_removal.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21, tzinfo=utc)
+        assert db_trip_removal.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21)
         assert db_trip_removal.vj_id == db_trip_removal.vj.id
         assert db_trip_removal.status == "delete"
         assert db_trip_removal.effect == "NO_SERVICE"
@@ -609,12 +608,12 @@ def check_db_6113_trip_removal():
         assert len(TripUpdate.query.all()) >= 1
         assert len(StopTimeUpdate.query.all()) >= 0
         db_trip_removal = TripUpdate.find_by_dated_vj(
-            "trip:OCETGV-87686006-87751008-2:25768", datetime(2015, 10, 6, 10, 37, tzinfo=utc)
+            "trip:OCETGV-87686006-87751008-2:25768", datetime(2015, 10, 6, 10, 37)
         )
         assert db_trip_removal
 
         assert db_trip_removal.vj.navitia_trip_id == "trip:OCETGV-87686006-87751008-2:25768"
-        assert db_trip_removal.vj.get_start_timestamp() == datetime(2015, 10, 6, 10, 37, tzinfo=utc)
+        assert db_trip_removal.vj.get_start_timestamp() == datetime(2015, 10, 6, 10, 37)
         assert db_trip_removal.vj_id == db_trip_removal.vj.id
         assert db_trip_removal.status == "delete"
         assert db_trip_removal.effect == "NO_SERVICE"
@@ -629,12 +628,12 @@ def check_db_6111_trip_removal_pass_midnight():
         assert len(TripUpdate.query.all()) >= 1
         assert len(StopTimeUpdate.query.all()) >= 0
         db_trip_removal = TripUpdate.find_by_dated_vj(
-            "trip:OCETGV-87686006-87751008-2:25768", datetime(2015, 10, 6, 20, 37, tzinfo=utc)
+            "trip:OCETGV-87686006-87751008-2:25768", datetime(2015, 10, 6, 20, 37)
         )
         assert db_trip_removal
 
         assert db_trip_removal.vj.navitia_trip_id == "trip:OCETGV-87686006-87751008-2:25768"
-        assert db_trip_removal.vj.get_start_timestamp() == datetime(2015, 10, 6, 20, 37, tzinfo=utc)
+        assert db_trip_removal.vj.get_start_timestamp() == datetime(2015, 10, 6, 20, 37)
         assert db_trip_removal.vj_id == db_trip_removal.vj.id
         assert db_trip_removal.status == "delete"
         assert db_trip_removal.effect == "NO_SERVICE"
@@ -649,12 +648,12 @@ def check_db_6114_trip_removal():
         assert len(TripUpdate.query.all()) >= 1
         assert len(StopTimeUpdate.query.all()) >= 0
         db_trip_removal = TripUpdate.find_by_dated_vj(
-            "trip:OCETGV-87686006-87751008-2:25768-2", datetime(2015, 10, 6, 10, 37, tzinfo=utc)
+            "trip:OCETGV-87686006-87751008-2:25768-2", datetime(2015, 10, 6, 10, 37)
         )
         assert db_trip_removal
 
         assert db_trip_removal.vj.navitia_trip_id == "trip:OCETGV-87686006-87751008-2:25768-2"
-        assert db_trip_removal.vj.get_start_timestamp() == datetime(2015, 10, 6, 10, 37, tzinfo=utc)
+        assert db_trip_removal.vj.get_start_timestamp() == datetime(2015, 10, 6, 10, 37)
         assert db_trip_removal.vj_id == db_trip_removal.vj.id
         assert db_trip_removal.status == "delete"
         assert db_trip_removal.message == "Accident à un Passage à Niveau"
@@ -668,12 +667,12 @@ def check_db_96231_partial_removal(contributor=None):
         assert len(TripUpdate.query.all()) >= 1
         assert len(StopTimeUpdate.query.all()) >= 6
         db_trip_partial_removed = TripUpdate.find_by_dated_vj(
-            "trip:OCETrainTER-87212027-85000109-3:11859", datetime(2015, 9, 21, 15, 21, tzinfo=utc)
+            "trip:OCETrainTER-87212027-85000109-3:11859", datetime(2015, 9, 21, 15, 21)
         )
         assert db_trip_partial_removed
 
         assert db_trip_partial_removed.vj.navitia_trip_id == "trip:OCETrainTER-87212027-85000109-3:11859"
-        assert db_trip_partial_removed.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21, tzinfo=utc)
+        assert db_trip_partial_removed.vj.get_start_timestamp() == datetime(2015, 9, 21, 15, 21)
         assert db_trip_partial_removed.vj_id == db_trip_partial_removed.vj.id
         assert db_trip_partial_removed.status == "update"
         assert db_trip_partial_removed.effect == "REDUCED_SERVICE"
@@ -741,13 +740,11 @@ def check_db_96231_partial_removal(contributor=None):
 
 def check_db_840427_partial_removal(contributor=None):
     with app.app_context():
-        db_trip_partial_removed = TripUpdate.find_by_dated_vj(
-            "OCE:SN840427F03001", datetime(2017, 3, 18, 13, 5, tzinfo=utc)
-        )
+        db_trip_partial_removed = TripUpdate.find_by_dated_vj("OCE:SN840427F03001", datetime(2017, 3, 18, 13, 5))
         assert db_trip_partial_removed
 
         assert db_trip_partial_removed.vj.navitia_trip_id == "OCE:SN840427F03001"
-        assert db_trip_partial_removed.vj.get_start_timestamp() == datetime(2017, 3, 18, 13, 5, tzinfo=utc)
+        assert db_trip_partial_removed.vj.get_start_timestamp() == datetime(2017, 3, 18, 13, 5)
         assert db_trip_partial_removed.vj_id == db_trip_partial_removed.vj.id
         assert db_trip_partial_removed.status == "update"
         assert db_trip_partial_removed.effect == "REDUCED_SERVICE"

--- a/tests/mock_navitia/vj_R_vj1.py
+++ b/tests/mock_navitia/vj_R_vj1.py
@@ -35,7 +35,7 @@ from tests.mock_navitia import navitia_response
 response = navitia_response.NavitiaResponse()
 
 response.queries = [
-    "vehicle_journeys/?filter=vehicle_journey.has_code(source, Code-R-vj1)&depth=2&since=20120615T120000Z&until=20120615T190000Z"
+    "vehicle_journeys/?filter=vehicle_journey.has_code(source, Code-R-vj1)&depth=2&since=20120615T120000+0000&until=20120615T190000+0000"
 ]
 
 response.response_code = 200

--- a/tests/mock_navitia/vj_R_vj2.py
+++ b/tests/mock_navitia/vj_R_vj2.py
@@ -35,7 +35,7 @@ from tests.mock_navitia import navitia_response
 response = navitia_response.NavitiaResponse()
 
 response.queries = [
-    "vehicle_journeys/?filter=vehicle_journey.has_code(source, Code-R-vj2)&depth=2&since=20120615T120000Z&until=20120615T190000Z"
+    "vehicle_journeys/?filter=vehicle_journey.has_code(source, Code-R-vj2)&depth=2&since=20120615T120000+0000&until=20120615T190000+0000"
 ]
 
 response.response_code = 200

--- a/tests/mock_navitia/vj_bad_order.py
+++ b/tests/mock_navitia/vj_bad_order.py
@@ -35,7 +35,7 @@ from tests.mock_navitia import navitia_response
 response = navitia_response.NavitiaResponse()
 
 response.queries = [
-    "vehicle_journeys/?filter=vehicle_journey.has_code(source, Code-orders)&depth=2&since=20120615T120000Z&until=20120615T190000Z"
+    "vehicle_journeys/?filter=vehicle_journey.has_code(source, Code-orders)&depth=2&since=20120615T120000+0000&until=20120615T190000+0000"
     # resquest time is UTC -> 12:00 is 8:00 local in Sherbrooke
 ]
 

--- a/tests/mock_navitia/vj_lollipop.py
+++ b/tests/mock_navitia/vj_lollipop.py
@@ -35,7 +35,7 @@ from tests.mock_navitia import navitia_response
 response = navitia_response.NavitiaResponse()
 
 response.queries = [
-    "vehicle_journeys/?filter=vehicle_journey.has_code(source, Code-lollipop)&depth=2&since=20120615T120000Z&until=20120615T190000Z"
+    "vehicle_journeys/?filter=vehicle_journey.has_code(source, Code-lollipop)&depth=2&since=20120615T120000+0000&until=20120615T190000+0000"
     # resquest time is UTC -> 12:00 is 08:00 local time in Sherbrooke
 ]
 

--- a/tests/mock_navitia/vj_pass_midnight.py
+++ b/tests/mock_navitia/vj_pass_midnight.py
@@ -35,7 +35,7 @@ from tests.mock_navitia import navitia_response
 response = navitia_response.NavitiaResponse()
 
 response.queries = [
-    "vehicle_journeys/?filter=vehicle_journey.has_code(source, Code-pass-midnight)&depth=2&since=20120616T020000Z&until=20120616T090000Z"
+    "vehicle_journeys/?filter=vehicle_journey.has_code(source, Code-pass-midnight)&depth=2&since=20120616T020000+0000&until=20120616T090000+0000"
     # resquest time is UTC -> 22:00 to 05:00 local
 ]
 

--- a/tests/mock_navitia/vj_pass_midnight_utc.py
+++ b/tests/mock_navitia/vj_pass_midnight_utc.py
@@ -35,7 +35,7 @@ from tests.mock_navitia import navitia_response
 response = navitia_response.NavitiaResponse()
 
 response.queries = [
-    "vehicle_journeys/?filter=vehicle_journey.has_code(source, Code-pass-midnight-UTC)&depth=2&since=20120615T220000Z&until=20120616T050000Z"
+    "vehicle_journeys/?filter=vehicle_journey.has_code(source, Code-pass-midnight-UTC)&depth=2&since=20120615T220000+0000&until=20120616T050000+0000"
     # resquest time is UTC -> 18:00 to 01:00 local
 ]
 

--- a/tests/mock_navitia/vj_start_midnight.py
+++ b/tests/mock_navitia/vj_start_midnight.py
@@ -35,7 +35,7 @@ from tests.mock_navitia import navitia_response
 response = navitia_response.NavitiaResponse()
 
 response.queries = [
-    "vehicle_journeys/?filter=vehicle_journey.has_code(source, Code-midnight)&depth=2&since=20171211T220000Z&until=20171212T050000Z"
+    "vehicle_journeys/?filter=vehicle_journey.has_code(source, Code-midnight)&depth=2&since=20171211T220000+0000&until=20171212T050000+0000"
     # resquest time is UTC -> 12:00 is 07:00 local time in Sherbrooke
 ]
 

--- a/tests/mock_navitia/vj_start_midnight_utc.py
+++ b/tests/mock_navitia/vj_start_midnight_utc.py
@@ -35,7 +35,7 @@ from tests.mock_navitia import navitia_response
 response = navitia_response.NavitiaResponse()
 
 response.queries = [
-    "vehicle_journeys/?filter=vehicle_journey.has_code(source, Code-midnight-UTC)&depth=2&since=20171211T170000Z&until=20171212T000000Z"
+    "vehicle_journeys/?filter=vehicle_journey.has_code(source, Code-midnight-UTC)&depth=2&since=20171211T170000+0000&until=20171212T000000+0000"
     # resquest time is UTC -> 12:00 is 07:00 local time in Sherbrooke
 ]
 


### PR DESCRIPTION
JIRA: https://jira.kisio.org/browse/NAVP-1344

The goal of this PR is to have **naive** UTC datetime (timezone-unaware) everywhere in the code.
That will help to have consistent types everywhere, especially when using db (that doesn't store/provide timezone-aware datetimes). Then we will always manipulate the same kind of datetime, being able to compare them, etc.

So remove the datetime right from the start once they are converted to UTC in connectors.
Other interface that needs timezone in when requesting navitia (so TZ is back for URL generation only).

Nota: datetimes were already UTC.

TODO:
- [x] merge #252 as this PR is on top of it (then rebase this branch for clarity?)
- [x] Maybe hand-test that it's OK with COTS, GTFSRT, status ?

:mag: Please review by commit (with commit messages).

:warning: the last commit is open for removal/modification: only there to secure any following dev.