### PR TITLE
[feature] Add PIVWorker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,5 @@
 web: KIRIN_USE_GEVENT=true FLASK_DEBUG=1 FLASK_APP=kirin:app flask run -p 54746 --without-threads
 load_realtime: KIRIN_USE_GEVENT=true ./manage.py load_realtime
 worker: celery worker -A kirin.tasks.celery -c 3
+piv_worker: ./manage.py piv_worker
 scheduler: celery beat -A kirin.tasks.celery

--- a/kirin/__init__.py
+++ b/kirin/__init__.py
@@ -91,6 +91,7 @@ redis_client = Redis(
 
 # activate a command
 import kirin.command.load_realtime
+import kirin.command.piv_worker
 
 from kirin.core import model
 

--- a/kirin/command/piv_worker.py
+++ b/kirin/command/piv_worker.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# [matrix] channel #navitia:matrix.org (https://app.element.io/#/room/#navitia:matrix.org)
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+from kirin import manager, app
+from kirin.core.model import Contributor, db
+from kirin.core.types import ConnectorType
+from kirin.core.abstract_builder import wrap_build
+from kirin.piv import KirinModelBuilder
+from kirin.piv.piv import get_piv_contributors, get_piv_contributor
+
+from kombu.mixins import ConsumerMixin
+from kombu import Connection, Exchange, Queue
+from datetime import datetime, timedelta
+from copy import deepcopy
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+CONF_RELOAD_TIMEOUT = timedelta(
+    seconds=float(str(app.config.get("BROKER_CONSUMER_CONFIGURATION_RELOAD_TIMEOUT")))
+)
+
+
+class PivWorker(ConsumerMixin):
+    def __init__(self, contributor):
+        if not contributor.broker_url:
+            raise ValueError("Missing 'broker_url' configuration for contributor '{0}'".format(contributor.id))
+        if not contributor.exchange_name:
+            raise ValueError(
+                "Missing 'exchange_name' configuration for contributor '{0}'".format(contributor.id)
+            )
+        if not contributor.queue_name:
+            raise ValueError("Missing 'queue_name' configuration for contributor '{0}'".format(contributor.id))
+        self.last_config_checked_time = datetime.now()
+        self.broker_url = deepcopy(contributor.broker_url)
+        self.builder = KirinModelBuilder(contributor)
+
+    def __enter__(self):
+        self.connection = Connection(self.builder.contributor.broker_url)
+        self.exchange = self._get_exchange(self.builder.contributor.exchange_name)
+        self.queue = self._get_queue(self.exchange, self.builder.contributor.queue_name)
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.connection.release()
+
+    def _get_exchange(self, exchange_name):
+        return Exchange(exchange_name, "fanout", durable=True, no_declare=True)
+
+    def _get_queue(self, exchange, queue_name):
+        return Queue(queue_name, exchange, durable=True, auto_delete=False)
+
+    def get_consumers(self, Consumer, channel):
+        return [
+            Consumer(
+                queues=[self.queue],
+                accept=["application/json"],
+                prefetch_count=1,
+                callbacks=[self.process_message],
+            )
+        ]
+
+    def process_message(self, body, message):
+        wrap_build(self.builder, body)
+        # TODO: We might want to not acknowledge the message in case of error in
+        # the processing.
+        message.ack()
+
+    def on_iteration(self):
+        if datetime.now() - self.last_config_checked_time < CONF_RELOAD_TIMEOUT:
+            return
+        else:
+            # SQLAlchemy is not querying the DB for read (uses cache instead),
+            # unless we specifically tell that the data is expired.
+            db.session.expire(self.builder.contributor, ["broker_url", "exchange_name", "queue_name"])
+            self.last_config_checked_time = datetime.now()
+        contributor = get_piv_contributor(self.builder.contributor.id)
+        if not contributor:
+            logger.info(
+                "contributor '{0}' doesn't exist anymore, let the worker die".format(self.builder.contributor.id)
+            )
+            self.should_stop = True
+            return
+        if contributor.broker_url != self.broker_url:
+            logger.info("broker URL for contributor '{0}' changed, let the worker die".format(contributor.id))
+            self.should_stop = True
+            return
+        if contributor.exchange_name != self.exchange.name:
+            logger.info(
+                "exchange name for contributor '{0}' changed, worker updated".format(contributor.exchange_name)
+            )
+            self.exchange = self._get_exchange(contributor.exchange_name)
+            self.queue = self._get_queue(self.exchange, contributor.queue_name)
+        if contributor.queue_name != self.queue.name:
+            logger.info(
+                "queue name for contributor '{0}' changed, worker updated".format(contributor.queue_name)
+            )
+            self.queue = self._get_queue(self.exchange, contributor.queue_name)
+        self.builder = KirinModelBuilder(contributor)
+
+
+@manager.command
+def piv_worker():
+    import sys
+
+    # We assume one and only one PIV contributor is going to exist in the DB
+    while True:
+        contributors = get_piv_contributors()
+        if len(contributors) == 0:
+            logger.warning("no PIV contributor")
+            time.sleep(CONF_RELOAD_TIMEOUT.total_seconds())
+            continue
+        contributor = contributors[0]
+        if len(contributors) > 1:
+            logger.warning(
+                "more than one PIV contributors: {0}; choosing '{1}'".format(
+                    map(lambda c: c.id, contributors), contributor.id
+                )
+            )
+        try:
+            with PivWorker(contributor) as worker:
+                logger.info("launching the PIV worker for '{0}'".format(contributor.id))
+                worker.run()
+        except Exception as e:
+            logger.warning("worker died unexpectedly: {0}".format(e))
+            time.sleep(CONF_RELOAD_TIMEOUT.total_seconds())

--- a/kirin/command/piv_worker.py
+++ b/kirin/command/piv_worker.py
@@ -52,6 +52,14 @@ CONF_RELOAD_TIMEOUT = timedelta(
 
 class PivWorker(ConsumerMixin):
     def __init__(self, contributor):
+        if contributor.connector_type != ConnectorType.piv.value:
+            raise ValueError(
+                "Contributor '{0}': PivWorker requires type {1}".format(contributor.id, ConnectorType.piv.value)
+            )
+        if not contributor.is_active:
+            raise ValueError(
+                "Contributor '{0}': PivWorker requires an activated contributor.".format(contributor.id)
+            )
         if not contributor.broker_url:
             raise ValueError("Missing 'broker_url' configuration for contributor '{0}'".format(contributor.id))
         if not contributor.exchange_name:

--- a/kirin/core/handler.py
+++ b/kirin/core/handler.py
@@ -648,15 +648,15 @@ def merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete):
     return None
 
 
-def publish(feed, contributor):
+def publish(feed, contributor_id):
     """
     send RT feed to navitia
     """
     try:
-        kirin.rmq_handler.publish(feed, contributor)
+        kirin.rmq_handler.publish(feed, contributor_id)
 
     except socket.error:
         logging.getLogger(__name__).exception(
-            "impossible to publish in rabbitmq", extra={"contributor": contributor}
+            "impossible to publish in rabbitmq", extra={"contributor": contributor_id}
         )
         raise MessageNotPublished()

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -535,6 +535,9 @@ class Contributor(db.Model):  # type: ignore
     connector_type = db.Column(Db_ConnectorType, nullable=False)
     retrieval_interval = db.Column(db.Integer, nullable=True, default=10)
     is_active = db.Column(db.Boolean, nullable=False, default=True)
+    broker_url = db.Column(db.Text, nullable=True)
+    exchange_name = db.Column(db.Text, nullable=True)
+    queue_name = db.Column(db.Text, nullable=True)
 
     def __init__(
         self,
@@ -545,6 +548,9 @@ class Contributor(db.Model):  # type: ignore
         feed_url=None,
         retrieval_interval=10,
         is_active=True,
+        broker_url=None,
+        exchange_name=None,
+        queue_name=None,
     ):
         self.id = id
         self.navitia_coverage = navitia_coverage
@@ -553,6 +559,9 @@ class Contributor(db.Model):  # type: ignore
         self.feed_url = feed_url
         self.retrieval_interval = retrieval_interval
         self.is_active = is_active
+        self.broker_url = broker_url
+        self.exchange_name = exchange_name
+        self.queue_name = queue_name
 
     @classmethod
     def find_by_connector_type(cls, type, include_deactivated=False):

--- a/kirin/default_settings.py
+++ b/kirin/default_settings.py
@@ -54,6 +54,12 @@ COTS_PAR_IV_REQUEST_TIMEOUT = int(
 )
 
 
+# PIV configuration
+BROKER_CONSUMER_CONFIGURATION_RELOAD_TIMEOUT = int(
+    os.getenv("KIRIN_BROKER_CONSUMER_CONFIGURATION_RELOAD_TIMEOUT", timedelta(minutes=1).total_seconds())
+)
+
+
 # TODO : Remove when conf from db is ready
 NAVITIA_GTFS_RT_INSTANCE = os.getenv("KIRIN_NAVITIA_GTFS_RT_INSTANCE", None)
 NAVITIA_GTFS_RT_TOKEN = os.getenv("KIRIN_NAVITIA_GTFS_RT_TOKEN", None)

--- a/kirin/piv/piv.py
+++ b/kirin/piv/piv.py
@@ -55,6 +55,16 @@ def get_piv_contributors(include_deactivated=False):
     return piv_contributors
 
 
+def get_piv_contributor(contributor_id):
+    """
+    :param contributor_id: Identifier of the contributor
+    :return: The PIV contributor from DB corresponding to the input ID
+    """
+    # FIXME: Raise an exception if no contributor is found?
+    contributor = model.Contributor.query.get(contributor_id)
+    return contributor
+
+
 def _get_piv(req):
     if not req.data:
         raise InvalidArguments("no piv data provided")

--- a/kirin/piv/piv.py
+++ b/kirin/piv/piv.py
@@ -61,8 +61,8 @@ def get_piv_contributor(contributor_id):
     :return: The PIV contributor from DB corresponding to the input ID
     """
     # FIXME: Raise an exception if no contributor is found?
-    contributor = model.Contributor.query.get(contributor_id)
-    return contributor
+    contributors = [c for c in get_piv_contributors() if c.id == contributor_id]
+    return contributors[0] if contributors else None
 
 
 def _get_piv(req):

--- a/kirin/rabbitmq_handler.py
+++ b/kirin/rabbitmq_handler.py
@@ -136,15 +136,15 @@ class RabbitMQHandler(object):
     def __init__(self, connection_string, exchange):
         self._connection = BrokerConnection(connection_string)
         self._connections = {self._connection}  # set of connection for the heartbeat
-        self._exchange = Exchange(exchange, durable=True, delivry_mode=2, type="topic")
+        self._exchange = Exchange(exchange, durable=True, delivery_mode=2, type="topic")
         monitor_heartbeats(self._connections)
 
     @retry(wait_fixed=200, stop_max_attempt_number=3)
-    def publish(self, item, contributor):
+    def publish(self, item, contributor_id):
         with self._connection.channel() as channel:
             with Producer(channel) as producer:
                 producer.publish(
-                    item, exchange=self._exchange, routing_key=contributor, declare=[self._exchange]
+                    item, exchange=self._exchange, routing_key=contributor_id, declare=[self._exchange]
                 )
 
     def info(self):

--- a/kirin/resources/contributors.py
+++ b/kirin/resources/contributors.py
@@ -106,22 +106,11 @@ class Contributors(Resource):
         broker_url = data.get("broker_url", None)
         exchange_name = data.get("exchange_name", None)
         queue_name = data.get("queue_name", None)
-        if broker_url:
-            if not exchange_name or not queue_name:
-                abort(
-                    400,
-                    message="When 'broker_url' is given, 'exchange_name' and 'queue_name' must be provided as well but were respectively '{0}' and '{1}'.".format(
-                        exchange_name, queue_name
-                    ),
-                )
-        else:
-            if exchange_name or queue_name:
-                abort(
-                    400,
-                    message="No 'broker_url' provided, expecting 'exchange_name' and 'queue_name' to be empty as well but were '{0}' and '{1}'.".format(
-                        exchange_name, queue_name
-                    ),
-                )
+        if any([broker_url, exchange_name, queue_name]) and not all([broker_url, exchange_name, queue_name]):
+            abort(
+                400,
+                message="'broker_url', 'exchange_name' and 'queue_name' must all be provided or none of them.",
+            )
 
         try:
             new_contrib = model.Contributor(

--- a/migrations/README
+++ b/migrations/README
@@ -1,3 +1,23 @@
 Generic single-database configuration.
 
-See the main readme of the project for the use of alembic migration files.
+The database schema is maintained using [alembic] and migration files you can
+find in `kirin/migrations/versions`. They each contain an `upgrade()` and a
+`downgrade()` function.
+
+To create a new migration file, you can use the following command from
+`kirin/migrations` folder.
+
+```sh
+PYTHONPATH="../:$PYTHONPATH" alembic revision -m "useful commit description"
+```
+
+This will create a new file in `kirin/migrations/versions` that you can edit to
+express the logic of the migration.
+
+To set up or upgrade your DB to the latest version, you can use.
+
+```sh
+honcho run ./manage.py db upgrade
+```
+
+[alembic]: https://pypi.org/project/alembic/

--- a/migrations/versions/75b9437c7af4_broker_configuration_for_contributor.py
+++ b/migrations/versions/75b9437c7af4_broker_configuration_for_contributor.py
@@ -1,0 +1,27 @@
+"""broker configuration for contributor
+
+Revision ID: 75b9437c7af4
+Revises: 85a968ce3ce5
+Create Date: 2020-09-30 09:11:27.861554
+
+"""
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+# revision identifiers, used by Alembic.
+revision = "75b9437c7af4"
+down_revision = "85a968ce3ce5"
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column("contributor", sa.Column("broker_url", sa.Text(), nullable=True))
+    op.add_column("contributor", sa.Column("exchange_name", sa.Text(), nullable=True))
+    op.add_column("contributor", sa.Column("queue_name", sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("contributor", "broker_url")
+    op.drop_column("contributor", "exchange_name")
+    op.drop_column("contributor", "queue_name")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,6 @@ def rabbitmq_docker_fixture():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def init_rabbitmq_db(rabbitmq_docker_fixture):
+def init_rabbitmq(rabbitmq_docker_fixture):
     # Switch global RabbitMQ-client's connection to use the RabbitMQ server from docker (instead of the conf)
     kirin.rmq_handler = rabbitmq_docker_fixture.get_rabbitmq_handler()

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -331,7 +331,7 @@ def test_put_contributor_with_malformed_data(test_client, with_custom_contributo
     assert resp.status_code == 400
 
 
-def test_post_get_put_to_ensure_API_consitency(test_client):
+def test_post_get_put_to_ensure_API_consistency(test_client):
     new_contrib = {
         "id": "realtime.tokyo",
         "navitia_coverage": "jp",
@@ -343,6 +343,9 @@ def test_post_get_put_to_ensure_API_consitency(test_client):
     }
     post_resp = test_client.post("/contributors", json=new_contrib)
     post_contrib = json.loads(post_resp.data)
+    new_contrib["broker_url"] = None
+    new_contrib["exchange_name"] = None
+    new_contrib["queue_name"] = None
     assert post_contrib["contributor"] == new_contrib
 
     get_resp = test_client.get("/contributors/realtime.tokyo")


### PR DESCRIPTION
Add a new type of worker that will listen to a RabbitMQ queue (associated with an Exchange).

- [x] Add configuration properties in DB (`broker_url`, `exchange_name`, `queue_name`)
- [x] Get the contributor from DB instead of hardcoding
- [x] Hot reload the MQ Consumer when configuration changes
- [x] Fix tests (see b2044660a40f6a387f39df92e35d3ff9a77d2073)
- [x] Parameterize the frequency at which configuration in DB is checked for change (see d32029cd2998d6969548b6c77da0a609c9e0a97a)
- [ ] Add tests

ref: ND-1007