### PR TITLE
Allow reprocessing after particular errors even if ETag is unchanged

### DIFF
--- a/kirin/__init__.py
+++ b/kirin/__init__.py
@@ -32,10 +32,7 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 import os
 
-import pybreaker
-
 from kirin import exceptions
-from kirin.rabbitmq_handler import RabbitMQHandler
 
 # remplace blocking method by a non blocking equivalent
 # this enable us to use gevent for launching background task
@@ -52,7 +49,6 @@ if str("threading") in sys.modules:
 from flask import Flask
 import logging.config
 from flask_script import Manager
-from kirin import utils
 from kirin.helper import KirinRequest
 
 app = Flask(__name__)
@@ -60,13 +56,6 @@ app.config.from_object(str("kirin.default_settings"))  # type: ignore
 if "KIRIN_CONFIG_FILE" in os.environ:
     app.config.from_envvar(str("KIRIN_CONFIG_FILE"))  # type: ignore
 app.request_class = KirinRequest
-
-if str("LOGGER") in app.config:
-    logging.config.dictConfig(app.config[str("LOGGER")])
-else:  # Default is std out
-    handler = logging.StreamHandler(stream=sys.stdout)
-    app.logger.addHandler(handler)
-    app.logger.setLevel("INFO")
 
 from kirin import new_relic
 
@@ -109,6 +98,16 @@ if str("threading") not in sys.modules:
 logger.info("Configs: %s", app.config)
 
 
+from kirin.rabbitmq_handler import RabbitMQHandler
+
 rabbitmq_handler = RabbitMQHandler(app.config[str("RABBITMQ_CONNECTION_STRING")], app.config[str("EXCHANGE")])
 
 import kirin.api
+from kirin import utils
+
+if str("LOGGER") in app.config:
+    logging.config.dictConfig(app.config[str("LOGGER")])
+else:  # Default is std out
+    handler = logging.StreamHandler(stream=sys.stdout)
+    app.logger.addHandler(handler)
+    app.logger.setLevel("INFO")

--- a/kirin/abstract_sncf_resource.py
+++ b/kirin/abstract_sncf_resource.py
@@ -33,7 +33,7 @@ from flask_restful import Resource
 
 import logging
 from datetime import datetime
-from kirin.utils import make_rt_update, record_call, set_rtu_status_ko
+from kirin.utils import make_rt_update, record_call, set_rtu_status_ko, allow_reprocess_same_data
 from kirin.exceptions import KirinException
 from kirin import core
 from kirin.core import model
@@ -47,10 +47,21 @@ class AbstractSNCFResource(Resource):
         self.builder = builder
 
     def process_post(self, input_raw, contributor_type, is_new_complete=False):
-
-        # create a raw rt_update obj, save the raw_input into the db
-        rt_update = make_rt_update(input_raw, contributor_type, contributor=self.contributor)
         start_datetime = datetime.utcnow()
+
+        try:
+            # create a raw rt_update obj, save the raw_input into the db
+            rt_update = make_rt_update(input_raw, contributor_type, contributor=self.contributor)
+        except Exception as e:
+            # as rt_update is probably not built, make sure reprocess is allowed
+            allow_reprocess_same_data(self.contributor)
+            # regular exception handling
+            set_rtu_status_ko(rt_update, e.message, is_reprocess_same_data_allowed=True)
+            model.db.session.add(rt_update)
+            model.db.session.commit()
+            record_call("failure", reason=six.text_type(e), contributor=self.contributor)
+            raise
+
         try:
             # assuming UTF-8 encoding for all input
             rt_update.raw_data = rt_update.raw_data.encode("utf-8")

--- a/kirin/gtfs_rt/gtfs_rt.py
+++ b/kirin/gtfs_rt/gtfs_rt.py
@@ -110,7 +110,13 @@ class GtfsRT(Resource):
             proto.ParseFromString(raw_proto)
         except DecodeError:
             # We save the non-decodable flux gtfs-rt
-            manage_db_error(proto, "gtfs-rt", contributor=self.contributor, status="KO", error="Decode Error")
+            manage_db_error(
+                proto,
+                "gtfs-rt",
+                contributor=self.contributor,
+                error="Decode Error",
+                is_reprocess_same_data_allowed=False,
+            )
             raise InvalidArguments("invalid protobuf")
         else:
             model_maker.handle(proto, self.navitia_wrapper, self.contributor)

--- a/kirin/gtfs_rt/model_maker.py
+++ b/kirin/gtfs_rt/model_maker.py
@@ -37,7 +37,13 @@ from kirin import core
 from kirin.core import model
 from kirin.core.types import ModificationType, get_higher_status, get_effect_by_stop_time_status
 from kirin.exceptions import KirinException, InternalException, InvalidArguments
-from kirin.utils import make_rt_update, floor_datetime, to_navitia_utc_str, set_rtu_status_ko
+from kirin.utils import (
+    make_rt_update,
+    floor_datetime,
+    to_navitia_utc_str,
+    set_rtu_status_ko,
+    allow_reprocess_same_data,
+)
 from kirin.utils import record_internal_failure, record_call
 from kirin import app
 import itertools
@@ -45,9 +51,21 @@ import calendar
 
 
 def handle(proto, navitia_wrapper, contributor):
-    data = six.binary_type(proto)  # temp, for the moment, we save the protobuf as text
-    rt_update = make_rt_update(data, "gtfs-rt", contributor=contributor)
     start_datetime = datetime.datetime.utcnow()
+
+    try:
+        data = six.binary_type(proto)  # temp, for the moment, we save the protobuf as text
+        rt_update = make_rt_update(data, "gtfs-rt", contributor=contributor)
+    except Exception as e:
+        # as rt_update is probably not built, make sure reprocess is allowed
+        allow_reprocess_same_data(contributor)
+        # regular exception handling
+        set_rtu_status_ko(rt_update, e.message, is_reprocess_same_data_allowed=True)
+        model.db.session.add(rt_update)
+        model.db.session.commit()
+        record_call("failure", reason=six.text_type(e), contributor=contributor)
+        raise
+
     try:
         trip_updates = KirinModelBuilder(navitia_wrapper, contributor).build(rt_update, data=proto)
         _, log_dict = core.handle(rt_update, trip_updates, contributor)

--- a/kirin/gtfs_rt/model_maker.py
+++ b/kirin/gtfs_rt/model_maker.py
@@ -57,12 +57,13 @@ def handle(proto, navitia_wrapper, contributor):
         data = six.binary_type(proto)  # temp, for the moment, we save the protobuf as text
         rt_update = make_rt_update(data, "gtfs-rt", contributor=contributor)
     except Exception as e:
-        # as rt_update is probably not built, make sure reprocess is allowed
-        allow_reprocess_same_data(contributor)
-        # regular exception handling
-        set_rtu_status_ko(rt_update, e.message, is_reprocess_same_data_allowed=True)
-        model.db.session.add(rt_update)
-        model.db.session.commit()
+        if rt_update is None:
+            # rt_update is not built, make sure reprocess is allowed
+            allow_reprocess_same_data(contributor)
+        else:
+            set_rtu_status_ko(rt_update, e.message, is_reprocess_same_data_allowed=True)
+            model.db.session.add(rt_update)
+            model.db.session.commit()
         record_call("failure", reason=six.text_type(e), contributor=contributor)
         raise
 

--- a/kirin/gtfs_rt/model_maker.py
+++ b/kirin/gtfs_rt/model_maker.py
@@ -36,8 +36,8 @@ import six
 from kirin import core
 from kirin.core import model
 from kirin.core.types import ModificationType, get_higher_status, get_effect_by_stop_time_status
-from kirin.exceptions import KirinException, InternalException
-from kirin.utils import make_rt_update, floor_datetime, to_navitia_utc_str
+from kirin.exceptions import KirinException, InternalException, InvalidArguments
+from kirin.utils import make_rt_update, floor_datetime, to_navitia_utc_str, set_rtu_status_ko
 from kirin.utils import record_internal_failure, record_call
 from kirin import app
 import itertools
@@ -53,15 +53,14 @@ def handle(proto, navitia_wrapper, contributor):
         _, log_dict = core.handle(rt_update, trip_updates, contributor)
         record_call("OK", contributor=contributor)
     except KirinException as e:
-        rt_update.status = "KO"
-        rt_update.error = e.data["error"]
+        allow_reprocess = not isinstance(e, InvalidArguments)  # reprocess is useless if input is invalid
+        set_rtu_status_ko(rt_update, e.data["error"], is_reprocess_same_data_allowed=allow_reprocess)
         model.db.session.add(rt_update)
         model.db.session.commit()
         record_call("failure", reason=six.text_type(e), contributor=contributor)
         raise
     except Exception as e:
-        rt_update.status = "KO"
-        rt_update.error = e.message
+        set_rtu_status_ko(rt_update, e.message, is_reprocess_same_data_allowed=True)
         model.db.session.add(rt_update)
         model.db.session.commit()
         record_call("failure", reason=six.text_type(e), contributor=contributor)
@@ -106,9 +105,9 @@ class KirinModelBuilder(object):
             trip_updates.extend(tu)
 
         if not trip_updates:
-            rt_update.status = "KO"
-            rt_update.error = "No information for this gtfs-rt with timestamp: {}".format(data.header.timestamp)
-            self.log.error("No information for this gtfs-rt with timestamp: {}".format(data.header.timestamp))
+            msg = "No information for this gtfs-rt with timestamp: {}".format(data.header.timestamp)
+            set_rtu_status_ko(rt_update, msg, is_reprocess_same_data_allowed=False)
+            self.log.error(msg)
 
         return trip_updates
 

--- a/tests/integration/gtfs_rt_test.py
+++ b/tests/integration/gtfs_rt_test.py
@@ -1802,8 +1802,9 @@ def test_manage_db_with_http_error_without_insert():
             "gtfs-rt",
             contributor=GTFS_CONTRIBUTOR,
             error="Http Error",
-            is_reprocess_same_data_allowed=False,
+            is_reprocess_same_data_allowed=True,
         )
+
         assert len(RealTimeUpdate.query.all()) == 1
         assert RealTimeUpdate.query.first().raw_data == "toto"
         assert RealTimeUpdate.query.first().status == "KO"
@@ -1818,7 +1819,7 @@ def test_manage_db_with_http_error_without_insert():
             "gtfs-rt",
             contributor=GTFS_CONTRIBUTOR,
             error="Http Error",
-            is_reprocess_same_data_allowed=False,
+            is_reprocess_same_data_allowed=True,
         )
         assert len(RealTimeUpdate.query.all()) == 1
         assert RealTimeUpdate.query.first().raw_data == "toto"
@@ -1836,7 +1837,7 @@ def test_manage_db_with_http_error_without_insert():
             "gtfs-rt",
             contributor=GTFS_CONTRIBUTOR,
             error="Http Error",
-            is_reprocess_same_data_allowed=False,
+            is_reprocess_same_data_allowed=True,
         )
         assert len(RealTimeUpdate.query.all()) == 1
         assert RealTimeUpdate.query.first().raw_data == "toto"
@@ -1857,7 +1858,7 @@ def test_manage_db_with_http_error_with_insert():
             "gtfs-rt",
             contributor=GTFS_CONTRIBUTOR,
             error="Http Error",
-            is_reprocess_same_data_allowed=False,
+            is_reprocess_same_data_allowed=True,
         )
         assert len(RealTimeUpdate.query.all()) == 1
         assert RealTimeUpdate.query.first().raw_data == "toto"
@@ -1883,7 +1884,7 @@ def test_manage_db_with_http_error_with_insert():
             "gtfs-rt",
             contributor=GTFS_CONTRIBUTOR,
             error="Http Error",
-            is_reprocess_same_data_allowed=False,
+            is_reprocess_same_data_allowed=True,
         )
         assert len(RealTimeUpdate.query.all()) == 3
         assert RealTimeUpdate.query.order_by(desc(RealTimeUpdate.created_at)).first().raw_data == "toto"

--- a/tests/integration/gtfs_rt_test.py
+++ b/tests/integration/gtfs_rt_test.py
@@ -35,13 +35,13 @@ import datetime
 import pytest
 from kirin.core.model import RealTimeUpdate, db, TripUpdate, StopTimeUpdate, VehicleJourney
 from kirin.core.populate_pb import to_posix_time, convert_to_gtfsrt
-from kirin import gtfs_rt
+from kirin import gtfs_rt, redis_client
 from kirin.core.types import TripEffect
 from kirin.tasks import purge_trip_update, purge_rt_update
 from tests import mock_navitia
 from tests.check_utils import dumb_nav_wrapper, api_post
 from kirin import gtfs_realtime_pb2, app
-from kirin.utils import save_rt_data_with_error, manage_db_error
+from kirin.utils import save_rt_data_with_error, manage_db_error, build_redis_etag_key
 from tests.integration.conftest import GTFS_CONTRIBUTOR
 import time
 from sqlalchemy import desc
@@ -125,8 +125,12 @@ def test_wrong_gtfs_rt_post():
     """
     wrong protobuf post on the api
     """
+    redis_client.set(build_redis_etag_key(GTFS_CONTRIBUTOR), "firstETag")  # set ETag key as if it was polled
     res, status = api_post("/gtfs_rt", check=False, data="bob")
 
+    assert (
+        redis_client.get(build_redis_etag_key(GTFS_CONTRIBUTOR)) == "firstETag"
+    )  # error in feed: remember it's processed
     assert status == 400
     assert "invalid protobuf" in res.get("error")
 
@@ -218,8 +222,12 @@ def test_gtfs_rt_simple_delay(basic_gtfs_rt_data, mock_rabbitmq):
 
     after the merge, we should have 4 stops (and only 2 delayed)
     """
+    redis_client.set(build_redis_etag_key(GTFS_CONTRIBUTOR), "firstETag")  # set ETag key as if it was polled
     tester = app.test_client()
     resp = tester.post("/gtfs_rt", data=basic_gtfs_rt_data.SerializeToString())
+    assert (
+        redis_client.get(build_redis_etag_key(GTFS_CONTRIBUTOR)) == "firstETag"
+    )  # all OK: remember it's processed
     assert resp.status_code == 200
 
     with app.app_context():
@@ -1780,6 +1788,7 @@ def test_save_gtfs_rt_with_error():
     test the function "save_gtfs_rt_with_error"
     """
     with app.app_context():
+        redis_client.set(build_redis_etag_key(GTFS_CONTRIBUTOR), "firstETag")  # set ETag key as if it was polled
         save_rt_data_with_error(
             "toto",
             "gtfs-rt",
@@ -1787,6 +1796,9 @@ def test_save_gtfs_rt_with_error():
             error="Decode Error",
             is_reprocess_same_data_allowed=False,
         )
+        assert (
+            redis_client.get(build_redis_etag_key(GTFS_CONTRIBUTOR)) == "firstETag"
+        )  # error in feed: remember it's processed
         assert len(RealTimeUpdate.query.all()) == 1
         assert RealTimeUpdate.query.first().status == "KO"
         assert RealTimeUpdate.query.first().error == "Decode Error"
@@ -1853,6 +1865,7 @@ def test_manage_db_with_http_error_with_insert():
     no gtfs-rt with 'Http Error' inserted since more than 5 seconds
     """
     with app.app_context():
+        redis_client.set(build_redis_etag_key(GTFS_CONTRIBUTOR), "firstETag")  # set ETag key as if it was polled
         manage_db_error(
             "toto",
             "gtfs-rt",
@@ -1860,6 +1873,9 @@ def test_manage_db_with_http_error_with_insert():
             error="Http Error",
             is_reprocess_same_data_allowed=True,
         )
+        assert (
+            redis_client.get(build_redis_etag_key(GTFS_CONTRIBUTOR)) is None
+        )  # external error: forget it was processed and allow reprocess
         assert len(RealTimeUpdate.query.all()) == 1
         assert RealTimeUpdate.query.first().raw_data == "toto"
         assert RealTimeUpdate.query.first().status == "KO"
@@ -1867,6 +1883,9 @@ def test_manage_db_with_http_error_with_insert():
 
         created_at = RealTimeUpdate.query.first().created_at
 
+        redis_client.set(
+            build_redis_etag_key(GTFS_CONTRIBUTOR), "secondETag"
+        )  # set ETag key as if it was polled
         manage_db_error(
             "",
             "gtfs-rt",
@@ -1874,11 +1893,15 @@ def test_manage_db_with_http_error_with_insert():
             error="Decode Error",
             is_reprocess_same_data_allowed=False,
         )
+        assert (
+            redis_client.get(build_redis_etag_key(GTFS_CONTRIBUTOR)) == "secondETag"
+        )  # error in feed: remember it's processed
         assert len(RealTimeUpdate.query.all()) == 2
         assert RealTimeUpdate.query.order_by(desc(RealTimeUpdate.created_at)).first().status == "KO"
         assert RealTimeUpdate.query.order_by(desc(RealTimeUpdate.created_at)).first().error == "Decode Error"
         assert RealTimeUpdate.query.order_by(desc(RealTimeUpdate.created_at)).first().created_at > created_at
 
+        redis_client.set(build_redis_etag_key(GTFS_CONTRIBUTOR), "thirdETag")  # set ETag key as if it was polled
         manage_db_error(
             "toto",
             "gtfs-rt",
@@ -1886,6 +1909,9 @@ def test_manage_db_with_http_error_with_insert():
             error="Http Error",
             is_reprocess_same_data_allowed=True,
         )
+        assert (
+            redis_client.get(build_redis_etag_key(GTFS_CONTRIBUTOR)) is None
+        )  # external error: forget it was processed and allow reprocess
         assert len(RealTimeUpdate.query.all()) == 3
         assert RealTimeUpdate.query.order_by(desc(RealTimeUpdate.created_at)).first().raw_data == "toto"
         assert RealTimeUpdate.query.order_by(desc(RealTimeUpdate.created_at)).first().status == "KO"


### PR DESCRIPTION
Previously if there was some issue in processing (for example connection loss to Navitia) we didn't retry to process the same input, as its ETag was unchanged.
Now we forget about previous' ETag if there was an error that is not related to the file itself.

:mag: Main code is in utils.py. Please read by commit with message.

TODO:
- [x] merge #266 as this branch is including it
- [x] merge #268 (and rebase) as Redis is needed to have tests running now
- [x] hand-test it:
  * With a good gtfsrt.pb : second poll avoided :heavy_check_mark: 
  * With a bad gtfsrt.pb : second poll avoided :heavy_check_mark: 
  * With a good gtfsrt.pb but no navitia linked to kirin : second poll redone, poll OK when navitia up again :heavy_check_mark: 
  * Always repolled when ETag changes :heavy_check_mark: 
- [x] maybe add unit tests if possible: Not added
  Added test just on ETag stored in redis, without the whole process (mostly basic low-level error management functions).
  :warning: as there is no poll test, it's not easy to add. It may be a separate task (here or/and in Artemis): tracked in https://jira.kisio.org/browse/NAVP-1412

Related to https://jira.kisio.org/browse/NAVITIAII-2800