### PR TITLE
Manage polling interval by contributor

### DIFF
--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -528,14 +528,25 @@ class Contributor(db.Model):  # type: ignore
     navitia_token = db.Column(db.Text, nullable=True)
     feed_url = db.Column(db.Text, nullable=True)
     connector_type = db.Column(Db_ConnectorType, nullable=False)
+    retrieval_interval = db.Column(db.Integer, nullable=True, default=10)
     is_active = db.Column(db.Boolean, nullable=False, default=True)
 
-    def __init__(self, id, navitia_coverage, connector_type, navitia_token=None, feed_url=None, is_active=True):
+    def __init__(
+        self,
+        id,
+        navitia_coverage,
+        connector_type,
+        navitia_token=None,
+        feed_url=None,
+        retrieval_interval=10,
+        is_active=True,
+    ):
         self.id = id
         self.navitia_coverage = navitia_coverage
         self.connector_type = connector_type
         self.navitia_token = navitia_token
         self.feed_url = feed_url
+        self.retrieval_interval = retrieval_interval
         self.is_active = is_active
 
     @classmethod

--- a/kirin/default_settings.py
+++ b/kirin/default_settings.py
@@ -156,17 +156,16 @@ REDIS_LOCK_TIMEOUT_POLLER = int(
 REDIS_LOCK_TIMEOUT_PURGE = int(os.getenv("KIRIN_REDIS_LOCK_TIMEOUT_PURGE", timedelta(hours=12).total_seconds()))
 
 TASK_LOCK_PREFIX = "kirin.lock"
+TASK_LAST_CALL_DATETIME_PREFIX = "kirin.last_exec_datetime"
 
 TASK_STOP_MAX_DELAY = int(os.getenv("KIRIN_TASK_STOP_MAX_DELAY", timedelta(seconds=10).total_seconds()))
 TASK_WAIT_FIXED = int(os.getenv("KIRIN_TASK_WAIT_FIXED", timedelta(seconds=2).total_seconds()))
 
-# Must be >= 1. Defines the minimal interval (seconds) between 2 tries for polling (can be longer if a task is running).
-POLLER_MIN_INTERVAL = int(os.getenv("KIRIN_POLLER_MIN_INTERVAL", timedelta(seconds=10).total_seconds()))
 CELERYBEAT_SCHEDULE = {
     "poller": {
         "task": "kirin.tasks.poller",
-        "schedule": timedelta(seconds=POLLER_MIN_INTERVAL),
-        "options": {"expires": timedelta(seconds=POLLER_MIN_INTERVAL).total_seconds()},
+        "schedule": timedelta(seconds=1),
+        "options": {"expires": timedelta(seconds=1).total_seconds()},
     },
     "purge_gtfs_trip_update": {
         "task": "kirin.tasks.purge_gtfs_trip_update",

--- a/kirin/default_settings.py
+++ b/kirin/default_settings.py
@@ -161,11 +161,16 @@ TASK_LAST_CALL_DATETIME_PREFIX = "kirin.last_exec_datetime"
 TASK_STOP_MAX_DELAY = int(os.getenv("KIRIN_TASK_STOP_MAX_DELAY", timedelta(seconds=10).total_seconds()))
 TASK_WAIT_FIXED = int(os.getenv("KIRIN_TASK_WAIT_FIXED", timedelta(seconds=2).total_seconds()))
 
+# Must be >= 1. Defines the general minimal interval (seconds) between 2 possible tries for polling.
+# WARNING: this is anyway also managed by retrieval_interval for each contributor
+# (can also  be longer if a task is running).
+POLLER_MIN_INTERVAL = int(os.getenv("KIRIN_POLLER_MIN_INTERVAL", timedelta(seconds=1).total_seconds()))
+
 CELERYBEAT_SCHEDULE = {
     "poller": {
         "task": "kirin.tasks.poller",
-        "schedule": timedelta(seconds=1),
-        "options": {"expires": timedelta(seconds=1).total_seconds()},
+        "schedule": timedelta(seconds=POLLER_MIN_INTERVAL),
+        "options": {"expires": timedelta(seconds=POLLER_MIN_INTERVAL).total_seconds()},
     },
     "purge_gtfs_trip_update": {
         "task": "kirin.tasks.purge_gtfs_trip_update",

--- a/kirin/gtfs_rt/tasks.py
+++ b/kirin/gtfs_rt/tasks.py
@@ -37,6 +37,7 @@ import requests
 import six
 
 from kirin import gtfs_realtime_pb2
+from kirin.cots.model_maker import as_duration
 
 from kirin.tasks import celery
 from kirin.utils import (
@@ -47,6 +48,7 @@ from kirin.utils import (
     manage_db_no_new,
     build_redis_etag_key,
     record_input_retrieval,
+    make_kirin_last_call_dt_name,
 )
 from kirin.gtfs_rt import model_maker
 from retrying import retry
@@ -106,14 +108,33 @@ def _retrieve_gtfsrt(config):
 def gtfs_poller(self, config):
     func_name = "gtfs_poller"
     logger = logging.LoggerAdapter(logging.getLogger(__name__), extra={"contributor": config["contributor"]})
-    logger.debug("polling of %s", config["feed_url"])
 
     contributor = config["contributor"]
     lock_name = make_kirin_lock_name(func_name, contributor)
     with get_lock(logger, lock_name, app.config[str("REDIS_LOCK_TIMEOUT_POLLER")]) as locked:
-        if not locked:
+        if not locked or not config["feed_url"]:
             new_relic.ignore_transaction()
             return
+
+        # retrieve last_call_datetime from redis
+        retrieval_interval = config["retrieval_interval"] or 10
+        str_dt_format = "%Y-%m-%d %H:%M:%S.%f"
+
+        last_exe_dt_name = make_kirin_last_call_dt_name(func_name, contributor)
+        last_exe_dt_str = redis_client.get(last_exe_dt_name)
+        last_exe_dt = datetime.strptime(last_exe_dt_str, str_dt_format) if last_exe_dt_str else None
+        now = datetime.utcnow()
+
+        if last_exe_dt and now <= last_exe_dt + as_duration(retrieval_interval):
+            # do nothing if the last call is too recent
+            new_relic.ignore_transaction()
+            return
+
+        # store last_call_datetime in redis
+        # to avoid storing things forever in redis: set an expiration duration of (interval + "security" margin)
+        redis_client.set(last_exe_dt_name, now.strftime(str_dt_format), ex=retrieval_interval + 10)
+
+        logger.debug("polling of %s", config["feed_url"])
 
         # We do a HEAD request at the very beginning of polling and we compare it with the previous one to check if
         # the gtfs-rt is changed.

--- a/kirin/resources/contributors.py
+++ b/kirin/resources/contributors.py
@@ -44,6 +44,7 @@ contributor_fields = {
     "navitia_token": fields.String,
     "feed_url": fields.String,
     "connector_type": fields.String,
+    "retrieval_interval": fields.Integer,
     "is_active": fields.Boolean,
 }
 
@@ -59,6 +60,7 @@ class Contributors(Resource):
         "navitia_token": {"type": "string"},
         "feed_url": {"type": "string", "format": "uri"},
         "connector_type": {"type": "string", "enum": ConnectorType.values()},
+        "retrieval_interval": {"type": "integer", "minimum": 1},
         "is_active": {"type": "boolean"},
     }
 
@@ -93,11 +95,18 @@ class Contributors(Resource):
         id = id or data.get("id")
         token = data.get("navitia_token", None)
         feed_url = data.get("feed_url", None)
+        retrieval_interval = data.get("retrieval_interval", 10)
         is_active = data.get("is_active", True)
 
         try:
             new_contrib = model.Contributor(
-                id, data["navitia_coverage"], data["connector_type"], token, feed_url, is_active
+                id,
+                data["navitia_coverage"],
+                data["connector_type"],
+                token,
+                feed_url,
+                retrieval_interval,
+                is_active,
             )
             model.db.session.add(new_contrib)
             model.db.session.commit()

--- a/kirin/tasks.py
+++ b/kirin/tasks.py
@@ -122,6 +122,7 @@ def poller(self):
             "token": contributor.navitia_token,
             "coverage": contributor.navitia_coverage,
             "feed_url": contributor.feed_url,
+            "retrieval_interval": contributor.retrieval_interval,
             "timeout": app.config.get(str("GTFS_RT_TIMEOUT"), 1),
         }
         gtfs_poller.delay(config)

--- a/kirin/utils.py
+++ b/kirin/utils.py
@@ -132,6 +132,12 @@ def make_kirin_lock_name(*args):
     return "|".join([app.config[str("TASK_LOCK_PREFIX")]] + [a for a in args])
 
 
+def make_kirin_last_call_dt_name(*args):
+    from kirin import app
+
+    return "|".join([app.config[str("TASK_LAST_CALL_DATETIME_PREFIX")]] + [a for a in args])
+
+
 def build_redis_etag_key(contributor):
     # type: (unicode) -> unicode
     return "|".join([contributor, "polling_HEAD"])

--- a/migrations/versions/ab44c0f366df_add_retrieval_interval.py
+++ b/migrations/versions/ab44c0f366df_add_retrieval_interval.py
@@ -1,0 +1,26 @@
+"""
+Add a retrieval_interval to contributors
+
+Revision ID: ab44c0f366df
+Revises: 57860080e5d6
+Create Date: 2020-02-12 16:56:35.678554
+
+"""
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+# revision identifiers, used by Alembic.
+revision = "ab44c0f366df"
+down_revision = "57860080e5d6"
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column(
+        "contributor", sa.Column("retrieval_interval", sa.Integer(), nullable=True, server_default="10")
+    )
+
+
+def downgrade():
+    op.drop_column("contributor", "retrieval_interval")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -77,13 +77,13 @@ def clean_db():
         # Add two contributors in the table
         db.session.add_all(
             [
-                model.Contributor(COTS_CONTRIBUTOR, "sncf", "cots", "cots_token", "cots_feed_url", True),
+                model.Contributor(COTS_CONTRIBUTOR, "sncf", "cots", "cots_token", "cots_feed_url", 10, True),
                 model.Contributor(
-                    GTFS_CONTRIBUTOR, "sherbrooke", "gtfs-rt", "gtfs-rt_token", "gtfs-rt_feed_url", True
+                    GTFS_CONTRIBUTOR, "sherbrooke", "gtfs-rt", "gtfs-rt_token", "gtfs-rt_feed_url", 1, True
                 ),
                 model.Contributor(COTS_CONTRIBUTOR_DB, "idfm", "cots", "cots_db_token", "cots_db_feed_url"),
                 model.Contributor(
-                    GTFS_CONTRIBUTOR_DB, "laval", "gtfs-rt", "gtfs-rt_db_token", "gtfs-rt_db_feed_url"
+                    GTFS_CONTRIBUTOR_DB, "laval", "gtfs-rt", "gtfs-rt_db_token", "gtfs-rt_db_feed_url", 30
                 ),
             ]
         )

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -60,7 +60,7 @@ def with_custom_contributors():
 
     db.session.add_all(
         [
-            model.Contributor("realtime.sherbrooke", "ca", "gtfs-rt", "my_token", "http://feed.url"),
+            model.Contributor("realtime.sherbrooke", "ca", "gtfs-rt", "my_token", "http://feed.url", 5),
             model.Contributor("realtime.paris", "idf", "gtfs-rt", "my_other_token", "http://otherfeed.url"),
             model.Contributor("realtime.london", "gb", "cots"),
         ]
@@ -93,6 +93,7 @@ def test_get_contributors_with_specific_id(test_client, with_custom_contributors
     assert contrib[0]["connector_type"] == "gtfs-rt"
     assert contrib[0]["navitia_token"] == "my_other_token"
     assert contrib[0]["feed_url"] == "http://otherfeed.url"
+    assert contrib[0]["retrieval_interval"] == 10
 
 
 def test_get_partial_contributor_with_empty_fields(test_client, with_custom_contributors):
@@ -126,6 +127,7 @@ def test_post_new_contributor(test_client):
         "navitia_token": "blablablabla",
         "feed_url": "http://nihongo.jp",
         "connector_type": "gtfs-rt",
+        "retrieval_interval": 30,
     }
     resp = test_client.post("/contributors", json=new_contrib)
     assert resp.status_code == 201
@@ -136,6 +138,7 @@ def test_post_new_contributor(test_client):
     assert contrib.connector_type == "gtfs-rt"
     assert contrib.navitia_token == "blablablabla"
     assert contrib.feed_url == "http://nihongo.jp"
+    assert contrib.retrieval_interval == 30
 
 
 def test_post_new_partial_contributor(test_client):
@@ -149,6 +152,7 @@ def test_post_new_partial_contributor(test_client):
     assert contrib.connector_type == "gtfs-rt"
     assert contrib.navitia_token is None
     assert contrib.feed_url is None
+    assert contrib.retrieval_interval == 10
 
 
 def test_post_empty_contributor_should_fail(test_client):
@@ -233,6 +237,7 @@ def test_put_contributor_with_id(test_client):
             "connector_type": "gtfs-rt",
             "navitia_token": "new_token",
             "feed_url": "http://new.feed",
+            "retrieval_interval": 50,
         },
     )
 
@@ -243,6 +248,7 @@ def test_put_contributor_with_id(test_client):
     assert contrib.connector_type == "gtfs-rt"
     assert contrib.navitia_token == "new_token"
     assert contrib.feed_url == "http://new.feed"
+    assert contrib.retrieval_interval == 50
 
 
 def test_put_partial_contributor(test_client):
@@ -305,6 +311,7 @@ def test_post_get_put_to_ensure_API_consitency(test_client):
         "navitia_token": "blablablabla",
         "feed_url": "http://nihongo.jp",
         "connector_type": "gtfs-rt",
+        "retrieval_interval": 180,
         "is_active": True,
     }
     test_client.post("/contributors", json=new_contrib)


### PR DESCRIPTION
https://jira.kisio.org/browse/ND-558

Difference with JIRA: store last_call_datetime in redis, as it is already used at the same place for lock.
Seemed like a simple way to do and keep conf separate from mechanic resources

:white_check_mark: Hand-tested