### PR TITLE
kirin: api delete removed, is_active added and api put resolved

### DIFF
--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -515,10 +515,12 @@ class Contributor(db.Model):  # type: ignore
     navitia_token = db.Column(db.Text, nullable=True)
     feed_url = db.Column(db.Text, nullable=True)
     connector_type = db.Column(Db_ConnectorType, nullable=False)
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
 
-    def __init__(self, id, navitia_coverage, connector_type, navitia_token=None, feed_url=None):
+    def __init__(self, id, navitia_coverage, connector_type, navitia_token=None, feed_url=None, is_active=True):
         self.id = id
         self.navitia_coverage = navitia_coverage
         self.connector_type = connector_type
         self.navitia_token = navitia_token
         self.feed_url = feed_url
+        self.is_active = is_active

--- a/migrations/versions/21194e8e2308_add_attribute_is_active.py
+++ b/migrations/versions/21194e8e2308_add_attribute_is_active.py
@@ -1,0 +1,25 @@
+"""
+Add attribut is_active in contributor
+Revision ID: 21194e8e2308
+Revises: 443587af1780
+Create Date: 2019-09-06 14:56:15.912974
+
+"""
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+# revision identifiers, used by Alembic.
+revision = '21194e8e2308'
+down_revision = u'443587af1780'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # Add column is_active in contributor
+    op.add_column('contributor', sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.true()))
+
+
+def downgrade():
+    # Drop column is_visible
+    op.drop_column('contributor', 'is_active')

--- a/migrations/versions/21194e8e2308_add_attribute_is_active.py
+++ b/migrations/versions/21194e8e2308_add_attribute_is_active.py
@@ -8,8 +8,8 @@ Create Date: 2019-09-06 14:56:15.912974
 from __future__ import absolute_import, print_function, unicode_literals, division
 
 # revision identifiers, used by Alembic.
-revision = '21194e8e2308'
-down_revision = u'443587af1780'
+revision = "21194e8e2308"
+down_revision = "443587af1780"
 
 from alembic import op
 import sqlalchemy as sa
@@ -17,9 +17,9 @@ import sqlalchemy as sa
 
 def upgrade():
     # Add column is_active in contributor
-    op.add_column('contributor', sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.true()))
+    op.add_column("contributor", sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()))
 
 
 def downgrade():
     # Drop column is_visible
-    op.drop_column('contributor', 'is_active')
+    op.drop_column("contributor", "is_active")

--- a/migrations/versions/21194e8e2308_add_attribute_is_active.py
+++ b/migrations/versions/21194e8e2308_add_attribute_is_active.py
@@ -16,10 +16,8 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    # Add column is_active in contributor
     op.add_column("contributor", sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()))
 
 
 def downgrade():
-    # Drop column is_visible
     op.drop_column("contributor", "is_active")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -75,9 +75,9 @@ def clean_db():
         # Add two contributors in the table
         db.session.add_all(
             [
-                model.Contributor(COTS_CONTRIBUTOR, "sncf", "cots", "cots_token", "cots_feed_url"),
+                model.Contributor(COTS_CONTRIBUTOR, "sncf", "cots", "cots_token", "cots_feed_url", True),
                 model.Contributor(
-                    GTFS_CONTRIBUTOR, "sherbrooke", "gtfs-rt", "gtfs-rt_token", "gtfs-rt_feed_url"
+                    GTFS_CONTRIBUTOR, "sherbrooke", "gtfs-rt", "gtfs-rt_token", "gtfs-rt_feed_url", True
                 ),
             ]
         )

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -332,27 +332,27 @@ def test_existing_contributors_after_put(test_client):
 
     # Verify that  the contributor "rt.tchoutchou" is not modified
     get_contrib = test_client.get("/contributors/rt.tchoutchou")
-    contrib_chou = json.loads(get_contrib.data)["contributors"][0]
-    assert contrib_chou == original_contrib_tchou
+    contrib_tchou = json.loads(get_contrib.data)["contributors"][0]
+    assert contrib_tchou == original_contrib_tchou
 
 
 def test_deactivate_contributor(test_client):
     # get existing contributor "rt.tchoutchou" which is active
     get_contrib = test_client.get("/contributors/rt.tchoutchou")
-    contrib_chou = json.loads(get_contrib.data)["contributors"][0]
-    assert contrib_chou["is_active"] is True
+    contrib_tchou = json.loads(get_contrib.data)["contributors"][0]
+    assert contrib_tchou["is_active"] is True
 
     # Modify attribute is_active to false and test after put
-    contrib_chou["is_active"] = False
-    put_resp = test_client.put("/contributors", json=contrib_chou)
+    contrib_tchou["is_active"] = False
+    put_resp = test_client.put("/contributors", json=contrib_tchou)
     put_data = json.loads(put_resp.data)
     assert put_data["contributor"]["id"] == "rt.tchoutchou"
     assert put_data["contributor"]["is_active"] is False
 
     # Verify the same contributor with a /get
     get_contrib = test_client.get("/contributors/rt.tchoutchou")
-    contrib_chou = json.loads(get_contrib.data)["contributors"][0]
-    assert contrib_chou["is_active"] is False
+    contrib_tchou = json.loads(get_contrib.data)["contributors"][0]
+    assert contrib_tchou["is_active"] is False
 
 
 def test_activate_contributor(test_client):

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -318,9 +318,10 @@ def test_post_get_put_to_ensure_API_consitency(test_client):
 def test_existing_contributors_after_put(test_client):
     # get existing contributor "rt.tchoutchou"
     get_contrib = test_client.get("/contributors/rt.tchoutchou")
-    original_contrib_chou = json.loads(get_contrib.data)["contributors"][0]
+    original_contrib_tchou = json.loads(get_contrib.data)["contributors"][0]
 
-    # Get and modify another contributor "rt.vroumvroum" and verify that it
+    # Get and modify another contributor "rt.vroumvroum" and verify that
+    # modification of this contributor doesn't affect another.
     get_contrib = test_client.get("/contributors/rt.vroumvroum")
     contrib_vroumvroum = json.loads(get_contrib.data)["contributors"][0]
     contrib_vroumvroum["navitia_coverage"] = "tokyo"
@@ -330,9 +331,9 @@ def test_existing_contributors_after_put(test_client):
     assert put_data["contributor"] == contrib_vroumvroum
 
     # Verify that  the contributor "rt.tchoutchou" is not modified
-    get_contib = test_client.get("/contributors/rt.tchoutchou")
-    contrib_chou = json.loads(get_contib.data)["contributors"][0]
-    assert contrib_chou == original_contrib_chou
+    get_contrib = test_client.get("/contributors/rt.tchoutchou")
+    contrib_chou = json.loads(get_contrib.data)["contributors"][0]
+    assert contrib_chou == original_contrib_tchou
 
 
 def test_deactivate_contributor(test_client):
@@ -347,6 +348,11 @@ def test_deactivate_contributor(test_client):
     put_data = json.loads(put_resp.data)
     assert put_data["contributor"]["id"] == "rt.tchoutchou"
     assert put_data["contributor"]["is_active"] is False
+
+    # Verify the same contributor with a /get
+    get_contrib = test_client.get("/contributors/rt.tchoutchou")
+    contrib_chou = json.loads(get_contrib.data)["contributors"][0]
+    assert contrib_chou["is_active"] is False
 
 
 def test_activate_contributor(test_client):
@@ -370,3 +376,7 @@ def test_activate_contributor(test_client):
     put_data = json.loads(put_resp.data)
     assert put_data["contributor"]["id"] == "realtime.tokyo"
     assert put_data["contributor"]["is_active"] is True
+
+    get_resp = test_client.get("/contributors/realtime.tokyo")
+    get_contrib = json.loads(get_resp.data)["contributors"][0]
+    assert get_contrib["is_active"] is True


### PR DESCRIPTION
Corrections:
- Correction on api /put
- Tests on /put added
- api /delete removed
- A new column "is_active" is added so that we can activate and desactivate a contributor.
-- is_active: default = True and True during migration
-- is_active = True if attribute absent while doing /post
-- Tests added on /put with is_active = true and false

Concerned ticket: https://jira.kisio.org/browse/NAVP-1395