### PR TITLE
GTFS-RT endpoints: Separate Index management from POST management

### DIFF
--- a/kirin/api.py
+++ b/kirin/api.py
@@ -50,8 +50,11 @@ api.app.url_map.strict_slashes = False
 api.add_resource(resources.Index, "/", endpoint=str("index"))
 api.add_resource(resources.Status, "/status", endpoint=str("status"))
 api.add_resource(cots.Cots, "/cots", endpoint=str("cots"))
-api.add_resource(gtfs_rt.GtfsRT, "/gtfs_rt", "/gtfs_rt/<string:id>", endpoint=str("gtfs_rt"))
-api.add_resource(resources.Contributors, "/contributors", "/contributors/<string:id>")
+api.add_resource(gtfs_rt.GtfsRTIndex, "/gtfs_rt", endpoint=str("gtfs_rt_index"))
+api.add_resource(gtfs_rt.GtfsRT, "/gtfs_rt/<string:id>", endpoint=str("gtfs_rt"))
+api.add_resource(
+    resources.Contributors, "/contributors", "/contributors/<string:id>", endpoint=str("contributors")
+)
 api.add_resource(resources.Health, "/health", endpoint=str("health"))
 
 

--- a/kirin/gtfs_rt/gtfs_rt.py
+++ b/kirin/gtfs_rt/gtfs_rt.py
@@ -31,6 +31,7 @@
 
 from __future__ import absolute_import, print_function, unicode_literals, division
 import flask
+from flask import url_for
 from flask.globals import current_app
 from flask_restful import Resource, marshal, abort
 from google.protobuf.message import DecodeError
@@ -90,10 +91,18 @@ def make_navitia_wrapper(contributor):
     ).instance(contributor.navitia_coverage)
 
 
-class GtfsRT(Resource):
+class GtfsRTIndex(Resource):
     def get(self):
-        return {"gtfs-rt": marshal(get_gtfsrt_contributors(), contributor_fields)}
+        contributors = get_gtfsrt_contributors()
 
+        if not contributors:
+            return {"message": "No GTFS-RT contributor defined"}, 200
+
+        response = {c.id: {"href": url_for("gtfs_rt", id=c.id, _external=True)} for c in contributors}
+        return response, 200
+
+
+class GtfsRT(Resource):
     def post(self, id=None):
         if id is None:
             abort(400, message="Contributor's id is missing")

--- a/tests/integration/gtfs_rt_test.py
+++ b/tests/integration/gtfs_rt_test.py
@@ -124,14 +124,13 @@ def basic_gtfs_rt_data_without_delays():
 
 def test_get_gtfs_rt_contributors():
     """
-    Get GTFS-RT contributors
+    Get GTFS-RT contributors index
     """
     resp = api_get("/gtfs_rt")
-    assert "gtfs-rt" in resp
-    assert len(resp["gtfs-rt"]) == 2
-    for contributor in resp["gtfs-rt"]:
-        assert contributor["connector_type"] == "gtfs-rt"
-        assert "rt.vroumvroum" in contributor["id"]
+    assert len(resp) == 2
+    for contrib, link in resp.iteritems():
+        assert "rt.vroumvroum" in contrib
+        assert "rt.vroumvroum" in link["href"]
 
 
 def test_wrong_gtfs_rt_post():
@@ -172,7 +171,7 @@ def test_gtfs_rt_post_no_data():
             assert len(TripUpdate.query.all()) == 0
             assert len(StopTimeUpdate.query.all()) == 0
 
-    post_and_check("/gtfs_rt/", 400, "Contributor's id is missing", None)
+    post_and_check("/gtfs_rt/", 405, "The method is not allowed for the requested URL.", None)
     post_and_check("/gtfs_rt/{}".format(GTFS_CONTRIBUTOR), 400, "invalid arguments", "no gtfs_rt data provided")
     post_and_check("/gtfs_rt/unknown_id", 404, "Contributor 'unknown_id' not found", None)
 

--- a/tests/integration/gtfs_rt_test.py
+++ b/tests/integration/gtfs_rt_test.py
@@ -133,6 +133,15 @@ def test_get_gtfs_rt_contributors():
         assert "rt.vroumvroum" in link["href"]
 
 
+def test_wrong_get_gtfs_rt_with_id():
+    """
+    GET /gtfs_rt/id.contributor (so with an id) is not allowed, only POST is possible
+    """
+    resp, status = api_get("/gtfs_rt/rt.vroumvroum", check=False)
+    assert status == 405
+    assert resp.get("message") == "The method is not allowed for the requested URL."
+
+
 def test_wrong_gtfs_rt_post():
     """
     Post wrong GTFS-RT data


### PR DESCRIPTION
This will avoid crash when requesting GET on `/gtfs_rt/id.contributor` (param  `id` was provided to `get()`, leading to a python crash)

Also `/gtfs_rt` now returns "classic" index:
```
{
  "realtime.toto": {
    "href": "http://localhost:54746/gtfs_rt/realtime.toto"
  },
  "realtime.tata": {
    "href": "http://localhost:54746/gtfs_rt/realtime.tata"
  }
}
```