### PR TITLE
Remove unused received_at from RealTimeUpdate

### DIFF
--- a/documentation/internal_format.md
+++ b/documentation/internal_format.md
@@ -28,7 +28,6 @@ Received raw data from a Real Time Update.
 Property | TYpe | Description
 --- | --- | ---
 id | UUID |
-received_at | DateTime, Required | Date and time of the reception of the data (UTC)
 connector | Enum, Required | Source of the data. See below for an available source format.
 status | Enum, Required | Processing status of the received data (Possible values are `OK`, `KO` or `pending`)
 error | String, Optional | Description of the error (if any)

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -74,7 +74,7 @@ def gen_uuid():
 
 class TimestampMixin(object):
     created_at = db.Column(db.DateTime(), default=datetime.datetime.utcnow, nullable=False)
-    updated_at = db.Column(db.DateTime(), default=None, onupdate=datetime.datetime.utcnow)
+    updated_at = db.Column(db.DateTime(), default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow)
 
 
 Db_TripEffect = db.Enum(*[e.name for e in TripEffect], name="trip_effect")

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -416,7 +416,6 @@ class RealTimeUpdate(db.Model, TimestampMixin):  # type: ignore
     """
 
     id = db.Column(postgresql.UUID, default=gen_uuid, primary_key=True)
-    received_at = db.Column(db.DateTime, nullable=False)
     connector = db.Column(Db_ConnectorType, nullable=False)
     status = db.Column(db.Enum("OK", "KO", "pending", name="rt_status"), nullable=False)
     db.Index("status_idx", status)
@@ -437,13 +436,12 @@ class RealTimeUpdate(db.Model, TimestampMixin):  # type: ignore
         db.Index("realtime_update_contributor_id_and_created_at", "created_at", "contributor_id"),
     )
 
-    def __init__(self, raw_data, connector, contributor, status="OK", error=None, received_at=None):
+    def __init__(self, raw_data, connector, contributor, status="OK", error=None):
         self.id = gen_uuid()
         self.raw_data = raw_data
         self.connector = connector
         self.status = status
         self.error = error
-        self.received_at = received_at if received_at else datetime.datetime.utcnow()
         self.contributor_id = contributor
 
     @classmethod

--- a/migrations/versions/1911dab5a030_nullable_received_at.py
+++ b/migrations/versions/1911dab5a030_nullable_received_at.py
@@ -1,0 +1,24 @@
+"""
+received_at is nullable (unused)
+
+Revision ID: 1911dab5a030
+Revises: ab44c0f366df
+Create Date: 2020-02-26 18:37:18.275510
+
+"""
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+# revision identifiers, used by Alembic.
+revision = "1911dab5a030"
+down_revision = "ab44c0f366df"
+
+from alembic import op
+
+
+def upgrade():
+    op.execute("ALTER TABLE real_time_update ALTER COLUMN received_at DROP NOT NULL;")
+
+
+def downgrade():
+    op.execute("UPDATE real_time_update SET received_at = created_at WHERE received_at IS NULL;")
+    op.execute("ALTER TABLE real_time_update ALTER COLUMN received_at SET NOT NULL;")

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -96,6 +96,21 @@ def test_get_contributors_with_specific_id(test_client, with_custom_contributors
     assert contrib[0]["retrieval_interval"] == 10
 
 
+def test_get_contributors_with_specific_retrieval_interval(test_client, with_custom_contributors):
+    resp = test_client.get("/contributors/realtime.sherbrooke")
+    assert resp.status_code == 200
+
+    data = json.loads(resp.data)
+    contrib = data["contributors"]
+    assert len(contrib) == 1
+    assert contrib[0]["id"] == "realtime.sherbrooke"
+    assert contrib[0]["navitia_coverage"] == "ca"
+    assert contrib[0]["connector_type"] == "gtfs-rt"
+    assert contrib[0]["navitia_token"] == "my_token"
+    assert contrib[0]["feed_url"] == "http://feed.url"
+    assert contrib[0]["retrieval_interval"] == 5
+
+
 def test_get_partial_contributor_with_empty_fields(test_client, with_custom_contributors):
     resp = test_client.get("/contributors/realtime.london")
     assert resp.status_code == 200
@@ -314,14 +329,16 @@ def test_post_get_put_to_ensure_API_consitency(test_client):
         "retrieval_interval": 180,
         "is_active": True,
     }
-    test_client.post("/contributors", json=new_contrib)
+    post_resp = test_client.post("/contributors", json=new_contrib)
+    post_contrib = json.loads(post_resp.data)
+    assert post_contrib["contributor"] == new_contrib
 
     get_resp = test_client.get("/contributors/realtime.tokyo")
     get_contrib = json.loads(get_resp.data)["contributors"][0]
+    assert get_contrib == new_contrib
 
     put_resp = test_client.put("/contributors", json=get_contrib)
     put_data = json.loads(put_resp.data)
-
     assert put_data["contributor"] == new_contrib
 
 

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -124,7 +124,7 @@ def test_cots_simple_post(mock_rabbitmq):
         assert len(rtu_array) == 1
         rtu = rtu_array[0]
         assert "-" in rtu.id
-        assert rtu.received_at
+        assert rtu.created_at
         assert rtu.status == "OK"
         assert rtu.error is None
         assert rtu.contributor_id == COTS_CONTRIBUTOR

--- a/tests/integration/test_end_point.py
+++ b/tests/integration/test_end_point.py
@@ -257,18 +257,18 @@ def setup_database():
         tu3 = model.TripUpdate(vj3, contributor=GTFS_CONTRIBUTOR)
         rtu1 = make_rt_update(None, "cots", COTS_CONTRIBUTOR)
         rtu1.created_at = datetime(2015, 11, 4, 6, 32)
-        rtu1.updated_at = None  # mock creation, no update done
+        rtu1.updated_at = datetime(2015, 11, 4, 6, 32)  # mock creation, no update done
         rtu1.trip_updates.append(tu1)
         model.db.session.add(rtu1)
         rtu2 = make_rt_update(None, "cots", contributor=COTS_CONTRIBUTOR)
         rtu2.created_at = datetime(2015, 11, 4, 7, 32)
-        rtu2.updated_at = None
+        rtu2.updated_at = datetime(2015, 11, 4, 7, 32)
         rtu2.trip_updates.append(tu2)
         model.db.session.add(rtu2)
 
         rtu3 = make_rt_update(None, "gtfs-rt", contributor=GTFS_CONTRIBUTOR)
         rtu3.created_at = datetime(2015, 11, 4, 7, 42)
-        rtu3.updated_at = None
+        rtu3.updated_at = datetime(2015, 11, 4, 7, 42)
         rtu3.trip_updates.append(tu3)
         model.db.session.add(rtu3)
 
@@ -280,17 +280,17 @@ def setup_database():
             is_reprocess_same_data_allowed=False,
         )
         rtu4.created_at = datetime(2015, 11, 4, 7, 52)
-        rtu4.updated_at = None
+        rtu4.updated_at = datetime(2015, 11, 4, 7, 52)
         model.db.session.add(rtu4)
 
         rtu5 = make_rt_update(None, connector="gtfs-rt", contributor=GTFS_CONTRIBUTOR_DB)
         rtu5.created_at = datetime(2015, 11, 4, 8, 2)
-        rtu5.updated_at = None
+        rtu5.updated_at = datetime(2015, 11, 4, 8, 2)
         model.db.session.add(rtu5)
 
         rtu6 = make_rt_update(None, connector="cots", contributor=COTS_CONTRIBUTOR_DB)
         rtu6.created_at = datetime(2015, 11, 4, 8, 12)
-        rtu6.updated_at = None
+        rtu6.updated_at = datetime(2015, 11, 4, 8, 12)
         model.db.session.add(rtu6)
 
         model.db.session.commit()


### PR DESCRIPTION
Cleanup part of https://jira.kisio.org/browse/ND-558

TODO:
- [ ] **check that db migration is stacked on the last master's** migration just before merge
- [x] open follow-up PR (db cleanup) to be merged once this is deployed everywhere: #310 
- [x] merge (and rebase) #304 (as it is stacked over it to avoid migration conflicts)
- [x] report corrections from reviews on #304 if needed
- [x] merge (and rebase) #308 (as it is a db hotfix, and it is stacked over it)

:mag: review by commit