### PR TITLE
Fix protobuf-compiler dependency

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,7 +20,7 @@ jobs:
             - name: Install Python Dependencies
               run: pip install --upgrade --requirement requirements_dev.txt --requirement requirements_pre-commit.txt
             - name: Install Protobuf Dependencies
-              run: sudo apt install --yes protobuf-compiler=3.6.1.3-2
+              run: sudo apt install --yes protobuf-compiler
             - name: Build Protobuf
               run: python setup.py build_pbf
             - name: Setup pre-commit
@@ -54,7 +54,7 @@ jobs:
             - name: Install Python Dependencies
               run: pip install --upgrade --requirement requirements_dev.txt pytest-cov
             - name: Install Protobuf Dependencies
-              run: sudo apt install --yes protobuf-compiler=3.6.1.3-2
+              run: sudo apt install --yes protobuf-compiler
             - name: Build Protobuf
               run: python setup.py build_pbf
             - name: Build Version


### PR DESCRIPTION
It seems that the `ubuntu-latest` that Github is using is not really the latest (or maybe it is the latest LTS?). Since our management of version dependencies for the CI is not ideal anyway, I think it will cause us less problem to remove completely the version for now...