### PR TITLE
Delete attribute contributor and clean code

### DIFF
--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -299,8 +299,6 @@ class TripUpdate(db.Model, TimestampMixin):  # type: ignore
         single_parent=True,
     )
     message = db.Column(db.Text, nullable=True)
-    contributor = db.Column(db.Text, nullable=True)
-    db.Index("contributor_idx", contributor)
     stop_time_updates = db.relationship(
         "StopTimeUpdate",
         backref="trip_update",
@@ -322,7 +320,6 @@ class TripUpdate(db.Model, TimestampMixin):  # type: ignore
         self.created_at = datetime.datetime.utcnow()
         self.vj = vj
         self.status = status
-        self.contributor = contributor
         self.company_id = company_id
         self.effect = effect
         self.physical_mode_id = physical_mode_id
@@ -425,7 +422,6 @@ class RealTimeUpdate(db.Model, TimestampMixin):  # type: ignore
     db.Index("status_idx", status)
     error = db.Column(db.Text, nullable=True)
     raw_data = deferred(db.Column(db.Text, nullable=True))
-    contributor = db.Column(db.Text, nullable=True)
     contributor_id = db.Column(db.Text, db.ForeignKey("contributor.id"), nullable=False)
 
     trip_updates = db.relationship(
@@ -438,7 +434,6 @@ class RealTimeUpdate(db.Model, TimestampMixin):  # type: ignore
 
     __table_args__ = (
         db.Index("realtime_update_created_at", "created_at"),
-        db.Index("realtime_update_contributor_and_created_at", "created_at", "contributor"),
         db.Index("realtime_update_contributor_id_and_created_at", "created_at", "contributor_id"),
     )
 
@@ -447,7 +442,6 @@ class RealTimeUpdate(db.Model, TimestampMixin):  # type: ignore
         self.raw_data = raw_data
         self.connector = connector
         self.status = status
-        self.contributor = contributor
         self.error = error
         self.received_at = received_at if received_at else datetime.datetime.utcnow()
         self.contributor_id = contributor

--- a/kirin/utils.py
+++ b/kirin/utils.py
@@ -148,7 +148,7 @@ def set_rtu_status_ko(rtu, error, is_reprocess_same_data_allowed):
         reprocess it (hoping a happier ending)
         """
     if is_reprocess_same_data_allowed:
-        allow_reprocess_same_data(rtu.contributor)
+        allow_reprocess_same_data(rtu.contributor_id)
 
     rtu.status = "KO"
     rtu.error = error

--- a/migrations/versions/57860080e5d6_clean_old_contributors.py
+++ b/migrations/versions/57860080e5d6_clean_old_contributors.py
@@ -1,0 +1,39 @@
+"""
+Deleting column contributor from tables real_time_update and trip_update
+Revision ID: 57860080e5d6
+Revises: 443587af1780
+Create Date: 2019-09-05 17:16:35.675541
+
+"""
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+# revision identifiers, used by Alembic.
+revision = '57860080e5d6'
+down_revision = u'443587af1780'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # Drop indexes on contributor
+    op.drop_index('realtime_update_contributor_and_created_at', table_name='real_time_update')
+    op.drop_index('contributor_idx', table_name='trip_update')
+
+    # Drop column contributor
+    op.drop_column('real_time_update', 'contributor')
+    op.drop_column('trip_update', 'contributor')
+
+
+def downgrade():
+    # Add column contributor in the tables real_time_update and trip_update
+    op.add_column('trip_update', sa.Column('contributor', sa.TEXT(), autoincrement=False, nullable=True))
+    op.add_column('real_time_update', sa.Column('contributor', sa.TEXT(), autoincrement=False, nullable=True))
+
+    # Add indexes on contributor
+    op.create_index('contributor_idx', 'trip_update', ['contributor'], unique=False)
+    op.create_index('realtime_update_contributor_and_created_at', 'real_time_update', ['created_at', 'contributor'], unique=False)
+
+    # Update contributor with the value of contributor_id
+    op.execute("UPDATE real_time_update SET contributor = contributor_id;")
+    op.execute("UPDATE trip_update SET contributor = contributor_id;")

--- a/migrations/versions/57860080e5d6_clean_old_contributors.py
+++ b/migrations/versions/57860080e5d6_clean_old_contributors.py
@@ -1,7 +1,7 @@
 """
 Deleting column contributor from tables real_time_update and trip_update
 Revision ID: 57860080e5d6
-Revises: 443587af1780
+Revises: 21194e8e2308
 Create Date: 2019-09-05 17:16:35.675541
 
 """
@@ -9,7 +9,7 @@ from __future__ import absolute_import, print_function, unicode_literals, divisi
 
 # revision identifiers, used by Alembic.
 revision = "57860080e5d6"
-down_revision = "443587af1780"
+down_revision = "21194e8e2308"
 
 from alembic import op
 import sqlalchemy as sa

--- a/migrations/versions/57860080e5d6_clean_old_contributors.py
+++ b/migrations/versions/57860080e5d6_clean_old_contributors.py
@@ -8,8 +8,8 @@ Create Date: 2019-09-05 17:16:35.675541
 from __future__ import absolute_import, print_function, unicode_literals, division
 
 # revision identifiers, used by Alembic.
-revision = '57860080e5d6'
-down_revision = u'443587af1780'
+revision = "57860080e5d6"
+down_revision = "443587af1780"
 
 from alembic import op
 import sqlalchemy as sa
@@ -17,22 +17,27 @@ import sqlalchemy as sa
 
 def upgrade():
     # Drop indexes on contributor
-    op.drop_index('realtime_update_contributor_and_created_at', table_name='real_time_update')
-    op.drop_index('contributor_idx', table_name='trip_update')
+    op.drop_index("realtime_update_contributor_and_created_at", table_name="real_time_update")
+    op.drop_index("contributor_idx", table_name="trip_update")
 
     # Drop column contributor
-    op.drop_column('real_time_update', 'contributor')
-    op.drop_column('trip_update', 'contributor')
+    op.drop_column("real_time_update", "contributor")
+    op.drop_column("trip_update", "contributor")
 
 
 def downgrade():
     # Add column contributor in the tables real_time_update and trip_update
-    op.add_column('trip_update', sa.Column('contributor', sa.TEXT(), autoincrement=False, nullable=True))
-    op.add_column('real_time_update', sa.Column('contributor', sa.TEXT(), autoincrement=False, nullable=True))
+    op.add_column("trip_update", sa.Column("contributor", sa.TEXT(), autoincrement=False, nullable=True))
+    op.add_column("real_time_update", sa.Column("contributor", sa.TEXT(), autoincrement=False, nullable=True))
 
     # Add indexes on contributor
-    op.create_index('contributor_idx', 'trip_update', ['contributor'], unique=False)
-    op.create_index('realtime_update_contributor_and_created_at', 'real_time_update', ['created_at', 'contributor'], unique=False)
+    op.create_index("contributor_idx", "trip_update", ["contributor"], unique=False)
+    op.create_index(
+        "realtime_update_contributor_and_created_at",
+        "real_time_update",
+        ["created_at", "contributor"],
+        unique=False,
+    )
 
     # Update contributor with the value of contributor_id
     op.execute("UPDATE real_time_update SET contributor = contributor_id;")

--- a/tests/integration/gtfs_rt_test.py
+++ b/tests/integration/gtfs_rt_test.py
@@ -201,7 +201,6 @@ def test_gtfs_model_builder(basic_gtfs_rt_data, basic_gtfs_rt_data_without_delay
         assert len(trip_updates) == 1
         assert len(trip_updates[0].stop_time_updates) == 4
         assert trip_updates[0].effect == "SIGNIFICANT_DELAYS"
-        assert trip_updates[0].contributor == GTFS_CONTRIBUTOR
         assert trip_updates[0].contributor_id == GTFS_CONTRIBUTOR
 
         # stop_time_update created with no delay
@@ -489,7 +488,6 @@ def test_gtfs_rt_pass_midnight(pass_midnight_gtfs_rt_data, mock_rabbitmq):
         assert RealTimeUpdate.query.first().status == "OK"
 
         trip_update = TripUpdate.find_by_dated_vj("R:vj1", datetime.datetime(2012, 6, 16, 3, 30))
-        assert trip_update.contributor == GTFS_CONTRIBUTOR
         assert trip_update.contributor_id == GTFS_CONTRIBUTOR
         assert trip_update
 

--- a/tests/integration/utils_sncf_test.py
+++ b/tests/integration/utils_sncf_test.py
@@ -104,7 +104,6 @@ def check_db_96231_delayed(contributor=None, motif_externe_is_null=False):
         else:
             assert second_st.message == "Affluence exceptionnelle de voyageurs"
 
-        assert db_trip_delayed.contributor == contributor
         assert db_trip_delayed.contributor_id == contributor
 
         return db_trip_delayed  # for additional testing if needed
@@ -152,7 +151,6 @@ def check_db_870154_partial_removal(contributor=None):
         assert fourth_st.departure_status == "delete"
         assert fourth_st.message is None
 
-        assert db_trip.contributor == contributor
         assert db_trip.contributor_id == contributor
 
 
@@ -414,7 +412,6 @@ def check_db_96231_mixed_statuses_inside_stops(contributor=None):
         assert sixth_st.departure_status == "none"  # not in the feed, so none and no delay
         assert sixth_st.departure_delay == timedelta(0)
 
-        assert db_trip_delayed.contributor == contributor
         assert db_trip_delayed.contributor_id == contributor
 
 
@@ -488,7 +485,6 @@ def check_db_96231_mixed_statuses_delay_removal_delay(contributor=None):
         assert sixth_st.departure_status == "none"  # not in the feed, so none and no delay
         assert sixth_st.departure_delay == timedelta(0)
 
-        assert db_trip_delayed.contributor == contributor
         assert db_trip_delayed.contributor_id == contributor
 
 
@@ -552,7 +548,6 @@ def check_db_96231_normal(contributor=None):
         except AssertionError:
             pass  # xfail: we don't change back the departure :(
 
-        assert db_trip_delayed.contributor == contributor
         assert db_trip_delayed.contributor_id == contributor
 
 
@@ -741,7 +736,6 @@ def check_db_96231_partial_removal(contributor=None):
         assert last_st.departure_delay == timedelta(minutes=0)
         assert last_st.departure_status == "none"
 
-        assert db_trip_partial_removed.contributor == contributor
         assert db_trip_partial_removed.contributor_id == contributor
 
 
@@ -797,5 +791,4 @@ def check_db_840427_partial_removal(contributor=None):
         assert tro_st.departure_status == "none"  # the train still does not leave from this stop
         assert tro_st.message == "Défaut d'alimentation électrique"
 
-        assert db_trip_partial_removed.contributor == contributor
         assert db_trip_partial_removed.contributor_id == contributor


### PR DESCRIPTION
This PR deletes attribut contributor in the tables real_time_update and trip_update.
- Delete index on contributor
- Delete attribut contributor in the tables
- Delete use of contributor in objects
- Modify tests

Concerned ticket: https://jira.kisio.org/browse/NAVP-1377


**Note: Not to be merged before a version with multi gtfs using the table contributor deployed in PROD**