### PR TITLE
Add timeout to navitia connection

### DIFF
--- a/kirin/utils.py
+++ b/kirin/utils.py
@@ -223,7 +223,7 @@ def manage_db_no_new(connector, contributor):
 
 def can_connect_to_navitia():
     try:
-        response = requests.head(current_app.config[str("NAVITIA_URL")])
+        response = requests.head(current_app.config[str("NAVITIA_URL")], timeout=1)
         return response.status_code == 200
     except Exception:
         return False


### PR DESCRIPTION
In less than 1s Kirin should have a HEAD from Navitia

This should fix the bug of having a gunicorn worker killed after 30s on /status or /health because it's waiting for a FW-blocked navitia.