### PR TITLE
Upgrade 'setuptools' to fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
         postgresql-client \
         git && \
     sed -i -e '/protobuf/d' requirements.txt && \
+    pip install --no-cache-dir -U setuptools && \
     pip install --no-cache-dir -r requirements.txt && \
     pip install --no-cache-dir gunicorn && \
     pip install --no-cache-dir newrelic && \


### PR DESCRIPTION
As seen in https://ci.navitia.io/job/kirin_master_build/566/console ,
Installing 'newrelic' requires an upgrade of 'setuptools'

That and the fix of navitia_pyhon_wrapper (http://github.com/CanalTP/navitia_python_wrapper/pull/16) should fix docker build.