### PR TITLE
Have pybreaker around all COTS message-subservice manager

### DIFF
--- a/kirin/__init__.py
+++ b/kirin/__init__.py
@@ -31,6 +31,9 @@
 
 from __future__ import absolute_import, print_function, unicode_literals, division
 import os
+
+import pybreaker
+
 from kirin import exceptions
 from kirin.rabbitmq_handler import RabbitMQHandler
 
@@ -88,6 +91,11 @@ redis = Redis(
     port=app.config[str("REDIS_PORT")],
     db=app.config[str("REDIS_DB")],
     password=app.config[str("REDIS_PASSWORD")],
+)
+
+cots_message_breaker = pybreaker.CircuitBreaker(
+    fail_max=app.config[str("COTS_PAR_IV_CIRCUIT_BREAKER_MAX_FAIL")],
+    reset_timeout=app.config[str("COTS_PAR_IV_CIRCUIT_BREAKER_TIMEOUT_S")],
 )
 
 # activate a command

--- a/kirin/__init__.py
+++ b/kirin/__init__.py
@@ -93,11 +93,6 @@ redis = Redis(
     password=app.config[str("REDIS_PASSWORD")],
 )
 
-cots_message_breaker = pybreaker.CircuitBreaker(
-    fail_max=app.config[str("COTS_PAR_IV_CIRCUIT_BREAKER_MAX_FAIL")],
-    reset_timeout=app.config[str("COTS_PAR_IV_CIRCUIT_BREAKER_TIMEOUT_S")],
-)
-
 # activate a command
 import kirin.command.load_realtime
 

--- a/kirin/cots/message_handler.py
+++ b/kirin/cots/message_handler.py
@@ -34,9 +34,15 @@ import pybreaker
 import requests as requests
 import six
 
-from kirin import app, cots_message_breaker
+from kirin import app
 
 from kirin.exceptions import ObjectNotFound, UnauthorizedOnSubService, SubServiceError
+
+
+cots_message_breaker = pybreaker.CircuitBreaker(
+    fail_max=app.config[str("COTS_PAR_IV_CIRCUIT_BREAKER_MAX_FAIL")],
+    reset_timeout=app.config[str("COTS_PAR_IV_CIRCUIT_BREAKER_TIMEOUT_S")],
+)
 
 
 class MessageHandler:


### PR DESCRIPTION
:mag: Review by commit.

As this "motif" service can return `503` HTTP errors on long periods,
no raise is done in GET method, so it was not handled by pybreaker,
as exception was raised outside of it, by `_service_caller()` method.

Also, pybreaker had the lifetime of a request processing, not the one of Kirin.

Looks like there is no easy way to test that (if it is worthy, as message-handling is tested already).

- [x] Hand-test are OK :heavy_check_mark: 

Related from afar to https://jira.kisio.org/browse/NAVITIAII-2800