### PR TITLE
Add a 'docker-compose.yml' for development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.7"
+services:
+    db:
+        image: postgres:12
+        restart: always
+        environment:
+            POSTGRES_USER: "navitia"
+            POSTGRES_PASSWORD: "navitia"
+            POSTGRES_DB: "kirin"
+        ports:
+            - "5432:5432"
+    redis:
+        image: redis:5
+        restart: always
+        ports:
+            - "6379:6379"
+    mq:
+        image: rabbitmq:3
+        restart: always
+        ports:
+            - "5672:5672"


### PR DESCRIPTION
This is to simplify the life of the developer who is working on his own machine and don't want to install all the dependencies. Note that this is only a bootstrap `docker-compose.yml` that can probably be improved a lot so I'm creating only a Draft PR for now, let's discuss it and improve it before merging it.

Ideas for improvements so far:
- a script to initialize the DB (instead of using only the environment variable in `docker-compose.yml`); this would allow to have multiple tables like `kirin` and `chaos_testing`
- add entries in `docker-compose.yml` to also start up the kirin instances
- define a volume to persist the DB?

I can try to work these improvements but I first want to be sure some of you are fine with the idea of this PR before investing more time on it.