### PR TITLE
Contributor endpoint

### DIFF
--- a/kirin/api.py
+++ b/kirin/api.py
@@ -47,12 +47,10 @@ api = flask_restful.Api(app, catch_all_404s=True)
 api.app.url_map.strict_slashes = False
 
 api.add_resource(resources.Index, "/", endpoint=str("index"))
-
 api.add_resource(resources.Status, "/status", endpoint=str("status"))
-
 api.add_resource(cots.Cots, "/cots", endpoint=str("cots"))
-
 api.add_resource(gtfs_rt.GtfsRT, "/gtfs_rt", endpoint=str("gtfs_rt"))
+api.add_resource(resources.Contributors, "/contributors", "/contributors/<string:id>")
 
 
 def log_exception(sender, exception):

--- a/kirin/resources/__init__.py
+++ b/kirin/resources/__init__.py
@@ -1,0 +1,35 @@
+# coding=utf-8
+
+# Copyright (c) 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from __future__ import absolute_import, print_function, unicode_literals, division
+from .index import Index
+from .status import Status
+from .contributors import Contributors

--- a/kirin/resources/contributors.py
+++ b/kirin/resources/contributors.py
@@ -1,0 +1,53 @@
+# coding=utf-8
+
+# Copyright (c) 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from __future__ import absolute_import, print_function, unicode_literals, division
+from flask_restful import Resource, marshal_with_field, fields
+from kirin.core import model
+
+contributor_fields = {
+    "id": fields.String,
+    "coverage": fields.String,
+    "token": fields.String,
+    "feed_url": fields.String,
+    "connector_type": fields.String,
+}
+
+
+class Contributors(Resource):
+    @marshal_with_field(fields.List(fields.Nested(contributor_fields)))
+    def get(self, id=None):
+        q = model.db.session.query(model.Contributor)
+
+        if id is not None:
+            q = q.filter(model.Contributor.id == id)
+
+        return q.all()

--- a/kirin/resources/contributors.py
+++ b/kirin/resources/contributors.py
@@ -54,13 +54,16 @@ class Contributors(Resource):
         return q.all()
 
     @marshal_with(contributor_fields)
-    def post(self):
+    def post(self, id=None):
         data = flask.request.get_json()
+
+        id = id or data["id"]
         token = data.get("navitia_token", None)
         feed_url = data.get("feed_url", None)
+
         try:
             new_contrib = model.Contributor(
-                data["id"], data["navitia_coverage"], data["connector_type"], token, feed_url
+                id, data["navitia_coverage"], data["connector_type"], token, feed_url
             )
             model.db.session.add(new_contrib)
             model.db.session.commit()

--- a/kirin/resources/contributors.py
+++ b/kirin/resources/contributors.py
@@ -36,8 +36,8 @@ from kirin.core import model
 
 contributor_fields = {
     "id": fields.String,
-    "coverage": fields.String,
-    "token": fields.String,
+    "navitia_coverage": fields.String,
+    "navitia_token": fields.String,
     "feed_url": fields.String,
     "connector_type": fields.String,
 }
@@ -56,10 +56,11 @@ class Contributors(Resource):
     @marshal_with(contributor_fields)
     def post(self):
         data = flask.request.get_json()
+        token = data.get("navitia_token", None)
+        feed_url = data.get("feed_url", None)
         try:
-
             new_contrib = model.Contributor(
-                data["id"], data["coverage"], data["connector_type"], data["token"], data["feed_url"]
+                data["id"], data["navitia_coverage"], data["connector_type"], token, feed_url
             )
             model.db.session.add(new_contrib)
             model.db.session.commit()

--- a/kirin/resources/index.py
+++ b/kirin/resources/index.py
@@ -1,0 +1,44 @@
+# coding=utf-8
+
+# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from __future__ import absolute_import, print_function, unicode_literals, division
+from flask_restful import Resource, url_for
+
+
+class Index(Resource):
+    def get(self):
+        response = {
+            "status": {"href": url_for("status", _external=True)},
+            "cots": {"href": url_for("cots", _external=True)},
+            "gtfs_rt": {"href": url_for("gtfs_rt", _external=True)},
+            "contributors": {"href": url_for("contributors", _external=True)},
+        }
+        return response, 200

--- a/kirin/resources/index.py
+++ b/kirin/resources/index.py
@@ -38,7 +38,6 @@ class Index(Resource):
         response = {
             "status": {"href": url_for("status", _external=True)},
             "cots": {"href": url_for("cots", _external=True)},
-            "gtfs_rt": {"href": url_for("gtfs_rt", _external=True)},
             "contributors": {"href": url_for("contributors", _external=True)},
         }
         return response, 200

--- a/kirin/resources/status.py
+++ b/kirin/resources/status.py
@@ -30,20 +30,11 @@
 # www.navitia.io
 
 from __future__ import absolute_import, print_function, unicode_literals, division
-from flask_restful import Resource, url_for
+from flask_restful import Resource
 import kirin
 from kirin.version import version
 from flask import current_app
 from kirin.core import model
-
-
-class Index(Resource):
-    def get(self):
-        response = {
-            "status": {"href": url_for("status", _external=True)},
-            "cots": {"href": url_for("cots", _external=True)},
-        }
-        return response, 200
 
 
 class Status(Resource):

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,4 @@ flask-cache==0.13.1
 click==6.7
 enum34==1.1.6
 typing==3.7.4
+jsonschema==3.0.2

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -120,11 +120,41 @@ def test_post_new_partial_contributor(test_client):
     assert contrib.id == "realtime.tokyo"
     assert contrib.coverage == "jp"
     assert contrib.connector_type == "gtfs-rt"
-    assert contrib.token == "blablablabla"
-    assert contrib.feed_url == "http://nihongo.jp"
+    assert contrib.navitia_token == None
+    assert contrib.feed_url == None
 
 
 def test_post_contributor_with_wrong_connector_type(test_client):
     new_contrib = {"id": "realtime.tokyo", "coverage": "jp", "connector_type": "THIS-TYPE-DOES-NOT-EXIST"}
     resp = test_client.post("/contributors", json=new_contrib)
     assert resp.status_code == 400
+
+
+def test_post_2_contributors_with_same_id_should_fail(test_client):
+    resp = test_client.post(
+        "/contributors", json={"id": "realtime.test", "navitia_coverage": "jp", "connector_type": "gtfs-rt"}
+    )
+    resp = test_client.post(
+        "/contributors", json={"id": "realtime.test", "navitia_coverage": "fr", "connector_type": "cots"}
+    )
+    assert resp.status_code == 400
+
+
+def test_post_contributor_with_wrong_connector_type_should_fail(test_client):
+    resp = test_client.post("/contributors", json={
+        "id": "realtime.tokyo",
+        "navitia_coverage": "jp",
+        "connector_type": "THIS-TYPE-DOES-NOT-EXIST",
+    })
+    assert resp.status_code == 400
+
+
+def test_post_new_valid_contributor_with_unknown_parameter_should_work(test_client):
+    resp = test_client.post("/contributors", json={
+        "UNKNOWN_PARAM": "gibberish",
+        "id": "realtime.tokyo",
+        "navitia_coverage": "jp",
+        "connector_type": "gtfs-rt",
+    })
+    assert resp.status_code == 201
+

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -1,0 +1,92 @@
+# coding=utf-8
+
+# Copyright (c) 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+from kirin import app, db
+from kirin.core import model
+from flask import json
+import pytest
+
+
+@pytest.yield_fixture
+def test_client():
+    app.testing = True
+    with app.app_context(), app.test_client() as tester:
+        yield tester
+
+
+def test_get_contributor_end_point(test_client):
+    assert test_client.get("/contributors").status_code == 200
+
+
+@pytest.fixture
+def with_contributors():
+    db.session.add_all(
+        [
+            model.Contributor("realtime.sherbrook", "ca", "gtfs-rt", "my_token", "http://feed.url"),
+            model.Contributor("realtime.paris", "idf", "gtfs-rt", "my_other_token", "http://otherfeed.url"),
+        ]
+    )
+    db.session.commit()
+
+
+def test_get_contributors(test_client, with_contributors):
+    resp = test_client.get("/contributors")
+    assert resp.status_code == 200
+
+    contribs = json.loads(resp.data)
+    assert len(contribs) == 2
+
+    ids = [c["id"] for c in contribs]
+    ids.sort()
+
+    assert ids == ["realtime.paris", "realtime.sherbrook"]
+
+
+def test_get_contributors_with_specific_id(test_client, with_contributors):
+    resp = test_client.get("/contributors/realtime.paris")
+    assert resp.status_code == 200
+
+    contrib = json.loads(resp.data)
+    assert len(contrib) == 1
+    assert contrib[0]["id"] == "realtime.paris"
+    assert contrib[0]["coverage"] == "idf"
+    assert contrib[0]["connector_type"] == "gtfs-rt"
+    assert contrib[0]["token"] == "my_other_token"
+    assert contrib[0]["feed_url"] == "http://otherfeed.url"
+
+
+def test_get_contributors_with_wrong_id(test_client, with_contributors):
+    resp = test_client.get("/contributors/this_id_doesnt_exist")
+    assert resp.status_code == 200
+
+    contrib = json.loads(resp.data)
+    assert len(contrib) == 0

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -63,10 +63,10 @@ def test_get_contributors(test_client, with_contributors):
     resp = test_client.get("/contributors")
     assert resp.status_code == 200
 
-    contribs = json.loads(resp.data)
-    assert len(contribs) == 2
+    data = json.loads(resp.data)
+    assert len(data["contributors"]) == 2
 
-    ids = [c["id"] for c in contribs]
+    ids = [c["id"] for c in data["contributors"]]
     ids.sort()
 
     assert ids == ["realtime.paris", "realtime.sherbrooke"]
@@ -76,7 +76,8 @@ def test_get_contributors_with_specific_id(test_client, with_contributors):
     resp = test_client.get("/contributors/realtime.paris")
     assert resp.status_code == 200
 
-    contrib = json.loads(resp.data)
+    data = json.loads(resp.data)
+    contrib = data["contributors"]
     assert len(contrib) == 1
     assert contrib[0]["id"] == "realtime.paris"
     assert contrib[0]["navitia_coverage"] == "idf"
@@ -89,8 +90,8 @@ def test_get_contributors_with_wrong_id(test_client, with_contributors):
     resp = test_client.get("/contributors/this_id_doesnt_exist")
     assert resp.status_code == 200
 
-    contrib = json.loads(resp.data)
-    assert len(contrib) == 0
+    data = json.loads(resp.data)
+    assert len(data["contributors"]) == 0
 
 
 def test_post_schema_distributor_is_valid():

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -54,6 +54,7 @@ def with_contributors():
         [
             model.Contributor("realtime.sherbrooke", "ca", "gtfs-rt", "my_token", "http://feed.url"),
             model.Contributor("realtime.paris", "idf", "gtfs-rt", "my_other_token", "http://otherfeed.url"),
+            model.Contributor("realtime.london", "gb", "cots"),
         ]
     )
     db.session.commit()
@@ -64,12 +65,12 @@ def test_get_contributors(test_client, with_contributors):
     assert resp.status_code == 200
 
     data = json.loads(resp.data)
-    assert len(data["contributors"]) == 2
+    assert len(data["contributors"]) == 3
 
     ids = [c["id"] for c in data["contributors"]]
     ids.sort()
 
-    assert ids == ["realtime.paris", "realtime.sherbrooke"]
+    assert ids == ["realtime.london", "realtime.paris", "realtime.sherbrooke"]
 
 
 def test_get_contributors_with_specific_id(test_client, with_contributors):
@@ -84,6 +85,17 @@ def test_get_contributors_with_specific_id(test_client, with_contributors):
     assert contrib[0]["connector_type"] == "gtfs-rt"
     assert contrib[0]["navitia_token"] == "my_other_token"
     assert contrib[0]["feed_url"] == "http://otherfeed.url"
+
+
+def test_get_partial_contributor_with_empty_fields(test_client, with_contributors):
+    resp = test_client.get("/contributors/realtime.london")
+    assert resp.status_code == 200
+
+    data = json.loads(resp.data)
+    contrib = data["contributors"]
+    assert len(contrib) == 1
+    assert contrib[0]["navitia_token"] == None
+    assert contrib[0]["feed_url"] == None
 
 
 def test_get_contributors_with_wrong_id(test_client, with_contributors):

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -90,3 +90,41 @@ def test_get_contributors_with_wrong_id(test_client, with_contributors):
 
     contrib = json.loads(resp.data)
     assert len(contrib) == 0
+
+
+def test_post_new_contributor(test_client):
+    new_contrib = {
+        "id": "realtime.tokyo",
+        "coverage": "jp",
+        "token": "blablablabla",
+        "feed_url": "http://nihongo.jp",
+        "connector_type": "gtfs-rt",
+    }
+    resp = test_client.post("/contributors", json=new_contrib)
+    assert resp.status_code == 201
+
+    contrib = db.session.query(model.Contributor).filter(model.Contributor.id == "realtime.tokyo").first()
+    assert contrib.id == "realtime.tokyo"
+    assert contrib.coverage == "jp"
+    assert contrib.connector_type == "gtfs-rt"
+    assert contrib.token == "blablablabla"
+    assert contrib.feed_url == "http://nihongo.jp"
+
+
+def test_post_new_partial_contributor(test_client):
+    new_contrib = {"id": "realtime.tokyo", "coverage": "jp", "connector_type": "gtfs-rt"}
+    resp = test_client.post("/contributors", json=new_contrib)
+    assert resp.status_code == 201
+
+    contrib = db.session.query(model.Contributor).filter(model.Contributor.id == "realtime.tokyo").first()
+    assert contrib.id == "realtime.tokyo"
+    assert contrib.coverage == "jp"
+    assert contrib.connector_type == "gtfs-rt"
+    assert contrib.token == "blablablabla"
+    assert contrib.feed_url == "http://nihongo.jp"
+
+
+def test_post_contributor_with_wrong_connector_type(test_client):
+    new_contrib = {"id": "realtime.tokyo", "coverage": "jp", "connector_type": "THIS-TYPE-DOES-NOT-EXIST"}
+    resp = test_client.post("/contributors", json=new_contrib)
+    assert resp.status_code == 400

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -30,10 +30,11 @@
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
 
-from kirin import app, db
+from kirin import app, db, resources
 from kirin.core import model
 from flask import json
 import pytest
+import jsonschema
 
 
 @pytest.yield_fixture
@@ -92,6 +93,10 @@ def test_get_contributors_with_wrong_id(test_client, with_contributors):
     assert len(contrib) == 0
 
 
+def test_post_schema_distributor_is_valid():
+    jsonschema.Draft4Validator.check_schema(resources.Contributors.post_data_schema)
+
+
 def test_post_new_contributor(test_client):
     new_contrib = {
         "id": "realtime.tokyo",
@@ -122,6 +127,11 @@ def test_post_new_partial_contributor(test_client):
     assert contrib.connector_type == "gtfs-rt"
     assert contrib.navitia_token == None
     assert contrib.feed_url == None
+
+
+def test_post_empty_contributor_should_fail(test_client):
+    resp = test_client.post("/contributors")
+    assert resp.status_code == 400
 
 
 def test_post_with_id_in_the_resource_path(test_client):

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -52,7 +52,7 @@ def test_get_contributor_end_point(test_client):
 def with_contributors():
     db.session.add_all(
         [
-            model.Contributor("realtime.sherbrook", "ca", "gtfs-rt", "my_token", "http://feed.url"),
+            model.Contributor("realtime.sherbrooke", "ca", "gtfs-rt", "my_token", "http://feed.url"),
             model.Contributor("realtime.paris", "idf", "gtfs-rt", "my_other_token", "http://otherfeed.url"),
         ]
     )
@@ -69,7 +69,7 @@ def test_get_contributors(test_client, with_contributors):
     ids = [c["id"] for c in contribs]
     ids.sort()
 
-    assert ids == ["realtime.paris", "realtime.sherbrook"]
+    assert ids == ["realtime.paris", "realtime.sherbrooke"]
 
 
 def test_get_contributors_with_specific_id(test_client, with_contributors):

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -78,9 +78,9 @@ def test_get_contributors_with_specific_id(test_client, with_contributors):
     contrib = json.loads(resp.data)
     assert len(contrib) == 1
     assert contrib[0]["id"] == "realtime.paris"
-    assert contrib[0]["coverage"] == "idf"
+    assert contrib[0]["navitia_coverage"] == "idf"
     assert contrib[0]["connector_type"] == "gtfs-rt"
-    assert contrib[0]["token"] == "my_other_token"
+    assert contrib[0]["navitia_token"] == "my_other_token"
     assert contrib[0]["feed_url"] == "http://otherfeed.url"
 
 
@@ -95,8 +95,8 @@ def test_get_contributors_with_wrong_id(test_client, with_contributors):
 def test_post_new_contributor(test_client):
     new_contrib = {
         "id": "realtime.tokyo",
-        "coverage": "jp",
-        "token": "blablablabla",
+        "navitia_coverage": "jp",
+        "navitia_token": "blablablabla",
         "feed_url": "http://nihongo.jp",
         "connector_type": "gtfs-rt",
     }
@@ -105,20 +105,20 @@ def test_post_new_contributor(test_client):
 
     contrib = db.session.query(model.Contributor).filter(model.Contributor.id == "realtime.tokyo").first()
     assert contrib.id == "realtime.tokyo"
-    assert contrib.coverage == "jp"
+    assert contrib.navitia_coverage == "jp"
     assert contrib.connector_type == "gtfs-rt"
-    assert contrib.token == "blablablabla"
+    assert contrib.navitia_token == "blablablabla"
     assert contrib.feed_url == "http://nihongo.jp"
 
 
 def test_post_new_partial_contributor(test_client):
-    new_contrib = {"id": "realtime.tokyo", "coverage": "jp", "connector_type": "gtfs-rt"}
+    new_contrib = {"id": "realtime.tokyo", "navitia_coverage": "jp", "connector_type": "gtfs-rt"}
     resp = test_client.post("/contributors", json=new_contrib)
     assert resp.status_code == 201
 
     contrib = db.session.query(model.Contributor).filter(model.Contributor.id == "realtime.tokyo").first()
     assert contrib.id == "realtime.tokyo"
-    assert contrib.coverage == "jp"
+    assert contrib.navitia_coverage == "jp"
     assert contrib.connector_type == "gtfs-rt"
     assert contrib.navitia_token == None
     assert contrib.feed_url == None

--- a/tests/integration/test_end_point.py
+++ b/tests/integration/test_end_point.py
@@ -42,6 +42,7 @@ def test_end_point():
     resp = api_get("/")
     assert "status" in resp
     assert "cots" in resp
+    assert "contributors" in resp
 
 
 def test_status(setup_database):


### PR DESCRIPTION
Add `/contributors` endpoint, CRUD style ! 

The endpoint has 2 ways of accessing a resource:
* `/contributors`
* `/contributors/<contributor_id>`

So far, only `C` and `R` are implemented:
- Create via `POST`:
```http
http --json POST :5000/contributors id=new_contrib navitia_coverage=co connector_type=gtfs-rt
```
```http
http --json POST :5000/contributors/other_contrib_id navitia_coverage=co connector_type=gtfs-rt
```
- Read via `GET`:
```
http GET :5000/contributors
```
```
http GET :5000/contributors/new_contrib
```

**http comes from [httpie](https://github.com/jakubroztocil/httpie)
