### PR TITLE
kirin: command to clean inactive contributor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,12 @@ pre-commit install
 ```
 
 
+## Internal data format
+
+The format used internally to store and process realtime information is
+described [here](documentation/internal_format.md)
+
+
 ## Alembic database revisions
 
 To generate a new database revision script (after an upgrade of the model.py file):

--- a/kirin/command/purge_rt.py
+++ b/kirin/command/purge_rt.py
@@ -53,7 +53,7 @@ def purge_rt(nb_day_to_keep, connector):
 @manager.command
 def purge_contributor(contributor_id):
     """
-    This task will delete a contributor with is_active = false and without any data in real_time_update
+    This task will delete a contributor if is_active = false and if it does not have any data in real_time_update
     and trip_update
     :param contributor_id:
     """
@@ -71,7 +71,7 @@ def purge_contributor(contributor_id):
                 logger.info("Contributor %s deleted", contributor_id)
             except IntegrityError:
                 logger.info(
-                    "Presence of data in real_time_update and/or trip_update for contributor: %s", contributor_id
+                    "Presence of data in real_time_update and/or trip_update for contributor %s", contributor_id
                 )
             except Exception:
                 logger.info("Error while deleting contributor %s", contributor_id)

--- a/kirin/command/purge_rt.py
+++ b/kirin/command/purge_rt.py
@@ -70,8 +70,8 @@ def purge_contributor(contributor_id):
                 logger.info(
                     "Presence of data in real_time_update and/or trip_update for contributor: %s", contributor_id
                 )
-            except Exception:
-                logger.info("Error while deleting contributor %s", contributor_id)
+            except Exception as e:
+                logger.error("Error while deleting contributor %s : %s", contributor_id, e)
         else:
             logger.info("Contributor %s is active and cannot be deleted", contributor_id)
 

--- a/kirin/command/purge_rt.py
+++ b/kirin/command/purge_rt.py
@@ -70,8 +70,9 @@ def purge_contributor(contributor_id):
                 db.session.commit()
                 logger.info("Contributor %s deleted", contributor_id)
             except IntegrityError:
-                logger.info("Presence of data in real_time_update and/or trip_update for contributor: %s",
-                            contributor_id)
+                logger.info(
+                    "Presence of data in real_time_update and/or trip_update for contributor: %s", contributor_id
+                )
             except Exception:
                 logger.info("Error while deleting contributor %s", contributor_id)
         else:

--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,20 @@ When running this image, the Kirin web server is launched and an optional *port*
 Note: a Kirin database is needed on localhost for the requests to be done successfully.
 
 
+### Maintenance
+
+##### Definitely remove a contributor from configuration
+
+A command to clean inactive contributors is available, to be triggered by hand.
+```bash
+python ./manage.py purge_contributor <contributor_id>
+```
+This will check that for the given contributor, `is_active=false` and that
+no more object is linked to that contributor in Kirin database.
+
+Those objects are progressively purged by automatic jobs configured in the settings file.
+
+
 ## API
 
 Kirin API provides several endpoints (that can be requested through port 5000 by default, or

--- a/readme.md
+++ b/readme.md
@@ -131,12 +131,12 @@ Note: a Kirin database is needed on localhost for the requests to be done succes
 
 ##### Definitely remove a contributor from configuration
 
-A command to clean inactive contributors is available, to be triggered by hand.
+A command to clean inactive contributors is available, to be triggered manually.
 ```bash
 python ./manage.py purge_contributor <contributor_id>
 ```
 This will check that for the given contributor, `is_active=false` and that
-no more object is linked to that contributor in Kirin database.
+no more object (TripUpdate or RealTimeUpdate) is linked to that contributor in Kirin database.
 
 Those objects are progressively purged by automatic jobs configured in the settings file.
 


### PR DESCRIPTION
- A command to clean inactive contributor without any data in real_time_update and trip_update
- command : 
python ./manage.py purge_contributor realtime.toto

- Concerned ticket : https://jira.kisio.org/browse/NAVP-1396
- Tested manually
-- Contributor doesn't exist : Return a message "Contributor toto doesn't exist"
-- Contributor with is_active = true : Return a message "Contributor toto is active and cannot be deleted"
-- Contributor has data in RTU or TU: return a message "Presence of data in real_time_update and/or trip_update for contributor: toto"
-- Success: Return message "Contributor toto deleted"

