### PR TITLE
Really clean old contributors from db

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,8 +64,17 @@ honcho run ./manage.py db migrate
 ```
 This will generate a new migration file, that you can amend at your will.
 
+:bulb: Keep in mind that db upgrade is done **before** deployment of Kirin (and Kirin must work all the way).  
+Also, where Kirin is duplicated, at some point both Kirin version `n-1` and Kirin version `n` are
+running, using the same upgraded database.
+
 :warning: To ensure safe db migrations for both upgrade (deploy) and downgrade (rollback), please make sure that:  
-Kirin version `n` is able to read/write in db version `n+1` FILLED by Kirin `n+1` (it's the case on rollback)
+Kirin version `n` is able to read/write in db version `n+1` FILLED by Kirin `n+1` (it's the case on rollback).  
+As for a (column) removal, one should ensure that version `n-1` (and of course `n`) don't use (read or write)
+the "object" removed from db.
+So first (in version `n-1`) do a PR removing **any** use in python (especially in model.py) but keeping db
+almost as-is, with just a "nullable" migration if needed.
+Then (version `n`) do a PR with only the db migration, removing the "object" unused.
 
 
 ## Roles and architecture

--- a/migrations/versions/fdc0f3db714b_really_clean_old_contributors.py
+++ b/migrations/versions/fdc0f3db714b_really_clean_old_contributors.py
@@ -1,0 +1,48 @@
+"""
+REALLY delete column contributor from tables real_time_update and trip_update
+
+This migration was in 57860080e5d6, but it was too soon (see comments in migration).
+As it was applied already for some platforms, removal is conditional (IF EXISTS).
+
+Revision ID: fdc0f3db714b
+Revises: ab44c0f366df
+Create Date: 2020-02-25 14:12:48.880949
+
+"""
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+# revision identifiers, used by Alembic.
+revision = "fdc0f3db714b"
+down_revision = "ab44c0f366df"
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # Conditionally drop indexes on contributor
+    op.execute("DROP INDEX IF EXISTS realtime_update_contributor_and_created_at;")
+    op.execute("DROP INDEX IF EXISTS contributor_idx;")
+
+    # Conditionally drop column contributor
+    op.execute("ALTER TABLE real_time_update DROP COLUMN IF EXISTS contributor;")
+    op.execute("ALTER TABLE trip_update DROP COLUMN IF EXISTS contributor;")
+
+
+def downgrade():
+    # Add column contributor in the tables real_time_update and trip_update
+    op.add_column("trip_update", sa.Column("contributor", sa.TEXT(), autoincrement=False, nullable=True))
+    op.add_column("real_time_update", sa.Column("contributor", sa.TEXT(), autoincrement=False, nullable=True))
+
+    # Add indexes on contributor
+    op.create_index("contributor_idx", "trip_update", ["contributor"], unique=False)
+    op.create_index(
+        "realtime_update_contributor_and_created_at",
+        "real_time_update",
+        ["created_at", "contributor"],
+        unique=False,
+    )
+
+    # Update contributor with the value of contributor_id
+    op.execute("UPDATE real_time_update SET contributor = contributor_id;")
+    op.execute("UPDATE trip_update SET contributor = contributor_id;")

--- a/migrations/versions/fdc0f3db714b_really_clean_old_contributors.py
+++ b/migrations/versions/fdc0f3db714b_really_clean_old_contributors.py
@@ -5,7 +5,7 @@ This migration was in 57860080e5d6, but it was too soon (see comments in migrati
 As it was applied already for some platforms, removal is conditional (IF EXISTS).
 
 Revision ID: fdc0f3db714b
-Revises: ab44c0f366df
+Revises: 1911dab5a030
 Create Date: 2020-02-25 14:12:48.880949
 
 """
@@ -13,7 +13,7 @@ from __future__ import absolute_import, print_function, unicode_literals, divisi
 
 # revision identifiers, used by Alembic.
 revision = "fdc0f3db714b"
-down_revision = "ab44c0f366df"
+down_revision = "1911dab5a030"
 
 from alembic import op
 import sqlalchemy as sa


### PR DESCRIPTION
This time for good, we can remove "contributor" columns as they
are unused (write or read) in previous version (since 4.0.1)

Follow-up of #308 

Also add a tiny doc.

:mag: review by commit (last 2 only)

TODO:
- [x] rebase and **stack migration on top of master's one** just before merge (update "down revision")
- [x] wait to have `4.0.1` deployed everywhere (including in prod)
- [x] ~merge (and rebase) #305 before (as it is stacked over it to avoid migration conflicts)~
  This PR is now directly on top of master ~(as #305 doesn't do any migration)~ for readability (#305 has migration, we'll see who gets merged first.)
- [x] Test locally:  migrate to `3.0.0`, add a feed, migrate to `4.0.1`, migrate to this > prod case
  > everything migrated as planned, column "contributor" removed and retrieval_interval exists, working
- [x] Test locally: migrate to `4.0.0`, add a feed, migrate to this (`4.0.1`) > custo case
  > everything migrated as planned, column "contributor" removed and retrieval_interval exists, working

JIRA: https://jira.kisio.org/browse/NDTMA-122