### PR TITLE
Test existence of config in file always using contributor

### DIFF
--- a/kirin/cots/cots.py
+++ b/kirin/cots/cots.py
@@ -48,7 +48,7 @@ def get_cots_contributor():
     File has priority over db
     TODO: Remove from config file
     """
-    if "NAVITIA_INSTANCE" in current_app.config and current_app.config.get(str("NAVITIA_INSTANCE")):
+    if "COTS_CONTRIBUTOR" in current_app.config and current_app.config.get(str("COTS_CONTRIBUTOR")):
         return model.Contributor(
             id=current_app.config.get(str("COTS_CONTRIBUTOR")),
             navitia_coverage=current_app.config.get(str("NAVITIA_INSTANCE")),


### PR DESCRIPTION
It was contributor already for all GTFS_RT, and in model for COTS.
This adds consistency to help debug and migration.