### PR TITLE
Add and use Redis docker in tests

### DIFF
--- a/kirin/__init__.py
+++ b/kirin/__init__.py
@@ -86,7 +86,7 @@ manager = Manager(app)
 
 from redis import Redis
 
-redis = Redis(
+redis_client = Redis(
     host=app.config[str("REDIS_HOST")],
     port=app.config[str("REDIS_PORT")],
     db=app.config[str("REDIS_DB")],

--- a/kirin/gtfs_rt/gtfs_rt.py
+++ b/kirin/gtfs_rt/gtfs_rt.py
@@ -37,7 +37,7 @@ from google.protobuf.message import DecodeError
 from kirin.exceptions import InvalidArguments
 import navitia_wrapper
 from kirin.gtfs_rt import model_maker
-from kirin import redis
+from kirin import redis_client
 from kirin.utils import manage_db_error
 
 
@@ -62,7 +62,7 @@ class GtfsRT(Resource):
             url=url,
             token=token,
             timeout=timeout,
-            cache=redis,
+            cache=redis_client,
             query_timeout=query_timeout,
             pubdate_timeout=pubdate_timeout,
         ).instance(instance)

--- a/kirin/utils.py
+++ b/kirin/utils.py
@@ -179,11 +179,11 @@ def manage_db_no_new(connector, contributor):
 
 @contextmanager
 def get_lock(logger, lock_name, lock_timeout):
-    from kirin import redis
+    from kirin import redis_client
 
     logger.debug("getting lock %s", lock_name)
     try:
-        lock = redis.lock(lock_name, timeout=lock_timeout)
+        lock = redis_client.lock(lock_name, timeout=lock_timeout)
         locked = lock.acquire(blocking=False)
     except ConnectionError:
         logging.exception("Exception with redis while locking")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,8 +31,7 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 from contextlib import closing
 
-import kirin
-from kirin import app, db
+from kirin import app, db, redis_client
 import pytest
 
 from tests.docker_wrapper import postgres_docker, redis_docker
@@ -70,5 +69,5 @@ def redis_docker_fixture():
 
 @pytest.fixture(scope="session", autouse=True)
 def init_redis_db(redis_docker_fixture):
-    # re-init the redis host by overwriting Redis client (same conf than the one tested in wrapper)
-    kirin.redis = redis_docker_fixture.get_redis_client()
+    # Switch global redis-client's connection to use the Redis server from docker (instead of the conf)
+    redis_client.connection_pool = redis_docker_fixture.get_redis_connection_pool()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,26 +34,24 @@ from contextlib import closing
 from kirin import app, db
 import pytest
 
-from tests.docker_wrapper import PostgresDocker
+from tests.docker_wrapper import postgres_docker
 
 
 @pytest.yield_fixture(scope="session", autouse=True)
-def docker():
+def pg_docker_fixture():
     """
-    a docker providing a database is started once for all tests
+    a docker providing a PostgreSQL database is started once for all tests
     """
-    with closing(PostgresDocker()) as database:
-        yield database
+    with closing(postgres_docker()) as pg_db:
+        yield pg_db
 
 
 @pytest.fixture(scope="session", autouse=True)
-def init_flask_db(docker):
+def init_flask_db(pg_docker_fixture):
     """
     when the docker is started, we init flask once for the new database
     """
-    db_url = "postgresql://{user}:{pwd}@{host}/{dbname}".format(
-        user=docker.USER, pwd=docker.PWD, host=docker.ip_addr, dbname=docker.DBNAME
-    )
+    db_url = pg_docker_fixture.get_db_params().cnx_string()
 
     # re-init the db by overriding the db_url
     app.config[str("SQLALCHEMY_DATABASE_URI")] = db_url

--- a/tests/docker_wrapper.py
+++ b/tests/docker_wrapper.py
@@ -31,68 +31,79 @@
 
 from __future__ import absolute_import, print_function, unicode_literals, division
 import docker
-import psycopg2
 import logging
+import psycopg2
+from io import BytesIO
+
+from typing import List, Optional, Dict, IO
 from retrying import retry
 
-# postgres image
-POSTGRES_IMAGE = "postgres:9.4"
-POSTGRES_CONTAINER_NAME = "kirin_test_postgres"
+"""
+This module contains classes about Docker management.
+"""
+
+logger = logging.getLogger(__name__)  # type: logging.Logger
 
 
-def _get_docker_file():
-    """
-    Return a dumb DockerFile
-
-    The best way to get the image would be to get postgres:9.4 it from dockerhub,
-    but with this dumb wrapper the runtime time of the unit tests
-    is reduced by 10s
-    """
-    from io import BytesIO
-
-    return BytesIO(str("FROM " + POSTGRES_IMAGE))
-
-
-class PostgresDocker(object):
-    USER = "postgres"
-    PWD = "postgres"
-    DBNAME = "kirin_test"
+class DockerWrapper(object):
     """
     launch a temporary docker with a postgresql db
     """
 
-    def __init__(self, user=USER, pwd=PWD, dbname=DBNAME):
-        log = logging.getLogger(__name__)
+    def __init__(
+        self,
+        image_name,  # type: unicode
+        container_name=None,  # type: Optional[unicode]
+        dockerfile_obj=None,  # type: Optional[IO]
+        dockerfile_path=None,  # type: Optional[unicode]
+        env_vars={},  # type: Dict[unicode, unicode]
+        mounts=None,  # type: Optional[List[docker.types.Mount]]
+    ):
+        # type: (...) -> None
         base_url = "unix://var/run/docker.sock"
         self.docker_client = docker.DockerClient(base_url=base_url)
         self.docker_api_client = docker.APIClient(base_url=base_url)
+        self.image_name = image_name
+        self.dockerfile_obj = dockerfile_obj
+        self.dockerfile_path = dockerfile_path
+        self.container_name = container_name
+        self.env_vars = env_vars
+        self.mounts = mounts or []
 
-        log.info("Trying to build/update the docker image")
+        logger.info("Trying to build/update the docker image")
+
         try:
-            for build_output in self.docker_client.images.build(
-                fileobj=_get_docker_file(), tag=POSTGRES_IMAGE, rm=True
-            ):
-                log.debug(build_output)
+            if self.dockerfile_path or self.dockerfile_obj:
+                for build_output in self.docker_client.images.build(
+                    path=self.dockerfile_path, fileobj=self.dockerfile_obj, tag=self.image_name, rm=True
+                ):
+                    logger.debug(build_output)
+            else:
+                self.docker_client.images.pull(self.image_name)
+
         except docker.errors.APIError as e:
             if e.is_server_error():
-                log.warn("[docker server error] A server error occcured, maybe " "missing internet connection?")
-                log.warn("[docker server error] Details: {}".format(e))
-                log.warn(
-                    "[docker server error] Checking if '{}' docker image "
-                    "is already built".format(POSTGRES_IMAGE)
+                logger.warn("[docker server error] A server error occcured, maybe missing internet connection?")
+                logger.warn("[docker server error] Details: {}".format(e))
+                logger.warn(
+                    "[docker server error] Checking if '{}' docker image is already built".format(
+                        self.image_name
+                    )
                 )
-                self.docker_client.images.get(POSTGRES_IMAGE)
-                log.warn(
-                    "[docker server error] Going on, as '{}' docker image "
-                    "is already built".format(POSTGRES_IMAGE)
+                self.docker_client.images.get(self.image_name)
+                logger.warn(
+                    "[docker server error] Going on, as '{}' docker image is already built".format(
+                        self.image_name
+                    )
                 )
             else:
                 raise
 
-        self.container = self.docker_client.containers.create(POSTGRES_IMAGE, name=POSTGRES_CONTAINER_NAME)
-        log.info("docker id is {}".format(self.container.id))
-
-        log.info("starting the temporary docker")
+        self.container = self.docker_client.containers.create(
+            self.image_name, name=self.container_name, environment=self.env_vars, mounts=self.mounts
+        )
+        logger.info("docker id is {}".format(self.container.id))
+        logger.info("starting the temporary docker")
         self.container.start()
         self.ip_addr = (
             self.docker_api_client.inspect_container(self.container.id)
@@ -101,33 +112,136 @@ class PostgresDocker(object):
         )
 
         if not self.ip_addr:
-            log.error("temporary docker {} not started".format(self.container.id))
-            assert False
-
-        # we create an empty database to prepare for the test
-        self._create_db(user, pwd, dbname)
+            logger.error("temporary docker {} not started".format(self.container.id))
+            exit(1)
 
     def close(self):
-        logging.getLogger(__name__).info("stopping the temporary docker")
+        # type: () -> None
+        """
+        Terminate the Docker and clean it.
+        """
+        logger.info("stopping the temporary docker")
         self.container.stop()
 
-        logging.getLogger(__name__).info("removing the temporary docker")
+        logger.info("removing the temporary docker")
         self.container.remove(v=True)
 
         # test to be sure the docker is removed at the end
         try:
             self.docker_client.containers.get(self.container.id)
         except docker.errors.NotFound:
-            logging.getLogger(__name__).info("the container is properly removed")
+            logger.info("the container is properly removed")
         else:
-            logging.getLogger(__name__).error("something is strange, the container is still there ...")
+            logger.error("something is strange, the container is still there ...")
             exit(1)
 
+
+class DbParams(object):
+    """
+    Class to store and manipulate database parameters.
+    """
+
+    def __init__(self, host, dbname, user, password):
+        # type: (unicode, unicode, unicode, unicode) -> None
+        """
+        Constructor of DbParams.
+
+        :param host: the host name
+        :param dbname: the database name
+        :param user: the user name to use for the database
+        :param password: the password of the user
+        """
+        self.host = host
+        self.user = user
+        self.dbname = dbname
+        self.password = password
+
+    def cnx_string(self):
+        # type: () -> unicode
+        """
+        The connection string for the database.
+        A string containing all the essentials data for a connection to a database.
+
+        :return: the connection string
+        """
+        return "postgresql://{u}:{pwd}@{h}/{dbname}".format(
+            h=self.host, u=self.user, dbname=self.dbname, pwd=self.password
+        )
+
+    def old_school_cnx_string(self):
+        # type: () -> unicode
+        """
+        The connection string for the database (old school version).
+        A string containg all the essentials data for a connection to a old school database (before Debian8). Old C++
+        component does not support the classic "postgres://...".
+
+        :return: the old school connection string
+        """
+        return "host={h} user={u} dbname={dbname} password={pwd}".format(
+            h=self.host, u=self.user, dbname=self.dbname, pwd=self.password
+        )
+
+
+class PostgresDockerWrapper(DockerWrapper):
+    def __init__(
+        self,
+        image_name,  # type: unicode
+        container_name=None,  # type: Optional[unicode]
+        dockerfile_obj=None,  # type: Optional[IO]
+        dockerfile_path=None,  # type: Optional[unicode]
+        env_vars={},  # type: Dict[unicode, unicode]
+        mounts=None,  # type: Optional[List[docker.types.Mount]]
+        db_name="kirin_test",  # type: unicode
+        db_user="postgres",  # type: unicode
+        db_password="postgres",  # type: unicode
+    ):
+        # type: (...) -> None
+        super(PostgresDockerWrapper, self).__init__(
+            image_name, container_name, dockerfile_obj, dockerfile_path, env_vars, mounts
+        )
+        self.db_name = db_name
+        self.db_user = db_user
+        self.db_password = db_password
+
+    def get_db_params(self):
+        # type: () -> DbParams
+        """
+        Create the connection parameters of the database.
+        Default user and password are "docker" and default database is "postgres".
+
+        :return: the DbParams for the database of the Docker
+        """
+        return DbParams(self.ip_addr, self.db_name, self.db_user, self.db_password)
+
     @retry(stop_max_delay=10000, wait_fixed=100, retry_on_exception=lambda e: isinstance(e, Exception))
-    def _create_db(self, user, pwd, dbname):
-        connect = psycopg2.connect(user=user, host=self.ip_addr, password=pwd)
-        connect.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
-        cur = connect.cursor()
-        cur.execute("CREATE DATABASE " + dbname)
-        cur.close()
-        connect.close()
+    def test_db_cnx(self):
+        # type: () -> None
+        """
+        Test the connection to the database.
+        """
+        params = self.get_db_params()
+        psycopg2.connect(database=params.dbname, user=params.user, password=params.password, host=params.host)
+
+
+def postgres_docker(db_name="kirin_test", db_user="postgres", db_password="postgres", mounts=None):
+    # type: (unicode, unicode, unicode, Optional[List[docker.types.Mount]]) -> PostgresDockerWrapper
+    env_vars = {"POSTGRES_DB": db_name, "POSTGRES_USER": db_user, "POSTGRES_PASSWORD": db_password}
+
+    postgres_image = "postgres:9.4"
+
+    # The best way to get the image would be to get it from dockerhub,
+    # but with this dumb wrapper the runtime time of the unit tests is reduced by 10s
+    dockerfile_obj = BytesIO(str("FROM " + postgres_image))
+
+    pg_wrap = PostgresDockerWrapper(
+        image_name=postgres_image,
+        dockerfile_obj=dockerfile_obj,
+        container_name="kirin_test_postgres",
+        db_name=db_name,
+        db_user=db_user,
+        db_password=db_password,
+        env_vars=env_vars,
+        mounts=mounts,
+    )
+    pg_wrap.test_db_cnx()  # we poll to ensure that the database is ready
+    return pg_wrap

--- a/tests/integration/gtfs_rt_test.py
+++ b/tests/integration/gtfs_rt_test.py
@@ -37,6 +37,7 @@ from kirin.core.model import RealTimeUpdate, db, TripUpdate, StopTimeUpdate, Veh
 from kirin.core.populate_pb import to_posix_time, convert_to_gtfsrt
 from kirin import gtfs_rt
 from kirin.core.types import TripEffect
+from kirin.tasks import purge_trip_update, purge_rt_update
 from tests import mock_navitia
 from tests.check_utils import dumb_nav_wrapper, api_post
 from kirin import gtfs_realtime_pb2, app
@@ -295,9 +296,11 @@ def test_gtfs_rt_purge(basic_gtfs_rt_data, mock_rabbitmq):
         assert db.session.execute("select * from associate_realtimeupdate_tripupdate").rowcount == 1
 
         # VehicleJourney affected is old, so it's affected by TripUpdate purge (based on base-VJ's date)
-        contrib = app.config.get(str("GTFS_RT_CONTRIBUTOR"))
-        until = datetime.date(2012, 12, 31)
-        TripUpdate.remove_by_contributors_and_period(contributors=[contrib], start_date=None, end_date=until)
+        config = {
+            "contributor": app.config.get(str("GTFS_RT_CONTRIBUTOR")),
+            "nb_days_to_keep": int(app.config.get("NB_DAYS_TO_KEEP_TRIP_UPDATE")),
+        }
+        purge_trip_update(config)
 
         assert len(TripUpdate.query.all()) == 0
         assert len(VehicleJourney.query.all()) == 0
@@ -309,8 +312,8 @@ def test_gtfs_rt_purge(basic_gtfs_rt_data, mock_rabbitmq):
         rtu = RealTimeUpdate.query.all()[0]
         rtu.created_at = datetime.datetime(2012, 6, 15, 15, 33)
 
-        connector = "gtfs-rt"
-        RealTimeUpdate.remove_by_connectors_until(connectors=[connector], until=until)
+        config = {"nb_days_to_keep": app.config.get(str("NB_DAYS_TO_KEEP_RT_UPDATE")), "connector": "gtfs-rt"}
+        purge_rt_update(config)
 
         assert len(TripUpdate.query.all()) == 0
         assert len(VehicleJourney.query.all()) == 0


### PR DESCRIPTION
Add test using Redis (tasks) and provide a docker for them.

Those tests are failing if no Redis exists on host.
Mostly reverting commit https://github.com/CanalTP/kirin/pull/244/commits/ea279e8c31869ab912b7729700db5d064608de63 for the test part. So now testing the same thing, but one level above :tada: 

More generally, this is going to allow test of code parts using Redis.

:mag: Review by commit, as they are independent.

JIRA: https://jira.kisio.org/browse/NAVP-1336