### PR TITLE
Convert to Github Actions for the Continuous Integration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,63 @@
+name: Continuous Integration
+on: [push, pull_request]
+
+jobs:
+    quality:
+        runs-on: ubuntu-latest
+        name: Check Quality
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+            - name: Checkout Submodules
+              uses: textbook/git-checkout-submodule-action@2.1.1
+            - name: Setup Python
+              uses: actions/setup-python@v1
+              with:
+                  # Kirin is Python 2.7 but the linting tools are Python 3.6
+                  python-version: '3.6'
+            - name: Upgrade pip
+              run: python -m pip install --upgrade pip
+            - name: Install Python Dependencies
+              run: pip install --upgrade --requirement requirements_dev.txt --requirement requirements_pre-commit.txt
+            - name: Install Protobuf Dependencies
+              run: sudo apt install --yes protobuf-compiler=3.6.1.3-2
+            - name: Build Protobuf
+              run: python setup.py build_pbf
+            - name: Setup pre-commit
+              run: pre-commit install
+            - name: Quality Check
+              run: pre-commit run --all --show-diff-on-failure
+            - name: Code Linting
+              # FIXME: 'pylint' is failing now, remove '|| exit 0' once fixed
+              run: pylint --rcfile=pylint.rc --output-format=parseable kirin || exit 0
+    tests:
+        runs-on: ubuntu-latest
+        name: Tests
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  # Need to fetch all commits for 'build_version' which needs
+                  # the last tag's commit
+                  fetch-depth: '0'
+            # Need all the tags for 'build_version'
+            - name: Pull Tags
+              run: git fetch --tags
+            - name: Checkout Submodules
+              uses: textbook/git-checkout-submodule-action@2.1.1
+            - name: Setup Python
+              uses: actions/setup-python@v1
+              with:
+                  python-version: '2.7'
+            - name: Upgrade pip
+              run: python -m pip install --upgrade pip
+            - name: Install Python Dependencies
+              run: pip install --upgrade --requirement requirements_dev.txt
+            - name: Install Protobuf Dependencies
+              run: sudo apt install --yes protobuf-compiler=3.6.1.3-2
+            - name: Build Protobuf
+              run: python setup.py build_pbf
+            - name: Build Version
+              run: python setup.py build_version
+            - name: Tests
+              run: PYTHONPATH=${{ github.workspace }}:${{ github.workspace }}/kirin KIRIN_CONFIG_FILE=test_settings.py py.test -v --doctest-modules --cov-report xml --junitxml=pytest_kirin.xml --cov=kirin .

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,7 +52,7 @@ jobs:
             - name: Upgrade pip
               run: python -m pip install --upgrade pip
             - name: Install Python Dependencies
-              run: pip install --upgrade --requirement requirements_dev.txt
+              run: pip install --upgrade --requirement requirements_dev.txt pytest-cov
             - name: Install Protobuf Dependencies
               run: sudo apt install --yes protobuf-compiler=3.6.1.3-2
             - name: Build Protobuf
@@ -61,3 +61,8 @@ jobs:
               run: python setup.py build_version
             - name: Tests
               run: PYTHONPATH=${{ github.workspace }}:${{ github.workspace }}/kirin KIRIN_CONFIG_FILE=test_settings.py py.test -v --doctest-modules --cov-report xml --junitxml=pytest_kirin.xml --cov=kirin .
+            - name: Codecov.io Publication
+              uses: codecov/codecov-action@v1
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  file: ./coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,14 @@
 *.pyc
 *_pb2.py
 kirin/version.py
+!kirin/default_settings.py
+!kirin/test_settings.py
+kirin/*_settings.py
+# pytest generated files
+pytest_kirin.xml
+.pytest_cache/
+# coverage generated files
+.coverage
+coverage.xml
+# mypy generated files
+.mypy_cache/

--- a/kirin/rabbitmq_handler.py
+++ b/kirin/rabbitmq_handler.py
@@ -152,6 +152,13 @@ class RabbitMQHandler(object):
         info.pop("password", None)
         return info
 
+    def connect(self):
+        self._connection.connect()
+
+    def close(self):
+        for c in self._connections:
+            c.release()
+
     def listen_load_realtime(self, queue_name, max_retries=10):
         log = logging.getLogger(__name__)
 
@@ -165,7 +172,7 @@ class RabbitMQHandler(object):
 
 def monitor_heartbeats(connections, rate=2):
     """
-    launch the heartbeat of amqp, it's mostly for prevent the f@#$ firewall from droping the connection
+    launch the heartbeat of amqp, it's mostly for preventing the f@#$ firewall from dropping the connection
     """
     supports_heartbeats = False
     interval = 10000

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
 ![Continuous Integration Status](https://img.shields.io/github/workflow/status/CanalTP/kirin/Continuous%20Integration)
+![Code Coverage](https://img.shields.io/codecov/c/gh/CanalTP/kirin)
 
 # Kirin
 

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
+![Continuous Integration Status](https://img.shields.io/github/workflow/status/CanalTP/kirin/Continuous%20Integration)
+
 # Kirin
 
 
@@ -57,6 +59,7 @@ The feeds can be of the following type:
 
 
 ## Setup
+Kirin supports Python 2.7.
 
  - Install dependencies with
     ```


### PR DESCRIPTION
For now, I'm leaving in place:
- TravisCI which is in charge of the code quality
- Jenkins which is in charge of the unit tests and integration tests

Everything has been moved inside Github Actions so if we decide to move forward with it, we should dump the [TravisCI configuration](https://github.com/CanalTP/kirin/blob/master/.travis.yml) and remove the corresponding [Jenkins job](https://ci.navitia.io/view/kirin/job/kirin_pull_request_build/).

An important modification concerns RabbitMQ. Kirin needs 3 components to work: Postgresql, Reddis and RabbitMQ. The two formers were spawn as part of the integration tests, the latter was already available on the Jenkins machine. For Github Actions, RabbitMQ was not available so I modified the integration tests to spawn a RabbitMQ as well. This has also the advantage that it should work on the machine of a developer too without any assumption that the developer is already running a RabbitMQ locally.

I also added a publication of the code coverage on Codecov.io. The Code Coverage was already generated in the Jenkins job. I just wanted to make it more visible with a nice UI to browse in it.