### PR TITLE
Fix deadlock on migrations

### DIFF
--- a/migrations/versions/1911dab5a030_nullable_received_at.py
+++ b/migrations/versions/1911dab5a030_nullable_received_at.py
@@ -20,5 +20,8 @@ def upgrade():
 
 
 def downgrade():
-    op.execute("UPDATE real_time_update SET received_at = created_at WHERE received_at IS NULL;")
-    op.execute("ALTER TABLE real_time_update ALTER COLUMN received_at SET NOT NULL;")
+    op.execute(
+        "LOCK TABLE real_time_update; \
+        UPDATE real_time_update SET received_at = created_at WHERE received_at IS NULL; \
+        ALTER TABLE real_time_update ALTER COLUMN received_at SET NOT NULL;"
+    )

--- a/migrations/versions/443587af1780_reference_contributor_in_other_tables.py
+++ b/migrations/versions/443587af1780_reference_contributor_in_other_tables.py
@@ -64,9 +64,11 @@ def downgrade():
     op.drop_index("realtime_update_contributor_id_and_created_at", table_name="real_time_update")
     op.drop_index("contributor_id_idx", table_name="trip_update")
 
-    # Drop foreignKey constraints
-    op.drop_constraint("fk_trip_update_contributor_id", "trip_update", type_="foreignkey")
-    op.drop_constraint("fk_real_time_update_contributor_id", "real_time_update", type_="foreignkey")
+    # Drop foreignKey constraints (lock required to avoid deadlock from Kirin's work on the side)
+    op.execute("LOCK TABLE trip_update; ALTER TABLE trip_update DROP CONSTRAINT fk_trip_update_contributor_id")
+    op.execute(
+        "LOCK TABLE real_time_update; ALTER TABLE real_time_update DROP CONSTRAINT fk_real_time_update_contributor_id"
+    )
 
     # Delete contributor_id in real_time_update and trip_update
     op.drop_column("trip_update", "contributor_id")

--- a/migrations/versions/85a968ce3ce5_add_piv_connector_type.py
+++ b/migrations/versions/85a968ce3ce5_add_piv_connector_type.py
@@ -15,27 +15,9 @@ down_revision = "fdc0f3db714b"
 
 
 def upgrade():
-    # create new type, then switch type, finally remove old type
-    op.execute("ALTER TYPE connector_type RENAME TO connector_type_tmp")
-    op.execute("CREATE TYPE connector_type AS ENUM('piv', 'cots', 'gtfs-rt')")  # add 'piv' here
-    # switch both tables to the new enum
-    op.execute(
-        "ALTER TABLE real_time_update ALTER COLUMN connector TYPE connector_type USING connector::text::connector_type"
-    )
-
-    # isolate ALTER contributor in a separate transaction and add a lock on real_time_update that is implied through
-    # a foreign_key constraint (avoid deadlock with insert that may happen at the same time)
     op.execute("COMMIT")  # end previous transaction (automatically started by alembic)
-    op.execute("BEGIN")  # start new transaction
-    op.execute("LOCK TABLE real_time_update")
-    op.execute(
-        "ALTER TABLE contributor ALTER COLUMN connector_type \
-            TYPE connector_type USING connector_type::text::connector_type"
-    )
-    op.execute("COMMIT")  # end previous transaction
+    op.execute("ALTER TYPE connector_type ADD VALUE 'piv'")  # only possible outside of a transaction
     op.execute("BEGIN")  # start new transaction (automatically ended by alembic)
-
-    op.execute("DROP TYPE connector_type_tmp")
 
 
 def downgrade():

--- a/migrations/versions/85a968ce3ce5_add_piv_connector_type.py
+++ b/migrations/versions/85a968ce3ce5_add_piv_connector_type.py
@@ -18,23 +18,23 @@ def upgrade():
     # create new type, then switch type, finally remove old type
     op.execute("ALTER TYPE connector_type RENAME TO connector_type_tmp")
     op.execute("CREATE TYPE connector_type AS ENUM('piv', 'cots', 'gtfs-rt')")  # add 'piv' here
-    # first drop foreign key constraint to avoid deadlocks with Kirin's work on the side
-    # (lock here is required for the same reason)
-    op.execute(
-        "LOCK TABLE real_time_update; ALTER TABLE real_time_update DROP CONSTRAINT fk_real_time_update_contributor_id"
-    )
     # switch both tables to the new enum
     op.execute(
         "ALTER TABLE real_time_update ALTER COLUMN connector TYPE connector_type USING connector::text::connector_type"
     )
+
+    # isolate ALTER contributor in a separate transaction and add a lock on real_time_update that is implied through
+    # a foreign_key constraint (avoid deadlock with insert that may happen at the same time)
+    op.execute("COMMIT")  # end previous transaction (automatically started by alembic)
+    op.execute("BEGIN")  # start new transaction
+    op.execute("LOCK TABLE real_time_update")
     op.execute(
         "ALTER TABLE contributor ALTER COLUMN connector_type \
             TYPE connector_type USING connector_type::text::connector_type"
     )
-    # put the foreign_key constraint back
-    op.create_foreign_key(
-        "fk_real_time_update_contributor_id", "real_time_update", "contributor", ["contributor_id"], ["id"]
-    )
+    op.execute("COMMIT")  # end previous transaction
+    op.execute("BEGIN")  # start new transaction (automatically ended by alembic)
+
     op.execute("DROP TYPE connector_type_tmp")
 
 
@@ -59,21 +59,21 @@ def downgrade():
     # delete type 'piv'
     op.execute("ALTER TYPE connector_type RENAME TO connector_type_tmp")
     op.execute("CREATE TYPE connector_type AS ENUM('cots', 'gtfs-rt')")  # no more 'piv'
-    # first drop foreign key constraint to avoid deadlocks with Kirin's work on the side
-    # (lock here is required for the same reason)
-    op.execute(
-        "LOCK TABLE real_time_update; ALTER TABLE real_time_update DROP CONSTRAINT fk_real_time_update_contributor_id"
-    )
     # switch both tables to the "old" enum
     op.execute(
         "ALTER TABLE real_time_update ALTER COLUMN connector TYPE connector_type USING connector::text::connector_type"
     )
+
+    # isolate "ALTER contributor" in a separate transaction and add a lock on real_time_update that is implicated
+    # because of a foreign_key constraint (avoid deadlock with insert that may happen at the same time)
+    op.execute("COMMIT")  # end previous transaction (automatically started by alembic)
+    op.execute("BEGIN")  # start new transaction
+    op.execute("LOCK TABLE real_time_update")
     op.execute(
         "ALTER TABLE contributor ALTER COLUMN connector_type \
             TYPE connector_type USING connector_type::text::connector_type"
     )
-    # put the foreign_key constraint back
-    op.create_foreign_key(
-        "fk_real_time_update_contributor_id", "real_time_update", "contributor", ["contributor_id"], ["id"]
-    )
+    op.execute("COMMIT")  # end previous transaction
+    op.execute("BEGIN")  # start new transaction (automatically ended by alembic)
+
     op.execute("DROP TYPE connector_type_tmp")


### PR DESCRIPTION
:mag: review by commit with comment may be better.

## On the last migration

Drop foreign_key constraint before migration to avoid deadlock (put FK back after)

Could not use:
* ALTER TYPE name ADD VALUE new_enum_value
  (Migrations are transactions.
   And we wouldn't solve downgrade but we may
   just have let 'piv' live there)
* hacky modifications on system tables equivalent of ADD VALUE enum
  (rights are preventing it and it would be super-dirty)
* column add, then switch, then drop
  (deadlocks too)
* lock on ALTER COLUMN operations without FK drop
  (deadlocks too)

:heavy_check_mark: tested locally (kirin being spammed during migration)
Don't see any easy way to add tests, and it will be tested a bit more on **dev** platform (which has the same amount of data than prod ~800K real_time_update)

Notes from experiment:
* Migration is ~3s locally for 20K real_time_updates
* During lock kirin just waits: tested locking during 70s and just ended-up with a slow response. So during migration kirin should work as intended on the side too (just slower).

## On other migrations

During local tests detected similar problems, so corrected as it was easy (see each commit).
