### PR TITLE
Contributor endpoint

### DIFF
--- a/kirin/core/types.py
+++ b/kirin/core/types.py
@@ -81,6 +81,10 @@ class ConnectorType(Enum):
     cots = "cots"
     gtfs_rt = "gtfs-rt"
 
+    @staticmethod
+    def values():
+        return [c.value for c in ConnectorType]
+
 
 def get_higher_status(st1, st2):
     return max([st1, st2], key=get_modification_type_order)

--- a/kirin/resources/contributors.py
+++ b/kirin/resources/contributors.py
@@ -34,6 +34,7 @@ import flask
 import jsonschema
 from flask_restful import Resource, marshal_with_field, marshal_with, fields, abort
 from kirin.core import model
+from kirin.core.types import ConnectorType
 from kirin.exceptions import ObjectNotFound
 
 contributor_fields = {
@@ -57,7 +58,7 @@ class Contributors(Resource):
             "navitia_coverage": {"type": "string"},
             "navitia_token": {"type": "string"},
             "feed_url": {"type": "string", "format": "uri"},
-            "connector_type": {"type": "string", "enum": ["cots", "gtfs-rt"]},
+            "connector_type": {"type": "string", "enum": ConnectorType.values()},
         },
         "required": ["navitia_coverage", "connector_type"],
     }
@@ -68,7 +69,7 @@ class Contributors(Resource):
             "navitia_coverage": {"type": "string"},
             "navitia_token": {"type": "string"},
             "feed_url": {"type": "string", "format": "uri"},
-            "connector_type": {"type": "string", "enum": ["cots", "gtfs-rt"]},
+            "connector_type": {"type": "string", "enum": ConnectorType.values()},
         },
     }
 

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -108,6 +108,10 @@ def test_post_schema_distributor_is_valid():
     jsonschema.Draft4Validator.check_schema(resources.Contributors.post_data_schema)
 
 
+def test_put_schema_distributor_is_valid():
+    jsonschema.Draft4Validator.check_schema(resources.Contributors.put_data_schema)
+
+
 def test_post_new_contributor(test_client):
     new_contrib = {
         "id": "realtime.tokyo",

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -309,3 +309,22 @@ def test_put_unknown_contributor(test_client, with_contributors):
 def test_put_contributor_with_malformed_data(test_client, with_contributors):
     resp = test_client.put("/contributors/realtime.paris", json={"feed_url": 42})
     assert resp.status_code == 400
+
+
+def test_post_get_put_to_ensure_API_consitency(test_client):
+    new_contrib = {
+        "id": "realtime.tokyo",
+        "navitia_coverage": "jp",
+        "navitia_token": "blablablabla",
+        "feed_url": "http://nihongo.jp",
+        "connector_type": "gtfs-rt",
+    }
+    test_client.post("/contributors", json=new_contrib)
+
+    get_resp = test_client.get("/contributors/realtime.tokyo")
+    get_contrib = json.loads(get_resp.data)["contributors"][0]
+
+    put_resp = test_client.put("/contributors", json=get_contrib)
+    put_data = json.loads(put_resp.data)
+
+    assert put_data["contributor"] == new_contrib


### PR DESCRIPTION
Part II of endpoint `/contributors`

* PUT `/contributors/<id>` with a JSON data that matches the contributor's model (same as for a POST). _The only field that cannot be changed is the object's `id`_ 
 ```bash
http --json PUT :5000/contributors/<id> navitia_coverage=idf
```
 ```bash
http --json PUT :5000/contributors/<id> navitia_coverage=idf feed_url="http://feed.url" navitia_token="XXXXXX" connector_type={cots|gtfs-rt}
```
* DELETE `/contributors/<id>`
```bash
http DELETE :5000/contributors/<id> 
```