### PR TITLE
Delete old contributor column in tables

### DIFF
--- a/kirin/abstract_sncf_model_maker.py
+++ b/kirin/abstract_sncf_model_maker.py
@@ -111,7 +111,7 @@ def get_navitia_stop_time_sncf(cr, ci, ch, nav_vj):
 
 
 class AbstractSNCFKirinModelBuilder(six.with_metaclass(ABCMeta, object)):
-    def __init__(self, nav, contributor=None):
+    def __init__(self, nav, contributor="realtime.cots"):
         self.navitia = nav
         self.contributor = contributor
 

--- a/kirin/core/handler.py
+++ b/kirin/core/handler.py
@@ -459,6 +459,7 @@ def merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete=False):
     if new_trip_update.message is not None or is_new_complete:
         res.message = new_trip_update.message
     res.contributor = new_trip_update.contributor
+    res.contributor_id = new_trip_update.contributor_id
 
     if res.status == ModificationType.delete.name:
         # for trip cancellation, we delete all StopTimeUpdates

--- a/kirin/core/handler.py
+++ b/kirin/core/handler.py
@@ -458,7 +458,6 @@ def merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete=False):
     res.effect = new_trip_update.effect
     if new_trip_update.message is not None or is_new_complete:
         res.message = new_trip_update.message
-    res.contributor = new_trip_update.contributor
     res.contributor_id = new_trip_update.contributor_id
 
     if res.status == ModificationType.delete.name:

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -302,8 +302,6 @@ class TripUpdate(db.Model, TimestampMixin):  # type: ignore
         single_parent=True,
     )
     message = db.Column(db.Text, nullable=True)
-    contributor = db.Column(db.Text, nullable=True)
-    db.Index("contributor_idx", contributor)
     stop_time_updates = db.relationship(
         "StopTimeUpdate",
         backref="trip_update",
@@ -332,7 +330,6 @@ class TripUpdate(db.Model, TimestampMixin):  # type: ignore
         self.created_at = datetime.datetime.utcnow()
         self.vj = vj
         self.status = status
-        self.contributor = contributor
         self.company_id = company_id
         self.effect = effect
         self.physical_mode_id = physical_mode_id
@@ -435,7 +432,6 @@ class RealTimeUpdate(db.Model, TimestampMixin):  # type: ignore
     db.Index("status_idx", status)
     error = db.Column(db.Text, nullable=True)
     raw_data = deferred(db.Column(db.Text, nullable=True))
-    contributor = db.Column(db.Text, nullable=True)
     contributor_id = db.Column(db.Text, db.ForeignKey("contributor.id"), nullable=False)
 
     trip_updates = db.relationship(
@@ -448,7 +444,6 @@ class RealTimeUpdate(db.Model, TimestampMixin):  # type: ignore
 
     __table_args__ = (
         db.Index("realtime_update_created_at", "created_at"),
-        db.Index("realtime_update_contributor_and_created_at", "created_at", "contributor"),
         db.Index("realtime_update_contributor_id_and_created_at", "created_at", "contributor_id"),
     )
 
@@ -457,7 +452,6 @@ class RealTimeUpdate(db.Model, TimestampMixin):  # type: ignore
         self.raw_data = raw_data
         self.connector = connector
         self.status = status
-        self.contributor = contributor
         self.error = error
         self.received_at = received_at if received_at else datetime.datetime.utcnow()
         self.contributor_id = contributor

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -470,6 +470,8 @@ class RealTimeUpdate(db.Model, TimestampMixin):  # type: ignore
         from kirin import app
 
         result = {"last_update": {}, "last_valid_update": {}, "last_update_error": {}}
+
+        # TODO: contributors to be read from the table contributor and updated if present in conig file
         contributors = [app.config[str("COTS_CONTRIBUTOR")], app.config[str("GTFS_RT_CONTRIBUTOR")]]
         for c in contributors:
             sql = db.session.query(cls.created_at, cls.status, cls.updated_at, cls.error)

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -323,7 +323,7 @@ class TripUpdate(db.Model, TimestampMixin):  # type: ignore
         self,
         vj=None,
         status="none",
-        contributor="realtime.cots",
+        contributor=None,
         company_id=None,
         effect=None,
         physical_mode_id=None,
@@ -332,6 +332,7 @@ class TripUpdate(db.Model, TimestampMixin):  # type: ignore
         self.created_at = datetime.datetime.utcnow()
         self.vj = vj
         self.status = status
+        self.contributor = contributor
         self.company_id = company_id
         self.effect = effect
         self.physical_mode_id = physical_mode_id
@@ -451,13 +452,12 @@ class RealTimeUpdate(db.Model, TimestampMixin):  # type: ignore
         db.Index("realtime_update_contributor_id_and_created_at", "created_at", "contributor_id"),
     )
 
-    def __init__(
-        self, raw_data, connector, contributor="realtime.cots", status="OK", error=None, received_at=None
-    ):
+    def __init__(self, raw_data, connector, contributor=None, status="OK", error=None, received_at=None):
         self.id = gen_uuid()
         self.raw_data = raw_data
         self.connector = connector
         self.status = status
+        self.contributor = contributor
         self.error = error
         self.received_at = received_at if received_at else datetime.datetime.utcnow()
         self.contributor_id = contributor

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -316,7 +316,7 @@ class TripUpdate(db.Model, TimestampMixin):  # type: ignore
     effect = db.Column(Db_TripEffect, nullable=True)
     physical_mode_id = db.Column(db.Text, nullable=True)
     headsign = db.Column(db.Text, nullable=True)
-    contributor_id = db.Column(db.Text, db.ForeignKey('contributor.id'), nullable=False)
+    contributor_id = db.Column(db.Text, db.ForeignKey("contributor.id"), nullable=False)
     db.Index("contributor_id_idx", contributor_id)
 
     def __init__(
@@ -435,7 +435,7 @@ class RealTimeUpdate(db.Model, TimestampMixin):  # type: ignore
     error = db.Column(db.Text, nullable=True)
     raw_data = deferred(db.Column(db.Text, nullable=True))
     contributor = db.Column(db.Text, nullable=True)
-    contributor_id = db.Column(db.Text, db.ForeignKey('contributor.id'), nullable=False)
+    contributor_id = db.Column(db.Text, db.ForeignKey("contributor.id"), nullable=False)
 
     trip_updates = db.relationship(
         "TripUpdate",
@@ -451,7 +451,9 @@ class RealTimeUpdate(db.Model, TimestampMixin):  # type: ignore
         db.Index("realtime_update_contributor_id_and_created_at", "created_at", "contributor_id"),
     )
 
-    def __init__(self, raw_data, connector, contributor="realtime.cots", status="OK", error=None, received_at=None):
+    def __init__(
+        self, raw_data, connector, contributor="realtime.cots", status="OK", error=None, received_at=None
+    ):
         self.id = gen_uuid()
         self.raw_data = raw_data
         self.connector = connector

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -448,6 +448,7 @@ class RealTimeUpdate(db.Model, TimestampMixin):  # type: ignore
     __table_args__ = (
         db.Index("realtime_update_created_at", "created_at"),
         db.Index("realtime_update_contributor_and_created_at", "created_at", "contributor"),
+        db.Index("realtime_update_contributor_id_and_created_at", "created_at", "contributor_id"),
     )
 
     def __init__(self, raw_data, connector, contributor="realtime.cots", status="OK", error=None, received_at=None):

--- a/kirin/core/populate_pb.py
+++ b/kirin/core/populate_pb.py
@@ -126,8 +126,8 @@ def fill_message(pb_trip_update, message):
 
 def fill_trip_update(pb_trip_update, trip_update):
     pb_trip = pb_trip_update.trip
-    if trip_update.contributor:
-        pb_trip.Extensions[kirin_pb2.contributor] = trip_update.contributor
+    if trip_update.contributor_id:
+        pb_trip.Extensions[kirin_pb2.contributor] = trip_update.contributor_id
     if trip_update.message:
         fill_message(pb_trip_update, trip_update.message)
     if trip_update.company_id:

--- a/kirin/cots/model_maker.py
+++ b/kirin/cots/model_maker.py
@@ -379,6 +379,7 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
         Following the COTS spec: https://github.com/CanalTP/kirin/blob/master/documentation/cots_connector.md
         """
         trip_update = model.TripUpdate(vj=vj, contributor=self.contributor)
+        trip_update.contributor = self.contributor
         trip_update.contributor_id = self.contributor
         trip_message_id = get_value(json_train, "idMotifInterneReference", nullable=True)
         if trip_message_id:

--- a/kirin/cots/model_maker.py
+++ b/kirin/cots/model_maker.py
@@ -295,7 +295,7 @@ def _get_action_on_trip(train_numbers, dict_version, pdps):
 
 
 class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
-    def __init__(self, nav, contributor=None):
+    def __init__(self, nav, contributor="realtime.cots"):
         super(KirinModelBuilder, self).__init__(nav, contributor)
         self.message_handler = MessageHandler(
             api_key=current_app.config[str("COTS_PAR_IV_API_KEY")],
@@ -378,8 +378,8 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
         create the new TripUpdate object
         Following the COTS spec: https://github.com/CanalTP/kirin/blob/master/documentation/cots_connector.md
         """
-        trip_update = model.TripUpdate(vj=vj)
-        trip_update.contributor = self.contributor
+        trip_update = model.TripUpdate(vj=vj, contributor=self.contributor)
+        trip_update.contributor_id = self.contributor
         trip_message_id = get_value(json_train, "idMotifInterneReference", nullable=True)
         if trip_message_id:
             trip_update.message = self.message_handler.get_message(index=trip_message_id)

--- a/kirin/cots/model_maker.py
+++ b/kirin/cots/model_maker.py
@@ -379,7 +379,6 @@ class KirinModelBuilder(AbstractSNCFKirinModelBuilder):
         Following the COTS spec: https://github.com/CanalTP/kirin/blob/master/documentation/cots_connector.md
         """
         trip_update = model.TripUpdate(vj=vj, contributor=self.contributor)
-        trip_update.contributor = self.contributor
         trip_update.contributor_id = self.contributor
         trip_message_id = get_value(json_train, "idMotifInterneReference", nullable=True)
         if trip_message_id:

--- a/kirin/gtfs_rt/gtfs_rt.py
+++ b/kirin/gtfs_rt/gtfs_rt.py
@@ -49,6 +49,9 @@ def _get_gtfs_rt(req):
 
 class GtfsRT(Resource):
     def __init__(self):
+        # TODO:
+        #  For the future multi-gtfs_rt with configurations in the table contributor
+        #  parameters values should be updated by parameters of config file if present.
         url = current_app.config[str("NAVITIA_URL")]
         token = current_app.config.get(str("NAVITIA_GTFS_RT_TOKEN"))
         timeout = current_app.config.get(str("NAVITIA_TIMEOUT"), 5)

--- a/kirin/gtfs_rt/model_maker.py
+++ b/kirin/gtfs_rt/model_maker.py
@@ -84,6 +84,7 @@ class KirinModelBuilder(object):
         self.period_filter_tolerance = datetime.timedelta(hours=3)
         self.stop_code_key = "source"  # TODO conf
         self.instance_data_pub_date = self.navitia.get_publication_date()
+        self.contributor_id = contributor
 
     def build(self, rt_update, data):
         """
@@ -131,6 +132,7 @@ class KirinModelBuilder(object):
         for vj in vjs:
             trip_update = model.TripUpdate(vj=vj)
             trip_update.contributor = self.contributor
+            trip_update.contributor_id = self.contributor_id
             highest_st_status = ModificationType.none.name
 
             is_tu_valid = True

--- a/kirin/gtfs_rt/model_maker.py
+++ b/kirin/gtfs_rt/model_maker.py
@@ -131,7 +131,6 @@ class KirinModelBuilder(object):
         trip_updates = []
         for vj in vjs:
             trip_update = model.TripUpdate(vj=vj)
-            trip_update.contributor = self.contributor
             trip_update.contributor_id = self.contributor_id
             highest_st_status = ModificationType.none.name
 

--- a/kirin/tasks.py
+++ b/kirin/tasks.py
@@ -113,6 +113,9 @@ from kirin.gtfs_rt.tasks import gtfs_poller
 
 @celery.task(bind=True)
 def poller(self):
+    # TODO:
+    #  For the future multi-gtfs_rt with configurations in the table contributor
+    #  parameters values should be updated by parameters of config file if present.
     config = {
         "contributor": app.config.get(str("GTFS_RT_CONTRIBUTOR")),
         "navitia_url": app.config.get(str("NAVITIA_URL")),

--- a/kirin/utils.py
+++ b/kirin/utils.py
@@ -79,6 +79,9 @@ def make_navitia_wrapper():
     """
     return a navitia wrapper to call the navitia API
     """
+    # TODO:
+    #  For the future multi-gtfs_rt with configurations in the table contributor
+    #  parameters values should be updated by parameters of config file if present.
     url = current_app.config[str("NAVITIA_URL")]
     token = current_app.config.get(str("NAVITIA_TOKEN"))
     instance = current_app.config[str("NAVITIA_INSTANCE")]

--- a/migrations/versions/443587af1780_reference_contributor_in_other_tables.py
+++ b/migrations/versions/443587af1780_reference_contributor_in_other_tables.py
@@ -8,8 +8,8 @@ Create Date: 2019-08-29 10:28:48.053647
 from __future__ import absolute_import, print_function, unicode_literals, division
 
 # revision identifiers, used by Alembic.
-revision = '443587af1780'
-down_revision = '53647ffeb3c6'
+revision = "443587af1780"
+down_revision = "53647ffeb3c6"
 
 from alembic import op
 import sqlalchemy as sa
@@ -30,11 +30,14 @@ def upgrade():
     op.execute("COMMIT")
 
     # add contributor_id in real_time_update and trip_update as foreign key
-    op.add_column('real_time_update', sa.Column('contributor_id', sa.Text(), nullable=True))
-    op.create_foreign_key('fk_real_time_update_contributor_id', 'real_time_update',
-                          'contributor', ['contributor_id'], ['id'])
-    op.add_column('trip_update', sa.Column('contributor_id', sa.Text(), nullable=True))
-    op.create_foreign_key('fk_trip_update_contributor_id', 'trip_update', 'contributor', ['contributor_id'], ['id'])
+    op.add_column("real_time_update", sa.Column("contributor_id", sa.Text(), nullable=True))
+    op.create_foreign_key(
+        "fk_real_time_update_contributor_id", "real_time_update", "contributor", ["contributor_id"], ["id"]
+    )
+    op.add_column("trip_update", sa.Column("contributor_id", sa.Text(), nullable=True))
+    op.create_foreign_key(
+        "fk_trip_update_contributor_id", "trip_update", "contributor", ["contributor_id"], ["id"]
+    )
 
     # Update contributor_id value with contributor
     op.execute("UPDATE real_time_update SET contributor_id = contributor;")
@@ -46,8 +49,10 @@ def upgrade():
 
     # create index on contributor_id
     op.create_index(
-        "realtime_update_contributor_id_and_created_at", "real_time_update",
-        ["created_at", "contributor_id"], unique=False,
+        "realtime_update_contributor_id_and_created_at",
+        "real_time_update",
+        ["created_at", "contributor_id"],
+        unique=False,
     )
     op.create_index("contributor_id_idx", "trip_update", ["contributor_id"], unique=False)
 
@@ -58,10 +63,9 @@ def downgrade():
     op.drop_index("contributor_id_idx", table_name="trip_update")
 
     # Drop foreignKey constraints
-    op.drop_constraint('fk_trip_update_contributor_id', 'trip_update', type_='foreignkey')
-    op.drop_constraint('fk_real_time_update_contributor_id', 'real_time_update', type_='foreignkey')
+    op.drop_constraint("fk_trip_update_contributor_id", "trip_update", type_="foreignkey")
+    op.drop_constraint("fk_real_time_update_contributor_id", "real_time_update", type_="foreignkey")
 
     # Delete contributor_id in real_time_update and trip_update
-    op.drop_column('trip_update', 'contributor_id')
-    op.drop_column('real_time_update', 'contributor_id')
-
+    op.drop_column("trip_update", "contributor_id")
+    op.drop_column("real_time_update", "contributor_id")

--- a/migrations/versions/443587af1780_reference_contributor_in_other_tables.py
+++ b/migrations/versions/443587af1780_reference_contributor_in_other_tables.py
@@ -16,18 +16,20 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    # Insert information for a contributor 'realtime.cots' and 'realtime.sherbrooke' if absent
+    # Insert information for a contributor 'realtime.cots' and 'realtime.sherbrooke'
+    # if present in the table trip_update and absent in contributor
     op.execute(
         "INSERT INTO contributor SELECT 'realtime.cots','sncf',"
         "'token_to_be_modified','feed_url_to_be_modified','cots'"
-        " WHERE NOT EXISTS (SELECT * FROM contributor WHERE ID = 'realtime.cots');"
+        " WHERE 'realtime.cots' in (SELECT DISTINCT contributor FROM real_time_update)"
+        " AND NOT EXISTS (SELECT * FROM contributor WHERE ID = 'realtime.cots');"
     )
     op.execute(
         "INSERT INTO contributor SELECT 'realtime.sherbrooke','ca-qc-sherbrooke',"
         "'token_to_be_modified','feed_url_to_be_modified','gtfs-rt'"
-        " WHERE NOT EXISTS (SELECT * FROM contributor WHERE ID = 'realtime.sherbrooke');"
+        " WHERE 'realtime.sherbrooke' in (SELECT DISTINCT contributor FROM real_time_update)"
+        " AND NOT EXISTS (SELECT * FROM contributor WHERE ID = 'realtime.sherbrooke');"
     )
-    op.execute("COMMIT")
 
     # add contributor_id in real_time_update and trip_update as foreign key
     op.add_column("real_time_update", sa.Column("contributor_id", sa.Text(), nullable=True))
@@ -69,3 +71,6 @@ def downgrade():
     # Delete contributor_id in real_time_update and trip_update
     op.drop_column("trip_update", "contributor_id")
     op.drop_column("real_time_update", "contributor_id")
+
+    # Delete lines from the table contributor
+    op.execute("DELETE FROM contributor;")

--- a/migrations/versions/443587af1780_reference_contributor_in_other_tables.py
+++ b/migrations/versions/443587af1780_reference_contributor_in_other_tables.py
@@ -1,0 +1,67 @@
+"""
+Table contributor referenced in real_time_update and trip_update
+Revision ID: 443587af1780
+Revises: 53647ffeb3c6
+Create Date: 2019-08-29 10:28:48.053647
+
+"""
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+# revision identifiers, used by Alembic.
+revision = '443587af1780'
+down_revision = '53647ffeb3c6'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # Insert information for a contributor 'realtime.cots' and 'realtime.sherbrooke' if absent
+    op.execute(
+        "INSERT INTO contributor SELECT 'realtime.cots','sncf',"
+        "'token_to_be_modified','feed_url_to_be_modified','cots'"
+        " WHERE NOT EXISTS (SELECT * FROM contributor WHERE ID = 'realtime.cots');"
+    )
+    op.execute(
+        "INSERT INTO contributor SELECT 'realtime.sherbrooke','ca-qc-sherbrooke',"
+        "'token_to_be_modified','feed_url_to_be_modified','gtfs-rt'"
+        " WHERE NOT EXISTS (SELECT * FROM contributor WHERE ID = 'realtime.sherbrooke');"
+    )
+    op.execute("COMMIT")
+
+    # add contributor_id in real_time_update and trip_update as foreign key
+    op.add_column('real_time_update', sa.Column('contributor_id', sa.Text(), nullable=True))
+    op.create_foreign_key('fk_real_time_update_contributor_id', 'real_time_update',
+                          'contributor', ['contributor_id'], ['id'])
+    op.add_column('trip_update', sa.Column('contributor_id', sa.Text(), nullable=True))
+    op.create_foreign_key('fk_trip_update_contributor_id', 'trip_update', 'contributor', ['contributor_id'], ['id'])
+
+    # Update contributor_id value with contributor
+    op.execute("UPDATE real_time_update SET contributor_id = contributor;")
+    op.execute("UPDATE trip_update SET contributor_id = contributor;")
+
+    # Modify nullable property to False
+    op.execute("ALTER TABLE real_time_update ALTER COLUMN contributor_id SET NOT NULL;")
+    op.execute("ALTER TABLE trip_update ALTER COLUMN contributor_id SET NOT NULL;")
+
+    # create index on contributor_id
+    op.create_index(
+        "realtime_update_contributor_id_and_created_at", "real_time_update",
+        ["created_at", "contributor_id"], unique=False,
+    )
+    op.create_index("contributor_id_idx", "trip_update", ["contributor_id"], unique=False)
+
+
+def downgrade():
+    # Drop index on contributor_id
+    op.drop_index("realtime_update_contributor_id_and_created_at", table_name="real_time_update")
+    op.drop_index("contributor_id_idx", table_name="trip_update")
+
+    # Drop foreignKey constraints
+    op.drop_constraint('fk_trip_update_contributor_id', 'trip_update', type_='foreignkey')
+    op.drop_constraint('fk_real_time_update_contributor_id', 'real_time_update', type_='foreignkey')
+
+    # Delete contributor_id in real_time_update and trip_update
+    op.drop_column('trip_update', 'contributor_id')
+    op.drop_column('real_time_update', 'contributor_id')
+

--- a/migrations/versions/443587af1780_reference_contributor_in_other_tables.py
+++ b/migrations/versions/443587af1780_reference_contributor_in_other_tables.py
@@ -73,4 +73,4 @@ def downgrade():
     op.drop_column("real_time_update", "contributor_id")
 
     # Delete lines from the table contributor
-    op.execute("DELETE FROM contributor;")
+    op.execute("DELETE FROM contributor WHERE id IN ('realtime.cots', 'realtime.sherbrooke') ;")

--- a/migrations/versions/5010b8ad1f2e_.py
+++ b/migrations/versions/5010b8ad1f2e_.py
@@ -1,0 +1,41 @@
+"""
+Deleting column contributor from tables real_time_update and trip_update
+Revision ID: 5010b8ad1f2e
+Revises: 443587af1780
+Create Date: 2019-09-04 11:09:48.072326
+
+"""
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+# revision identifiers, used by Alembic.
+revision = '5010b8ad1f2e'
+down_revision = u'443587af1780'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # Drop indexes on contributor
+    op.drop_index('realtime_update_contributor_and_created_at', table_name='real_time_update')
+    op.drop_index('contributor_idx', table_name='trip_update')
+
+    # Drop column contributor
+    op.drop_column('real_time_update', 'contributor')
+    op.drop_column('trip_update', 'contributor')
+
+
+def downgrade():
+    # Add column contributor in the tables real_time_update and trip_update
+    op.add_column('trip_update', sa.Column('contributor', sa.TEXT(), autoincrement=False, nullable=True))
+    op.add_column('real_time_update', sa.Column('contributor', sa.TEXT(), autoincrement=False, nullable=True))
+
+    # Add indexes on contributor
+    op.create_index('contributor_idx', 'trip_update', ['contributor'], unique=False)
+    op.create_index(
+        'realtime_update_contributor_and_created_at', 'real_time_update', ['created_at', 'contributor'], unique=False
+    )
+
+    # Update contributor with the value of contributor_id
+    op.execute("UPDATE real_time_update SET contributor = contributor_id;")
+    op.execute("UPDATE trip_update SET contributor = contributor_id;")

--- a/migrations/versions/5010b8ad1f2e_.py
+++ b/migrations/versions/5010b8ad1f2e_.py
@@ -8,8 +8,8 @@ Create Date: 2019-09-04 11:09:48.072326
 from __future__ import absolute_import, print_function, unicode_literals, division
 
 # revision identifiers, used by Alembic.
-revision = '5010b8ad1f2e'
-down_revision = u'443587af1780'
+revision = "5010b8ad1f2e"
+down_revision = "443587af1780"
 
 from alembic import op
 import sqlalchemy as sa
@@ -17,23 +17,26 @@ import sqlalchemy as sa
 
 def upgrade():
     # Drop indexes on contributor
-    op.drop_index('realtime_update_contributor_and_created_at', table_name='real_time_update')
-    op.drop_index('contributor_idx', table_name='trip_update')
+    op.drop_index("realtime_update_contributor_and_created_at", table_name="real_time_update")
+    op.drop_index("contributor_idx", table_name="trip_update")
 
     # Drop column contributor
-    op.drop_column('real_time_update', 'contributor')
-    op.drop_column('trip_update', 'contributor')
+    op.drop_column("real_time_update", "contributor")
+    op.drop_column("trip_update", "contributor")
 
 
 def downgrade():
     # Add column contributor in the tables real_time_update and trip_update
-    op.add_column('trip_update', sa.Column('contributor', sa.TEXT(), autoincrement=False, nullable=True))
-    op.add_column('real_time_update', sa.Column('contributor', sa.TEXT(), autoincrement=False, nullable=True))
+    op.add_column("trip_update", sa.Column("contributor", sa.TEXT(), autoincrement=False, nullable=True))
+    op.add_column("real_time_update", sa.Column("contributor", sa.TEXT(), autoincrement=False, nullable=True))
 
     # Add indexes on contributor
-    op.create_index('contributor_idx', 'trip_update', ['contributor'], unique=False)
+    op.create_index("contributor_idx", "trip_update", ["contributor"], unique=False)
     op.create_index(
-        'realtime_update_contributor_and_created_at', 'real_time_update', ['created_at', 'contributor'], unique=False
+        "realtime_update_contributor_and_created_at",
+        "real_time_update",
+        ["created_at", "contributor"],
+        unique=False,
     )
 
     # Update contributor with the value of contributor_id

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -64,7 +64,8 @@ def clean_db():
     before all tests the database is cleared
     """
     with app.app_context():
-        tables = [six.text_type(table) for table in db.metadata.sorted_tables]
+        # The table contributor should never be emptied as referenced in real_time_update and trip_update
+        tables = [six.text_type(table) for table in db.metadata.sorted_tables if six.text_type(table) != 'contributor']
         db.session.execute("TRUNCATE {} CASCADE;".format(", ".join(tables)))
         db.session.commit()
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -34,6 +34,7 @@ import os
 import six
 
 from kirin import app, db
+from kirin.core import model
 import pytest
 import flask_migrate
 
@@ -70,13 +71,19 @@ def clean_db():
         db.session.commit()
 
         # Add two contributors in the table
-        db.session.execute(
-            "INSERT INTO contributor VALUES('realtime.cots','sncf',"
-            "'token_to_be_modified','feed_url_to_be_modified','cots');"
-        )
-        db.session.execute(
-            "INSERT INTO contributor VALUES('realtime.sherbrooke','sherbrooke',"
-            "'token_to_be_modified','feed_url_to_be_modified','gtfs-rt');"
+        db.session.add_all(
+            [
+                model.Contributor(
+                    "realtime.cots", "sncf", "cots", "token_to_be_modified", "feed_url_to_be_modified"
+                ),
+                model.Contributor(
+                    "realtime.sherbrooke",
+                    "sherbrooke",
+                    "gtfs-rt",
+                    "token_to_be_modified",
+                    "feed_url_to_be_modified",
+                ),
+            ]
         )
         db.session.commit()
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -65,10 +65,19 @@ def clean_db():
     """
     with app.app_context():
         # The table contributor should never be emptied as referenced in real_time_update and trip_update
-        tables = [
-            six.text_type(table) for table in db.metadata.sorted_tables if six.text_type(table) != "contributor"
-        ]
+        tables = [six.text_type(table) for table in db.metadata.sorted_tables]
         db.session.execute("TRUNCATE {} CASCADE;".format(", ".join(tables)))
+        db.session.commit()
+
+        # Add two contributors in the table
+        db.session.execute(
+            "INSERT INTO contributor VALUES('realtime.cots','sncf',"
+            "'token_to_be_modified','feed_url_to_be_modified','cots');"
+        )
+        db.session.execute(
+            "INSERT INTO contributor VALUES('realtime.sherbrooke','sherbrooke',"
+            "'token_to_be_modified','feed_url_to_be_modified','gtfs-rt');"
+        )
         db.session.commit()
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -65,7 +65,9 @@ def clean_db():
     """
     with app.app_context():
         # The table contributor should never be emptied as referenced in real_time_update and trip_update
-        tables = [six.text_type(table) for table in db.metadata.sorted_tables if six.text_type(table) != 'contributor']
+        tables = [
+            six.text_type(table) for table in db.metadata.sorted_tables if six.text_type(table) != "contributor"
+        ]
         db.session.execute("TRUNCATE {} CASCADE;".format(", ".join(tables)))
         db.session.commit()
 

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -50,6 +50,10 @@ def test_get_contributor_end_point(test_client):
 
 @pytest.fixture
 def with_contributors():
+    # Clean table contributor before adding any elements as we don't clean it in the function clean_db
+    db.session.execute("TRUNCATE table contributor CASCADE;")
+    db.session.commit()
+
     db.session.add_all(
         [
             model.Contributor("realtime.sherbrooke", "ca", "gtfs-rt", "my_token", "http://feed.url"),
@@ -129,7 +133,7 @@ def test_post_new_contributor(test_client):
     assert contrib.feed_url == "http://nihongo.jp"
 
 
-def test_post_new_partial_contributor(test_client):
+def test_post_new_partial_contributor(test_client, with_contributors):
     new_contrib = {"id": "realtime.tokyo", "navitia_coverage": "jp", "connector_type": "gtfs-rt"}
     resp = test_client.post("/contributors", json=new_contrib)
     assert resp.status_code == 201
@@ -192,7 +196,7 @@ def test_post_contributor_with_wrong_connector_type_should_fail(test_client):
     assert resp.status_code == 400
 
 
-def test_post_new_valid_contributor_with_unknown_parameter_should_work(test_client):
+def test_post_new_valid_contributor_with_unknown_parameter_should_work(test_client, with_contributors):
     resp = test_client.post(
         "/contributors",
         json={

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -50,7 +50,7 @@ def test_get_contributor_end_point(test_client):
 
 @pytest.fixture
 def with_contributors():
-    # Clean table contributor before adding any elements as we don't clean it in the function clean_db
+    # Clean table contributor before adding any elements as we fill two contributors in the function clean_db
     db.session.execute("TRUNCATE table contributor CASCADE;")
     db.session.commit()
 

--- a/tests/integration/cots_model_maker_test.py
+++ b/tests/integration/cots_model_maker_test.py
@@ -174,7 +174,8 @@ def test_get_action_on_trip_add(mock_navitia_fixture):
         assert action_on_trip == ActionOnTrip.PREVIOUSLY_ADDED.name
 
         # Clean database for further test
-        tables = [six.text_type(table) for table in db.metadata.sorted_tables]
+        # The table contributor should never be emptied as referenced in real_time_update and trip_update
+        tables = [six.text_type(table) for table in db.metadata.sorted_tables if six.text_type(table) != 'contributor']
         db.session.execute("TRUNCATE {} CASCADE;".format(", ".join(tables)))
         db.session.commit()
 

--- a/tests/integration/cots_model_maker_test.py
+++ b/tests/integration/cots_model_maker_test.py
@@ -175,7 +175,9 @@ def test_get_action_on_trip_add(mock_navitia_fixture):
 
         # Clean database for further test
         # The table contributor should never be emptied as referenced in real_time_update and trip_update
-        tables = [six.text_type(table) for table in db.metadata.sorted_tables if six.text_type(table) != 'contributor']
+        tables = [
+            six.text_type(table) for table in db.metadata.sorted_tables if six.text_type(table) != "contributor"
+        ]
         db.session.execute("TRUNCATE {} CASCADE;".format(", ".join(tables)))
         db.session.commit()
 

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -126,7 +126,7 @@ def test_cots_simple_post(mock_rabbitmq):
         assert rtu.received_at
         assert rtu.status == "OK"
         assert rtu.error is None
-        assert rtu.contributor == "realtime.cots"
+        assert rtu.contributor_id == "realtime.cots"
         assert rtu.connector == "cots"
         assert "listePointDeParcours" in rtu.raw_data
     assert mock_rabbitmq.call_count == 1

--- a/tests/integration/gtfs_rt_test.py
+++ b/tests/integration/gtfs_rt_test.py
@@ -153,8 +153,10 @@ def test_gtfs_model_builder(basic_gtfs_rt_data, basic_gtfs_rt_data_without_delay
     """
     with app.app_context():
         data = ""
-        rt_update = RealTimeUpdate(data, connector="gtfs-rt", contributor="realtime.gtfs")
-        trip_updates = gtfs_rt.KirinModelBuilder(dumb_nav_wrapper()).build(rt_update, basic_gtfs_rt_data)
+        rt_update = RealTimeUpdate(data, connector="gtfs-rt", contributor="realtime.sherbrooke")
+        trip_updates = gtfs_rt.KirinModelBuilder(dumb_nav_wrapper(), contributor="realtime.sherbrooke").build(
+            rt_update, basic_gtfs_rt_data
+        )
 
         # we associate the trip_update manually for sqlalchemy to make the links
         rt_update.trip_updates = trip_updates
@@ -194,8 +196,8 @@ def test_gtfs_model_builder(basic_gtfs_rt_data, basic_gtfs_rt_data_without_delay
         assert feed.entity[0].trip_update.trip.start_date == "20120615"  # must be UTC start date
 
         # if there is no delay field (delay is optional in StopTimeEvent), effect = 'UNKNOWN_EFFECT'
-        rt_update = RealTimeUpdate(data, connector="gtfs-rt", contributor="realtime.gtfs")
-        trip_updates = gtfs_rt.KirinModelBuilder(dumb_nav_wrapper()).build(
+        rt_update = RealTimeUpdate(data, connector="gtfs-rt", contributor="realtime.sherbrooke")
+        trip_updates = gtfs_rt.KirinModelBuilder(dumb_nav_wrapper(), contributor="realtime.sherbrooke").build(
             rt_update, basic_gtfs_rt_data_without_delays
         )
         assert len(trip_updates) == 1
@@ -365,8 +367,10 @@ def test_gtfs_pass_midnight_model_builder(pass_midnight_gtfs_rt_data):
     """
     with app.app_context():
         data = ""
-        rt_update = RealTimeUpdate(data, connector="gtfs-rt", contributor="realtime.gtfs")
-        trip_updates = gtfs_rt.KirinModelBuilder(dumb_nav_wrapper()).build(rt_update, pass_midnight_gtfs_rt_data)
+        rt_update = RealTimeUpdate(data, connector="gtfs-rt", contributor="realtime.sherbrooke")
+        trip_updates = gtfs_rt.KirinModelBuilder(dumb_nav_wrapper(), contributor="realtime.sherbrooke").build(
+            rt_update, pass_midnight_gtfs_rt_data
+        )
 
         # we associate the trip_update manually for sqlalchemy to make the links
         rt_update.trip_updates = trip_updates
@@ -516,8 +520,8 @@ def test_gtfs_pass_midnight_utc_model_builder(pass_midnight_utc_gtfs_rt_data):
     """
     with app.app_context():
         data = ""
-        rt_update = RealTimeUpdate(data, connector="gtfs-rt", contributor="realtime.gtfs")
-        trip_updates = gtfs_rt.KirinModelBuilder(dumb_nav_wrapper()).build(
+        rt_update = RealTimeUpdate(data, connector="gtfs-rt", contributor="realtime.sherbrooke")
+        trip_updates = gtfs_rt.KirinModelBuilder(dumb_nav_wrapper(), contributor="realtime.sherbrooke").build(
             rt_update, pass_midnight_utc_gtfs_rt_data
         )
 
@@ -1060,8 +1064,10 @@ def test_gtfs_lollipop_model_builder(lollipop_gtfs_rt_data):
     """
     with app.app_context():
         data = ""
-        rt_update = RealTimeUpdate(data, connector="gtfs-rt", contributor="realtime.gtfs")
-        trip_updates = gtfs_rt.KirinModelBuilder(dumb_nav_wrapper()).build(rt_update, lollipop_gtfs_rt_data)
+        rt_update = RealTimeUpdate(data, connector="gtfs-rt", contributor="realtime.sherbrooke")
+        trip_updates = gtfs_rt.KirinModelBuilder(dumb_nav_wrapper(), contributor="realtime.sherbrooke").build(
+            rt_update, lollipop_gtfs_rt_data
+        )
 
         # we associate the trip_update manually for sqlalchemy to make the links
         rt_update.trip_updates = trip_updates
@@ -1184,8 +1190,10 @@ def test_gtfs_bad_order_model_builder(bad_ordered_gtfs_rt_data):
     """
     with app.app_context():
         data = ""
-        rt_update = RealTimeUpdate(data, connector="gtfs-rt", contributor="realtime.gtfs")
-        trip_updates = gtfs_rt.KirinModelBuilder(dumb_nav_wrapper()).build(rt_update, bad_ordered_gtfs_rt_data)
+        rt_update = RealTimeUpdate(data, connector="gtfs-rt", contributor="realtime.sherbrooke")
+        trip_updates = gtfs_rt.KirinModelBuilder(dumb_nav_wrapper(), contributor="realtime.sherbrooke").build(
+            rt_update, bad_ordered_gtfs_rt_data
+        )
 
         # we associate the trip_update manually for sqlalchemy to make the links
         rt_update.trip_updates = trip_updates
@@ -1366,8 +1374,8 @@ def test_gtfs_lollipop_for_second_passage_model_builder(lollipop_gtfs_rt_from_se
     """
     with app.app_context():
         data = ""
-        rt_update = RealTimeUpdate(data, connector="gtfs-rt", contributor="realtime.gtfs")
-        trip_updates = gtfs_rt.KirinModelBuilder(dumb_nav_wrapper()).build(
+        rt_update = RealTimeUpdate(data, connector="gtfs-rt", contributor="realtime.sherbrooke")
+        trip_updates = gtfs_rt.KirinModelBuilder(dumb_nav_wrapper(), contributor="realtime.sherbrooke").build(
             rt_update, lollipop_gtfs_rt_from_second_passage_data
         )
 
@@ -1552,8 +1560,8 @@ def test_gtfs_more_stops_model_builder(gtfs_rt_data_with_more_stops):
     """
     with app.app_context():
         data = ""
-        rt_update = RealTimeUpdate(data, connector="gtfs-rt", contributor="realtime.gtfs")
-        trip_updates = gtfs_rt.KirinModelBuilder(dumb_nav_wrapper()).build(
+        rt_update = RealTimeUpdate(data, connector="gtfs-rt", contributor="realtime.sherbrooke")
+        trip_updates = gtfs_rt.KirinModelBuilder(dumb_nav_wrapper(), contributor="realtime.sherbrooke").build(
             rt_update, gtfs_rt_data_with_more_stops
         )
 
@@ -1765,7 +1773,7 @@ def test_save_gtfs_rt_with_error():
     """
     with app.app_context():
         save_gtfs_rt_with_error(
-            "toto", "gtfs-rt", contributor="realtime.gtfs", status="KO", error="Decode Error"
+            "toto", "gtfs-rt", contributor="realtime.sherbrooke", status="KO", error="Decode Error"
         )
         assert len(RealTimeUpdate.query.all()) == 1
         assert RealTimeUpdate.query.first().status == "KO"
@@ -1777,7 +1785,7 @@ def test_manage_db_with_http_error_without_insert():
     test the function "manage_db_error" without any insert of a new gtfs-rt
     """
     with app.app_context():
-        manage_db_error("toto", "gtfs-rt", contributor="realtime.gtfs", status="KO", error="Http Error")
+        manage_db_error("toto", "gtfs-rt", contributor="realtime.sherbrooke", status="KO", error="Http Error")
         assert len(RealTimeUpdate.query.all()) == 1
         assert RealTimeUpdate.query.first().raw_data == "toto"
         assert RealTimeUpdate.query.first().status == "KO"
@@ -1787,7 +1795,7 @@ def test_manage_db_with_http_error_without_insert():
         updated_at = RealTimeUpdate.query.first().updated_at
         assert updated_at > created_at
 
-        manage_db_error("toto", "gtfs-rt", contributor="realtime.gtfs", status="KO", error="Http Error")
+        manage_db_error("toto", "gtfs-rt", contributor="realtime.sherbrooke", status="KO", error="Http Error")
         assert len(RealTimeUpdate.query.all()) == 1
         assert RealTimeUpdate.query.first().raw_data == "toto"
         assert RealTimeUpdate.query.first().status == "KO"
@@ -1799,7 +1807,7 @@ def test_manage_db_with_http_error_without_insert():
 
         time.sleep(6)
 
-        manage_db_error("toto", "gtfs-rt", contributor="realtime.gtfs", status="KO", error="Http Error")
+        manage_db_error("toto", "gtfs-rt", contributor="realtime.sherbrooke", status="KO", error="Http Error")
         assert len(RealTimeUpdate.query.all()) == 1
         assert RealTimeUpdate.query.first().raw_data == "toto"
         assert RealTimeUpdate.query.first().status == "KO"
@@ -1814,7 +1822,7 @@ def test_manage_db_with_http_error_with_insert():
     no gtfs-rt with 'Http Error' inserted since more than 5 seconds
     """
     with app.app_context():
-        manage_db_error("toto", "gtfs-rt", contributor="realtime.gtfs", status="KO", error="Http Error")
+        manage_db_error("toto", "gtfs-rt", contributor="realtime.sherbrooke", status="KO", error="Http Error")
         assert len(RealTimeUpdate.query.all()) == 1
         assert RealTimeUpdate.query.first().raw_data == "toto"
         assert RealTimeUpdate.query.first().status == "KO"
@@ -1822,13 +1830,13 @@ def test_manage_db_with_http_error_with_insert():
 
         created_at = RealTimeUpdate.query.first().created_at
 
-        manage_db_error("", "gtfs-rt", contributor="realtime.gtfs", status="KO", error="Decode Error")
+        manage_db_error("", "gtfs-rt", contributor="realtime.sherbrooke", status="KO", error="Decode Error")
         assert len(RealTimeUpdate.query.all()) == 2
         assert RealTimeUpdate.query.order_by(desc(RealTimeUpdate.created_at)).first().status == "KO"
         assert RealTimeUpdate.query.order_by(desc(RealTimeUpdate.created_at)).first().error == "Decode Error"
         assert RealTimeUpdate.query.order_by(desc(RealTimeUpdate.created_at)).first().created_at > created_at
 
-        manage_db_error("toto", "gtfs-rt", contributor="realtime.gtfs", status="KO", error="Http Error")
+        manage_db_error("toto", "gtfs-rt", contributor="realtime.sherbrooke", status="KO", error="Http Error")
         assert len(RealTimeUpdate.query.all()) == 3
         assert RealTimeUpdate.query.order_by(desc(RealTimeUpdate.created_at)).first().raw_data == "toto"
         assert RealTimeUpdate.query.order_by(desc(RealTimeUpdate.created_at)).first().status == "KO"

--- a/tests/integration/gtfs_rt_test.py
+++ b/tests/integration/gtfs_rt_test.py
@@ -163,9 +163,13 @@ def test_gtfs_model_builder(basic_gtfs_rt_data, basic_gtfs_rt_data_without_delay
         db.session.add(rt_update)
         db.session.commit()
 
+        assert rt_update.contributor == "realtime.sherbrooke"
+        assert rt_update.contributor_id == "realtime.sherbrooke"
         assert len(trip_updates) == 1
         assert len(trip_updates[0].stop_time_updates) == 4
         assert trip_updates[0].effect == "SIGNIFICANT_DELAYS"
+        assert trip_updates[0].contributor == "realtime.sherbrooke"
+        assert trip_updates[0].contributor_id == "realtime.sherbrooke"
 
         # stop_time_update created with no delay
         first_stop = trip_updates[0].stop_time_updates[0]
@@ -444,7 +448,7 @@ def test_gtfs_rt_pass_midnight(pass_midnight_gtfs_rt_data, mock_rabbitmq):
         assert RealTimeUpdate.query.first().status == "OK"
 
         trip_update = TripUpdate.find_by_dated_vj("R:vj1", datetime.datetime(2012, 6, 16, 3, 30))
-
+        assert trip_update.contributor == "realtime.sherbrooke"
         assert trip_update
 
         assert trip_update.vj.get_start_timestamp() == datetime.datetime(2012, 6, 16, 3, 30)

--- a/tests/integration/gtfs_rt_test.py
+++ b/tests/integration/gtfs_rt_test.py
@@ -449,6 +449,7 @@ def test_gtfs_rt_pass_midnight(pass_midnight_gtfs_rt_data, mock_rabbitmq):
 
         trip_update = TripUpdate.find_by_dated_vj("R:vj1", datetime.datetime(2012, 6, 16, 3, 30))
         assert trip_update.contributor == "realtime.sherbrooke"
+        assert trip_update.contributor_id == "realtime.sherbrooke"
         assert trip_update
 
         assert trip_update.vj.get_start_timestamp() == datetime.datetime(2012, 6, 16, 3, 30)

--- a/tests/integration/gtfs_rt_test.py
+++ b/tests/integration/gtfs_rt_test.py
@@ -163,12 +163,10 @@ def test_gtfs_model_builder(basic_gtfs_rt_data, basic_gtfs_rt_data_without_delay
         db.session.add(rt_update)
         db.session.commit()
 
-        assert rt_update.contributor == "realtime.sherbrooke"
         assert rt_update.contributor_id == "realtime.sherbrooke"
         assert len(trip_updates) == 1
         assert len(trip_updates[0].stop_time_updates) == 4
         assert trip_updates[0].effect == "SIGNIFICANT_DELAYS"
-        assert trip_updates[0].contributor == "realtime.sherbrooke"
         assert trip_updates[0].contributor_id == "realtime.sherbrooke"
 
         # stop_time_update created with no delay
@@ -448,7 +446,6 @@ def test_gtfs_rt_pass_midnight(pass_midnight_gtfs_rt_data, mock_rabbitmq):
         assert RealTimeUpdate.query.first().status == "OK"
 
         trip_update = TripUpdate.find_by_dated_vj("R:vj1", datetime.datetime(2012, 6, 16, 3, 30))
-        assert trip_update.contributor == "realtime.sherbrooke"
         assert trip_update.contributor_id == "realtime.sherbrooke"
         assert trip_update
 

--- a/tests/integration/handle_test.py
+++ b/tests/integration/handle_test.py
@@ -40,7 +40,7 @@ from kirin import app, db
 from tests.check_utils import _dt
 
 
-def create_trip_update(id, trip_id, circulation_date, stops, status="update"):
+def create_trip_update(id, trip_id, circulation_date, stops, status="update", contributor="realtime.cots"):
     trip_update = TripUpdate(
         VehicleJourney(
             {
@@ -53,6 +53,7 @@ def create_trip_update(id, trip_id, circulation_date, stops, status="update"):
             datetime.datetime.combine(circulation_date, datetime.time(9, 10)),
         ),
         status,
+        contributor,
     )
     trip_update.id = id
     for stop in stops:
@@ -176,7 +177,7 @@ def test_handle_basic():
     # a RealTimeUpdate without any TripUpdate doesn't do anything
     with app.app_context():
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
-        res, _ = handle(real_time_update, [], "kisio-digital")
+        res, _ = handle(real_time_update, [], contributor="realtime.cots")
         assert res == real_time_update
 
 
@@ -198,11 +199,11 @@ def test_handle_new_vj():
         ],
     }
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update")
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor="realtime.cots")
         st = StopTimeUpdate({"id": "sa:1"}, departure_delay=timedelta(minutes=5), dep_status="update")
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
         trip_update.stop_time_updates.append(st)
-        res, _ = handle(real_time_update, [trip_update], "kisio-digital")
+        res, _ = handle(real_time_update, [trip_update], contributor="realtime.cots")
 
         assert len(res.trip_updates) == 1
         trip_update = res.trip_updates[0]
@@ -264,11 +265,11 @@ def test_past_midnight():
         vj = VehicleJourney(
             navitia_vj, datetime.datetime(2015, 9, 8, 21, 15, 0), datetime.datetime(2015, 9, 9, 4, 20, 0)
         )
-        trip_update = TripUpdate(vj, status="update")
+        trip_update = TripUpdate(vj, status="update", contributor="realtime.cots")
         st = StopTimeUpdate({"id": "sa:2"}, departure_delay=timedelta(minutes=31), dep_status="update", order=1)
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
         trip_update.stop_time_updates.append(st)
-        res, _ = handle(real_time_update, [trip_update], "kisio-digital")
+        res, _ = handle(real_time_update, [trip_update], contributor="realtime.cots")
 
         assert len(res.trip_updates) == 1
         trip_update = res.trip_updates[0]
@@ -298,7 +299,7 @@ def test_handle_new_trip_out_of_order(navitia_vj):
     so we have to reorder the stop times in the resulting trip_update
     """
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update")
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor="realtime.cots")
         st = StopTimeUpdate(
             {"id": "sa:2"},
             departure_delay=timedelta(minutes=40),
@@ -309,7 +310,7 @@ def test_handle_new_trip_out_of_order(navitia_vj):
         )
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
         trip_update.stop_time_updates.append(st)
-        res, _ = handle(real_time_update, [trip_update], "kisio-digital")
+        res, _ = handle(real_time_update, [trip_update], contributor="realtime.cots")
 
         assert len(res.trip_updates) == 1
         trip_update = res.trip_updates[0]
@@ -338,7 +339,7 @@ def test_manage_consistency(navitia_vj):
     expected result   08:10-08:10     10:15-10:15     11:10-11:10
     """
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update")
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor="realtime.cots")
         st = StopTimeUpdate(
             {"id": "sa:2"},
             arrival_delay=timedelta(minutes=70),
@@ -351,7 +352,7 @@ def test_manage_consistency(navitia_vj):
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
         real_time_update.id = "30866ce8-0638-4fa1-8556-1ddfa22d09d3"
         trip_update.stop_time_updates.append(st)
-        res, _ = handle(real_time_update, [trip_update], "kisio-digital")
+        res, _ = handle(real_time_update, [trip_update], contributor="realtime.cots")
 
         assert len(res.trip_updates) == 1
         trip_update = res.trip_updates[0]
@@ -384,7 +385,7 @@ def test_handle_update_vj(setup_database, navitia_vj):
     update kirin       -      *9:15-9:20*      -
     """
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update")
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor="realtime.cots")
         st = StopTimeUpdate(
             {"id": "sa:2"},
             arrival_delay=timedelta(minutes=10),
@@ -397,7 +398,7 @@ def test_handle_update_vj(setup_database, navitia_vj):
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
         real_time_update.id = "30866ce8-0638-4fa1-8556-1ddfa22d09d3"
         trip_update.stop_time_updates.append(st)
-        res, _ = handle(real_time_update, [trip_update], "kisio-digital")
+        res, _ = handle(real_time_update, [trip_update], contributor="realtime.cots")
 
         assert len(res.trip_updates) == 1
         trip_update = res.trip_updates[0]
@@ -462,7 +463,7 @@ def test_handle_update_vj(setup_database, navitia_vj):
 def test_simple_delay(navitia_vj):
     """Test on delay when there is nothing in the db"""
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update")
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor="realtime.cots")
         st = StopTimeUpdate(
             {"id": "sa:1"},
             departure_delay=timedelta(minutes=10),
@@ -473,7 +474,7 @@ def test_simple_delay(navitia_vj):
         )
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
         trip_update.stop_time_updates.append(st)
-        res, _ = handle(real_time_update, [trip_update], "kisio-digital")
+        res, _ = handle(real_time_update, [trip_update], contributor="realtime.cots")
         assert len(res.trip_updates) == 1
         trip_update = res.trip_updates[0]
         assert trip_update.status == "update"
@@ -558,14 +559,14 @@ def test_multiple_delays(setup_database, navitia_vj):
     update kirin      8:20*   *9:07-9:10     10:05
     """
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update")
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor="realtime.cots")
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
         trip_update.stop_time_updates = [
             # Note: the delay is based of the navitia's vj
             StopTimeUpdate({"id": "sa:1"}, departure_delay=timedelta(minutes=10), dep_status="update"),
             StopTimeUpdate({"id": "sa:2"}, arrival_delay=timedelta(minutes=2), arr_status="update"),
         ]
-        res, _ = handle(real_time_update, [trip_update], "kisio-digital")
+        res, _ = handle(real_time_update, [trip_update], contributor="realtime.cots")
 
         _check_multiples_delay(res)
 
@@ -583,20 +584,20 @@ def test_multiple_delays_in_2_updates(navitia_vj):
     same test as test_multiple_delays, but with nothing in the db and with 2 trip updates
     """
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update")
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor="realtime.cots")
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
         trip_update.stop_time_updates = [
             StopTimeUpdate({"id": "sa:1"}, departure_delay=timedelta(minutes=5), dep_status="update")
         ]
-        handle(real_time_update, [trip_update], "kisio-digital")
+        handle(real_time_update, [trip_update], contributor="realtime.cots")
 
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update")
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor="realtime.cots")
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
         trip_update.stop_time_updates = [
             StopTimeUpdate({"id": "sa:1"}, departure_delay=timedelta(minutes=10), dep_status="update"),
             StopTimeUpdate({"id": "sa:2"}, arrival_delay=timedelta(minutes=2), arr_status="update"),
         ]
-        res, _ = handle(real_time_update, [trip_update], "kisio-digital")
+        res, _ = handle(real_time_update, [trip_update], contributor="realtime.cots")
 
         _check_multiples_delay(res)
         # we also check that there is what we want in the db
@@ -618,9 +619,9 @@ def test_delays_then_cancellation(setup_database, navitia_vj):
     update kirin                   -
     """
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="delete")
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="delete", contributor="realtime.cots")
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
-        res, _ = handle(real_time_update, [trip_update], "kisio-digital")
+        res, _ = handle(real_time_update, [trip_update], contributor="realtime.cots")
 
         assert len(res.trip_updates) == 1
         trip_update = res.trip_updates[0]
@@ -634,16 +635,16 @@ def test_delays_then_cancellation_in_2_updates(navitia_vj):
     Same test as above, but with nothing in the db, and with 2 updates
     """
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update")
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor="realtime.cots")
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
         trip_update.stop_time_updates = [
             StopTimeUpdate({"id": "sa:1"}, departure_delay=timedelta(minutes=5), dep_status="update")
         ]
-        handle(real_time_update, [trip_update], "kisio-digital")
+        handle(real_time_update, [trip_update], contributor="realtime.cots")
 
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="delete")
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="delete", contributor="realtime.cots")
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
-        res, _ = handle(real_time_update, [trip_update], "kisio-digital")
+        res, _ = handle(real_time_update, [trip_update], contributor="realtime.cots")
 
         assert len(res.trip_updates) == 1
         trip_update = res.trip_updates[0]
@@ -714,12 +715,12 @@ def test_cancellation_then_delay(navitia_vj):
         db.session.commit()
 
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update")
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor="realtime.cots")
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
         trip_update.stop_time_updates = [
             StopTimeUpdate({"id": "sa:3"}, arrival_delay=timedelta(minutes=40), arr_status="update", order=2)
         ]
-        res, _ = handle(real_time_update, [trip_update], "kisio-digital")
+        res, _ = handle(real_time_update, [trip_update], "realtime.cots")
 
         _check_cancellation_then_delay(res)
 
@@ -729,16 +730,16 @@ def test_cancellation_then_delay_in_2_updates(navitia_vj):
     same as test_cancellation_then_delay, but with a clear db and in 2 updates
     """
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="delete")
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="delete", contributor="realtime.cots")
         trip_update.stop_time_updates = []
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
-        handle(real_time_update, [trip_update], "kisio-digital")
+        handle(real_time_update, [trip_update], contributor="realtime.cots")
 
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update")
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor="realtime.cots")
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
         trip_update.stop_time_updates = [
             StopTimeUpdate({"id": "sa:3"}, arrival_delay=timedelta(minutes=40), arr_status="update", order=2)
         ]
-        res, _ = handle(real_time_update, [trip_update], "kisio-digital")
+        res, _ = handle(real_time_update, [trip_update], "realtime.cots")
 
         _check_cancellation_then_delay(res)

--- a/tests/integration/model_test.py
+++ b/tests/integration/model_test.py
@@ -238,7 +238,9 @@ def test_find_activate():
                             20150905   20150906
         """
 
-        rtu = TripUpdate.find_by_contributor_period(["realtime.cots"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 6))
+        rtu = TripUpdate.find_by_contributor_period(
+            ["realtime.cots"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 6)
+        )
         assert len(rtu) == 0
 
         """
@@ -250,7 +252,9 @@ def test_find_activate():
                             20150905            20150908
         """
 
-        rtu = TripUpdate.find_by_contributor_period(["realtime.cots"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 8))
+        rtu = TripUpdate.find_by_contributor_period(
+            ["realtime.cots"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 8)
+        )
         assert len(rtu) == 1
 
         """
@@ -262,7 +266,9 @@ def test_find_activate():
                             20150905                    20150909
         """
 
-        rtu = TripUpdate.find_by_contributor_period(["realtime.cots"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 9))
+        rtu = TripUpdate.find_by_contributor_period(
+            ["realtime.cots"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 9)
+        )
         assert len(rtu) == 1
 
         """

--- a/tests/integration/model_test.py
+++ b/tests/integration/model_test.py
@@ -39,7 +39,7 @@ import pytest
 import sqlalchemy
 
 
-def create_trip_update(vj_id, trip_id, circulation_date):
+def create_trip_update(vj_id, trip_id, circulation_date, contributor="realtime.cots"):
     trip_update = TripUpdate()
     vj = VehicleJourney(
         {
@@ -53,6 +53,7 @@ def create_trip_update(vj_id, trip_id, circulation_date):
     )
     vj.id = vj_id
     trip_update.vj = vj
+    trip_update.contributor_id = contributor
 
     db.session.add(vj)
     db.session.add(trip_update)

--- a/tests/integration/model_test.py
+++ b/tests/integration/model_test.py
@@ -63,7 +63,7 @@ def create_real_time_update(id, contributor, connector, vj_id, trip_id, circulat
     rtu = RealTimeUpdate("", connector, contributor=contributor)
     rtu.id = id
     trip_update = create_trip_update(vj_id, trip_id, circulation_date)
-    trip_update.contributor = contributor
+    trip_update.contributor_id = contributor
     rtu.trip_updates.append(trip_update)
 
 
@@ -115,7 +115,7 @@ def test_find_activate():
     with app.app_context():
         create_real_time_update(
             "70866ce8-0638-4fa1-8556-1ddfa22d09d3",
-            "C1",
+            "realtime.cots",
             "cots",
             "70866ce8-0638-4fa1-8556-1ddfa22d09d3",
             "vj1",
@@ -123,7 +123,7 @@ def test_find_activate():
         )
         create_real_time_update(
             "70866ce8-0638-4fa1-8556-1ddfa22d09d4",
-            "C1",
+            "realtime.cots",
             "cots",
             "70866ce8-0638-4fa1-8556-1ddfa22d09d4",
             "vj2",
@@ -131,7 +131,7 @@ def test_find_activate():
         )
         create_real_time_update(
             "70866ce8-0638-4fa1-8556-1ddfa22d09d5",
-            "C1",
+            "realtime.cots",
             "cots",
             "70866ce8-0638-4fa1-8556-1ddfa22d09d5",
             "vj3",
@@ -140,7 +140,7 @@ def test_find_activate():
 
         create_real_time_update(
             "70866ce8-0638-4fa1-8556-1ddfa22d09d6",
-            "C2",
+            "realtime.sherbrooke",
             "cots",
             "70866ce8-0638-4fa1-8556-1ddfa22d09d6",
             "vj4",
@@ -149,88 +149,88 @@ def test_find_activate():
         db.session.commit()
 
         """
-        contributor                     C1
+        contributor                     realtime.cots
         VehicleJourney                  vj1
         Circulation date                20150908                         20150910                20150912
                                             |                               |                       |
         request date            20150906    |                               |                       |
         """
 
-        rtu = TripUpdate.find_by_contributor_period(["C1"], datetime.date(2015, 9, 6))
+        rtu = TripUpdate.find_by_contributor_period(["realtime.cots"], datetime.date(2015, 9, 6))
         assert len(rtu) == 3
         assert rtu[0].vj_id == "70866ce8-0638-4fa1-8556-1ddfa22d09d3"
         assert rtu[1].vj_id == "70866ce8-0638-4fa1-8556-1ddfa22d09d4"
         assert rtu[2].vj_id == "70866ce8-0638-4fa1-8556-1ddfa22d09d5"
 
         """
-        contributor                     C1
+        contributor                     realtime.cots
         VehicleJourney                  vj1
         Circulation date                20150908                         20150910                20150912
                                             |                               |                       |
         request date                    20150908                            |                       |
         """
-        rtu = TripUpdate.find_by_contributor_period(["C1"], datetime.date(2015, 9, 8))
+        rtu = TripUpdate.find_by_contributor_period(["realtime.cots"], datetime.date(2015, 9, 8))
         assert len(rtu) == 3
 
         """
-        contributor                     C1
+        contributor                     realtime.cots
         VehicleJourney                  vj1
         Circulation date                20150908                         20150910                20150912
                                             |                               |                       |
         request date                        |   20150909                    |                       |
         """
-        rtu = TripUpdate.find_by_contributor_period(["C1"], datetime.date(2015, 9, 9))
+        rtu = TripUpdate.find_by_contributor_period(["realtime.cots"], datetime.date(2015, 9, 9))
         assert len(rtu) == 2
         assert rtu[0].vj_id == "70866ce8-0638-4fa1-8556-1ddfa22d09d4"
         assert rtu[1].vj_id == "70866ce8-0638-4fa1-8556-1ddfa22d09d5"
 
         """
-        contributor                     C1
+        contributor                     realtime.cots
         VehicleJourney                  vj1
         Circulation date                20150908                         20150910                20150912
                                             |                               |                       |
         request date                        |                            20150910                   |
         """
 
-        rtu = TripUpdate.find_by_contributor_period(["C1"], datetime.date(2015, 9, 10))
+        rtu = TripUpdate.find_by_contributor_period(["realtime.cots"], datetime.date(2015, 9, 10))
         assert len(rtu) == 2
 
         """
-        contributor                     C1
+        contributor                     realtime.cots
         VehicleJourney                  vj1
         Circulation date                20150908                         20150910                20150912
                                             |                               |                       |
         request date                        |                               |   20150911            |
         """
 
-        rtu = TripUpdate.find_by_contributor_period(["C1"], datetime.date(2015, 9, 11))
+        rtu = TripUpdate.find_by_contributor_period(["realtime.cots"], datetime.date(2015, 9, 11))
         assert len(rtu) == 1
         assert rtu[0].vj_id == "70866ce8-0638-4fa1-8556-1ddfa22d09d5"
 
         """
-        contributor                     C1
+        contributor                     realtime.cots
         VehicleJourney                  vj1
         Circulation date                20150908                         20150910                20150912
                                             |                               |                       |
         request date                        |                               |                    20150912
         """
 
-        rtu = TripUpdate.find_by_contributor_period(["C1"], datetime.date(2015, 9, 12))
+        rtu = TripUpdate.find_by_contributor_period(["realtime.cots"], datetime.date(2015, 9, 12))
         assert len(rtu) == 1
 
         """
-        contributor                     C1
+        contributor                     realtime.cots
         VehicleJourney                  vj1
         Circulation date                20150908                         20150910                20150912
                                             |                               |                       |
         request date                        |                               |                       |   20150913
         """
 
-        rtu = TripUpdate.find_by_contributor_period(["C1"], datetime.date(2015, 9, 13))
+        rtu = TripUpdate.find_by_contributor_period(["realtime.cots"], datetime.date(2015, 9, 13))
         assert len(rtu) == 0
 
         """
-        contributor                            C1
+        contributor                            realtime.cots
         VehicleJourney                          vj1
         Circulation date                        20150908                         20150910                20150912
                                                     |                               |                       |
@@ -238,11 +238,11 @@ def test_find_activate():
                             20150905   20150906
         """
 
-        rtu = TripUpdate.find_by_contributor_period(["C1"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 6))
+        rtu = TripUpdate.find_by_contributor_period(["realtime.cots"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 6))
         assert len(rtu) == 0
 
         """
-        contributor                            C1
+        contributor                            realtime.cots
         VehicleJourney                          vj1
         Circulation date                        20150908                         20150910                20150912
                                                     |                               |                       |
@@ -250,11 +250,11 @@ def test_find_activate():
                             20150905            20150908
         """
 
-        rtu = TripUpdate.find_by_contributor_period(["C1"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 8))
+        rtu = TripUpdate.find_by_contributor_period(["realtime.cots"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 8))
         assert len(rtu) == 1
 
         """
-        contributor                            C1
+        contributor                            realtime.cots
         VehicleJourney                          vj1
         Circulation date                        20150908                         20150910                20150912
                                                     |                               |                       |
@@ -262,11 +262,11 @@ def test_find_activate():
                             20150905                    20150909
         """
 
-        rtu = TripUpdate.find_by_contributor_period(["C1"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 9))
+        rtu = TripUpdate.find_by_contributor_period(["realtime.cots"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 9))
         assert len(rtu) == 1
 
         """
-        contributor                            C1
+        contributor                            realtime.cots
         VehicleJourney                          vj1
         Circulation date                        20150908                         20150910                20150912
                                                     |                               |                       |
@@ -275,12 +275,12 @@ def test_find_activate():
         """
 
         rtu = TripUpdate.find_by_contributor_period(
-            ["C1"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 10)
+            ["realtime.cots"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 10)
         )
         assert len(rtu) == 2
 
         """
-        contributor                            C1
+        contributor                            realtime.cots
         VehicleJourney                          vj1
         Circulation date                        20150908                         20150910                20150912
                                                     |                               |                       |
@@ -289,12 +289,12 @@ def test_find_activate():
         """
 
         rtu = TripUpdate.find_by_contributor_period(
-            ["C1"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 11)
+            ["realtime.cots"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 11)
         )
         assert len(rtu) == 2
 
         """
-        contributor                            C1
+        contributor                            realtime.cots
         VehicleJourney                          vj1
         Circulation date                        20150908                         20150910                20150912
                                                     |                               |                       |
@@ -303,12 +303,12 @@ def test_find_activate():
         """
 
         rtu = TripUpdate.find_by_contributor_period(
-            ["C1"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 12)
+            ["realtime.cots"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 12)
         )
         assert len(rtu) == 3
 
         """
-        contributor                            C1
+        contributor                            realtime.cots
         VehicleJourney                          vj1
         Circulation date                        20150908                         20150910                20150912
                                                     |                               |                       |
@@ -317,12 +317,12 @@ def test_find_activate():
         """
 
         rtu = TripUpdate.find_by_contributor_period(
-            ["C1"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 14)
+            ["realtime.cots"], datetime.date(2015, 9, 5), datetime.date(2015, 9, 14)
         )
         assert len(rtu) == 3
 
         """
-        contributor                            C1
+        contributor                            realtime.cots
         VehicleJourney                          vj1
         Circulation date                        20150908                         20150910                20150912
                                                     |                               |                       |
@@ -331,12 +331,12 @@ def test_find_activate():
         """
 
         rtu = TripUpdate.find_by_contributor_period(
-            ["C1"], datetime.date(2015, 9, 8), datetime.date(2015, 9, 14)
+            ["realtime.cots"], datetime.date(2015, 9, 8), datetime.date(2015, 9, 14)
         )
         assert len(rtu) == 3
 
         """
-        contributor                            C1
+        contributor                            realtime.cots
         VehicleJourney                          vj1
         Circulation date                        20150908                         20150910                20150912
                                                     |                               |                       |
@@ -345,12 +345,12 @@ def test_find_activate():
         """
 
         rtu = TripUpdate.find_by_contributor_period(
-            ["C1"], datetime.date(2015, 9, 9), datetime.date(2015, 9, 14)
+            ["realtime.cots"], datetime.date(2015, 9, 9), datetime.date(2015, 9, 14)
         )
         assert len(rtu) == 2
 
         """
-        contributor                            C1
+        contributor                            realtime.cots
         VehicleJourney                          vj1
         Circulation date                        20150908                         20150910                20150912
                                                     |                               |                       |
@@ -359,12 +359,12 @@ def test_find_activate():
         """
 
         rtu = TripUpdate.find_by_contributor_period(
-            ["C1"], datetime.date(2015, 9, 10), datetime.date(2015, 9, 14)
+            ["realtime.cots"], datetime.date(2015, 9, 10), datetime.date(2015, 9, 14)
         )
         assert len(rtu) == 2
 
         """
-        contributor                            C1
+        contributor                            realtime.cots
         VehicleJourney                          vj1
         Circulation date                        20150908                         20150910                20150912
                                                     |                               |                       |
@@ -373,12 +373,12 @@ def test_find_activate():
         """
 
         rtu = TripUpdate.find_by_contributor_period(
-            ["C1"], datetime.date(2015, 9, 11), datetime.date(2015, 9, 14)
+            ["realtime.cots"], datetime.date(2015, 9, 11), datetime.date(2015, 9, 14)
         )
         assert len(rtu) == 1
 
         """
-        contributor                            C1
+        contributor                            realtime.cots
         VehicleJourney                          vj1
         Circulation date                        20150908                         20150910                20150912
                                                     |                               |                       |
@@ -387,12 +387,12 @@ def test_find_activate():
         """
 
         rtu = TripUpdate.find_by_contributor_period(
-            ["C1"], datetime.date(2015, 9, 12), datetime.date(2015, 9, 14)
+            ["realtime.cots"], datetime.date(2015, 9, 12), datetime.date(2015, 9, 14)
         )
         assert len(rtu) == 1
 
         """
-        contributor                            C1
+        contributor                            realtime.cots
         VehicleJourney                          vj1
         Circulation date                        20150908                         20150910                20150912
                                                     |                               |                       |
@@ -401,17 +401,19 @@ def test_find_activate():
         """
 
         rtu = TripUpdate.find_by_contributor_period(
-            ["C1"], datetime.date(2015, 9, 13), datetime.date(2015, 9, 14)
+            ["realtime.cots"], datetime.date(2015, 9, 13), datetime.date(2015, 9, 14)
         )
         assert len(rtu) == 0
 
-        rtu = TripUpdate.find_by_contributor_period(["C2"], datetime.date(2015, 9, 6))
+        rtu = TripUpdate.find_by_contributor_period(["realtime.sherbrooke"], datetime.date(2015, 9, 6))
         assert len(rtu) == 1
 
-        rtu = TripUpdate.find_by_contributor_period(["C2"], datetime.date(2015, 9, 12))
+        rtu = TripUpdate.find_by_contributor_period(["realtime.sherbrooke"], datetime.date(2015, 9, 12))
         assert len(rtu) == 1
 
-        rtu = TripUpdate.find_by_contributor_period(["C1", "C2"], datetime.date(2015, 9, 12))
+        rtu = TripUpdate.find_by_contributor_period(
+            ["realtime.cots", "realtime.sherbrooke"], datetime.date(2015, 9, 12)
+        )
         assert len(rtu) == 2
 
 

--- a/tests/integration/populate_pb_test.py
+++ b/tests/integration/populate_pb_test.py
@@ -63,7 +63,7 @@ def test_populate_pb_with_one_stop_time():
     }
 
     with app.app_context():
-        trip_update = TripUpdate()
+        trip_update = TripUpdate(contributor="realtime.cots")
         vj = VehicleJourney(
             navitia_vj, datetime.datetime(2015, 9, 8, 5, 10, 0), datetime.datetime(2015, 9, 8, 8, 10, 0)
         )
@@ -116,7 +116,7 @@ def test_populate_pb_with_two_stop_time():
     }
 
     with app.app_context():
-        trip_update = TripUpdate()
+        trip_update = TripUpdate(contributor="realtime.cots")
         vj = VehicleJourney(
             navitia_vj, datetime.datetime(2015, 9, 8, 5, 10, 0), datetime.datetime(2015, 9, 8, 8, 10, 0)
         )
@@ -220,7 +220,7 @@ def test_populate_pb_with_deleted_stop_time():
     }
 
     with app.app_context():
-        trip_update = TripUpdate()
+        trip_update = TripUpdate(contributor="realtime.cots")
         vj = VehicleJourney(
             navitia_vj, datetime.datetime(2015, 9, 8, 5, 11, 0), datetime.datetime(2015, 9, 8, 10, 10, 0)
         )
@@ -363,6 +363,7 @@ def test_populate_pb_with_cancelation():
         trip_update.contributor = "realtime.cots"
         trip_update.company_id = "sncf"
         trip_update.effect = "REDUCED_SERVICE"
+        trip_update.contributor_id = "realtime.cots"
         real_time_update.trip_updates.append(trip_update)
 
         db.session.add(real_time_update)
@@ -527,6 +528,7 @@ def test_populate_pb_for_added_trip():
             dep_status="none",
         )
         trip_update.stop_time_updates.append(st)
+        trip_update.contributor_id = "realtime.cots"
 
         db.session.add(real_time_update)
         db.session.commit()

--- a/tests/integration/populate_pb_test.py
+++ b/tests/integration/populate_pb_test.py
@@ -90,7 +90,7 @@ def test_populate_pb_with_one_stop_time():
         assert pb_stop_time.stop_id == "sa:1"
 
         assert pb_trip_update.HasExtension(kirin_pb2.trip_message) is False
-        assert pb_trip_update.trip.HasExtension(kirin_pb2.contributor) is False
+        assert pb_trip_update.trip.HasExtension(kirin_pb2.contributor) is True
         assert pb_trip_update.trip.HasExtension(kirin_pb2.company_id) is False
         assert pb_trip_update.HasExtension(kirin_pb2.effect) is False
 
@@ -150,7 +150,7 @@ def test_populate_pb_with_two_stop_time():
         assert pb_trip_update.trip.trip_id == "vehicle_journey:1"
         assert pb_trip_update.trip.start_date == "20150908"
         assert pb_trip_update.HasExtension(kirin_pb2.trip_message) is False
-        assert pb_trip_update.trip.HasExtension(kirin_pb2.contributor) is False
+        assert pb_trip_update.trip.HasExtension(kirin_pb2.contributor) is True
         assert pb_trip_update.trip.HasExtension(kirin_pb2.company_id) is False
         assert pb_trip_update.HasExtension(kirin_pb2.effect) is False
         assert pb_trip_update.trip.schedule_relationship == gtfs_realtime_pb2.TripDescriptor.SCHEDULED
@@ -273,7 +273,7 @@ def test_populate_pb_with_deleted_stop_time():
         assert pb_trip_update.trip.trip_id == "vehicle_journey:1"
         assert pb_trip_update.trip.start_date == "20150908"
         assert pb_trip_update.HasExtension(kirin_pb2.trip_message) is False
-        assert pb_trip_update.trip.HasExtension(kirin_pb2.contributor) is False
+        assert pb_trip_update.trip.HasExtension(kirin_pb2.contributor) is True
         assert pb_trip_update.trip.HasExtension(kirin_pb2.company_id) is False
         assert pb_trip_update.HasExtension(kirin_pb2.effect) is False
         assert pb_trip_update.trip.schedule_relationship == gtfs_realtime_pb2.TripDescriptor.SCHEDULED
@@ -360,7 +360,7 @@ def test_populate_pb_with_cancelation():
         trip_update.status = "delete"
         trip_update.message = "Message Test"
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
-        trip_update.contributor = "kisio-digital"
+        trip_update.contributor = "realtime.cots"
         trip_update.company_id = "sncf"
         trip_update.effect = "REDUCED_SERVICE"
         real_time_update.trip_updates.append(trip_update)
@@ -375,12 +375,12 @@ def test_populate_pb_with_cancelation():
         pb_trip_update = feed_entity.entity[0].trip_update
         assert pb_trip_update.trip.trip_id == "vehicle_journey:1"
         assert pb_trip_update.trip.start_date == "20150908"
-        assert pb_trip_update.HasExtension(kirin_pb2.trip_message) == True
+        assert pb_trip_update.HasExtension(kirin_pb2.trip_message) is True
         assert pb_trip_update.Extensions[kirin_pb2.trip_message] == "Message Test"
         assert pb_trip_update.trip.schedule_relationship == gtfs_realtime_pb2.TripDescriptor.CANCELED
 
-        assert pb_trip_update.trip.HasExtension(kirin_pb2.contributor) == True
-        assert pb_trip_update.trip.Extensions[kirin_pb2.contributor] == "kisio-digital"
+        assert pb_trip_update.trip.HasExtension(kirin_pb2.contributor) is True
+        assert pb_trip_update.trip.Extensions[kirin_pb2.contributor] == "realtime.cots"
         assert pb_trip_update.trip.Extensions[kirin_pb2.company_id] == "sncf"
         assert pb_trip_update.Extensions[kirin_pb2.effect] == gtfs_realtime_pb2.Alert.REDUCED_SERVICE
 
@@ -405,7 +405,7 @@ def test_populate_pb_with_full_dataset():
         trip_update.status = "delete"
         trip_update.message = "Message Test"
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
-        trip_update.contributor = "kisio-digital"
+        trip_update.contributor_id = "realtime.cots"
         trip_update.company_id = "keolis"
         trip_update.effect = "DETOUR"
         real_time_update.trip_updates.append(trip_update)
@@ -424,8 +424,8 @@ def test_populate_pb_with_full_dataset():
         assert pb_trip_update.Extensions[kirin_pb2.trip_message] == "Message Test"
         assert pb_trip_update.trip.schedule_relationship == gtfs_realtime_pb2.TripDescriptor.CANCELED
 
-        assert pb_trip_update.trip.HasExtension(kirin_pb2.contributor) == True
-        assert pb_trip_update.trip.Extensions[kirin_pb2.contributor] == "kisio-digital"
+        assert pb_trip_update.trip.HasExtension(kirin_pb2.contributor) is True
+        assert pb_trip_update.trip.Extensions[kirin_pb2.contributor] == "realtime.cots"
         assert pb_trip_update.trip.Extensions[kirin_pb2.company_id] == "keolis"
         assert pb_trip_update.Extensions[kirin_pb2.effect] == gtfs_realtime_pb2.Alert.DETOUR
 
@@ -540,7 +540,7 @@ def test_populate_pb_for_added_trip():
         assert pb_trip_update.trip.trip_id == "OCE:SN:vehicle_journey:1"
         assert pb_trip_update.trip.start_date == "20150908"
         assert pb_trip_update.HasExtension(kirin_pb2.trip_message) is False
-        assert pb_trip_update.trip.HasExtension(kirin_pb2.contributor) is False
+        assert pb_trip_update.trip.HasExtension(kirin_pb2.contributor) is True
         assert pb_trip_update.trip.HasExtension(kirin_pb2.company_id) is False
         assert pb_trip_update.HasExtension(kirin_pb2.effect) is True
         assert pb_trip_update.Extensions[kirin_pb2.effect] == gtfs_realtime_pb2.Alert.ADDITIONAL_SERVICE

--- a/tests/integration/populate_pb_test.py
+++ b/tests/integration/populate_pb_test.py
@@ -360,7 +360,6 @@ def test_populate_pb_with_cancelation():
         trip_update.status = "delete"
         trip_update.message = "Message Test"
         real_time_update = RealTimeUpdate(raw_data=None, connector="cots", contributor="realtime.cots")
-        trip_update.contributor = "realtime.cots"
         trip_update.company_id = "sncf"
         trip_update.effect = "REDUCED_SERVICE"
         trip_update.contributor_id = "realtime.cots"

--- a/tests/integration/utils_sncf_test.py
+++ b/tests/integration/utils_sncf_test.py
@@ -103,7 +103,7 @@ def check_db_96231_delayed(motif_externe_is_null=False):
         else:
             assert second_st.message == "Affluence exceptionnelle de voyageurs"
 
-        assert db_trip_delayed.contributor is None
+        assert db_trip_delayed.contributor is not None
         assert db_trip_delayed.contributor_id == "realtime.cots"
 
         return db_trip_delayed  # for additional testing if needed
@@ -151,7 +151,7 @@ def check_db_870154_partial_removal(contributor=None):
         assert fourth_st.departure_status == "delete"
         assert fourth_st.message is None
 
-        assert db_trip.contributor is None
+        assert db_trip.contributor is not None
         assert db_trip.contributor_id == contributor
 
 
@@ -413,7 +413,7 @@ def check_db_96231_mixed_statuses_inside_stops(contributor=None):
         assert sixth_st.departure_status == "none"  # not in the feed, so none and no delay
         assert sixth_st.departure_delay == timedelta(0)
 
-        assert db_trip_delayed.contributor is None
+        assert db_trip_delayed.contributor is not None
         assert db_trip_delayed.contributor_id == contributor
 
 
@@ -487,7 +487,7 @@ def check_db_96231_mixed_statuses_delay_removal_delay(contributor=None):
         assert sixth_st.departure_status == "none"  # not in the feed, so none and no delay
         assert sixth_st.departure_delay == timedelta(0)
 
-        assert db_trip_delayed.contributor is None
+        assert db_trip_delayed.contributor is not None
         assert db_trip_delayed.contributor_id == contributor
 
 
@@ -551,7 +551,7 @@ def check_db_96231_normal(contributor=None):
         except AssertionError:
             pass  # xfail: we don't change back the departure :(
 
-        assert db_trip_delayed.contributor is None
+        assert db_trip_delayed.contributor is not None
         assert db_trip_delayed.contributor_id == contributor
 
 
@@ -740,7 +740,7 @@ def check_db_96231_partial_removal(contributor=None):
         assert last_st.departure_delay == timedelta(minutes=0)
         assert last_st.departure_status == "none"
 
-        assert db_trip_partial_removed.contributor is None
+        assert db_trip_partial_removed.contributor is not None
         assert db_trip_partial_removed.contributor_id == contributor
 
 
@@ -796,5 +796,5 @@ def check_db_840427_partial_removal(contributor=None):
         assert tro_st.departure_status == "none"  # the train still does not leave from this stop
         assert tro_st.message == "Défaut d'alimentation électrique"
 
-        assert db_trip_partial_removed.contributor is None
+        assert db_trip_partial_removed.contributor is not None
         assert db_trip_partial_removed.contributor_id == contributor

--- a/tests/integration/utils_sncf_test.py
+++ b/tests/integration/utils_sncf_test.py
@@ -103,7 +103,8 @@ def check_db_96231_delayed(motif_externe_is_null=False):
         else:
             assert second_st.message == "Affluence exceptionnelle de voyageurs"
 
-        assert db_trip_delayed.contributor == "realtime.cots"
+        assert db_trip_delayed.contributor is None
+        assert db_trip_delayed.contributor_id == "realtime.cots"
 
         return db_trip_delayed  # for additional testing if needed
 
@@ -150,7 +151,8 @@ def check_db_870154_partial_removal(contributor=None):
         assert fourth_st.departure_status == "delete"
         assert fourth_st.message is None
 
-        assert db_trip.contributor == contributor
+        assert db_trip.contributor is None
+        assert db_trip.contributor_id == contributor
 
 
 def check_db_870154_delay():
@@ -411,7 +413,8 @@ def check_db_96231_mixed_statuses_inside_stops(contributor=None):
         assert sixth_st.departure_status == "none"  # not in the feed, so none and no delay
         assert sixth_st.departure_delay == timedelta(0)
 
-        assert db_trip_delayed.contributor == contributor
+        assert db_trip_delayed.contributor is None
+        assert db_trip_delayed.contributor_id == contributor
 
 
 def check_db_96231_mixed_statuses_delay_removal_delay(contributor=None):
@@ -484,7 +487,8 @@ def check_db_96231_mixed_statuses_delay_removal_delay(contributor=None):
         assert sixth_st.departure_status == "none"  # not in the feed, so none and no delay
         assert sixth_st.departure_delay == timedelta(0)
 
-        assert db_trip_delayed.contributor == contributor
+        assert db_trip_delayed.contributor is None
+        assert db_trip_delayed.contributor_id == contributor
 
 
 def check_db_96231_normal(contributor=None):
@@ -547,7 +551,8 @@ def check_db_96231_normal(contributor=None):
         except AssertionError:
             pass  # xfail: we don't change back the departure :(
 
-        assert db_trip_delayed.contributor == contributor
+        assert db_trip_delayed.contributor is None
+        assert db_trip_delayed.contributor_id == contributor
 
 
 def check_db_john_trip_removal():
@@ -735,7 +740,8 @@ def check_db_96231_partial_removal(contributor=None):
         assert last_st.departure_delay == timedelta(minutes=0)
         assert last_st.departure_status == "none"
 
-        assert db_trip_partial_removed.contributor == contributor
+        assert db_trip_partial_removed.contributor is None
+        assert db_trip_partial_removed.contributor_id == contributor
 
 
 def check_db_840427_partial_removal(contributor=None):
@@ -790,4 +796,5 @@ def check_db_840427_partial_removal(contributor=None):
         assert tro_st.departure_status == "none"  # the train still does not leave from this stop
         assert tro_st.message == "Défaut d'alimentation électrique"
 
-        assert db_trip_partial_removed.contributor == contributor
+        assert db_trip_partial_removed.contributor is None
+        assert db_trip_partial_removed.contributor_id == contributor

--- a/tests/integration/utils_sncf_test.py
+++ b/tests/integration/utils_sncf_test.py
@@ -103,7 +103,6 @@ def check_db_96231_delayed(motif_externe_is_null=False):
         else:
             assert second_st.message == "Affluence exceptionnelle de voyageurs"
 
-        assert db_trip_delayed.contributor is not None
         assert db_trip_delayed.contributor_id == "realtime.cots"
 
         return db_trip_delayed  # for additional testing if needed
@@ -151,7 +150,6 @@ def check_db_870154_partial_removal(contributor=None):
         assert fourth_st.departure_status == "delete"
         assert fourth_st.message is None
 
-        assert db_trip.contributor is not None
         assert db_trip.contributor_id == contributor
 
 
@@ -413,7 +411,6 @@ def check_db_96231_mixed_statuses_inside_stops(contributor=None):
         assert sixth_st.departure_status == "none"  # not in the feed, so none and no delay
         assert sixth_st.departure_delay == timedelta(0)
 
-        assert db_trip_delayed.contributor is not None
         assert db_trip_delayed.contributor_id == contributor
 
 
@@ -487,7 +484,6 @@ def check_db_96231_mixed_statuses_delay_removal_delay(contributor=None):
         assert sixth_st.departure_status == "none"  # not in the feed, so none and no delay
         assert sixth_st.departure_delay == timedelta(0)
 
-        assert db_trip_delayed.contributor is not None
         assert db_trip_delayed.contributor_id == contributor
 
 
@@ -551,7 +547,6 @@ def check_db_96231_normal(contributor=None):
         except AssertionError:
             pass  # xfail: we don't change back the departure :(
 
-        assert db_trip_delayed.contributor is not None
         assert db_trip_delayed.contributor_id == contributor
 
 
@@ -740,7 +735,6 @@ def check_db_96231_partial_removal(contributor=None):
         assert last_st.departure_delay == timedelta(minutes=0)
         assert last_st.departure_status == "none"
 
-        assert db_trip_partial_removed.contributor is not None
         assert db_trip_partial_removed.contributor_id == contributor
 
 
@@ -796,5 +790,4 @@ def check_db_840427_partial_removal(contributor=None):
         assert tro_st.departure_status == "none"  # the train still does not leave from this stop
         assert tro_st.message == "Défaut d'alimentation électrique"
 
-        assert db_trip_partial_removed.contributor is not None
         assert db_trip_partial_removed.contributor_id == contributor


### PR DESCRIPTION
This PR deletes attribut contributor in the tables real_time_update and trip_update.
- Delete index on contributor
- Delete attribut contributor in the tables
- Delete use of contributor in objects
- Modify tests

Concerned ticket: https://jira.kisio.org/browse/NAVP-1377