### PR TITLE
[tech] Remove received_at field from db

### DIFF
--- a/migrations/versions/1f13d13948dd_rm_rtu_received_at.py
+++ b/migrations/versions/1f13d13948dd_rm_rtu_received_at.py
@@ -1,0 +1,24 @@
+"""
+Remove unused column real_time_update.received_at
+
+Revision ID: 1f13d13948dd
+Revises: 7bfe6fc8271d
+Create Date: 2020-02-13 12:41:32.412507
+
+"""
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+# revision identifiers, used by Alembic.
+revision = "1f13d13948dd"
+down_revision = "7bfe6fc8271d"
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.drop_column("real_time_update", "received_at")
+
+
+def downgrade():
+    op.add_column("real_time_update", sa.Column("received_at", sa.DateTime(), nullable=True))


### PR DESCRIPTION
To be merged only once the python part (model.py) is already deployed everywhere: #305 

:mag: Last commit only is new after #305 

TODO (hence 'do_not_merge'):
- [x] rebase and **check that this migration is stacked on top of last master's one** right before merge
- [x] deploy #305 (so >= `4.1.0`) everywhere
- [x] merge #305 ~(stacked over this PR for now)~ and rebase

Last part of JIRA: https://jira.kisio.org/browse/ND-558