### PR TITLE
[ci] Put a fixed version for black

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,7 +18,7 @@ jobs:
             - name: Upgrade pip
               run: python -m pip install --upgrade pip
             - name: Install Python Dependencies
-              run: pip install --upgrade --requirement requirements_dev.txt --requirement requirements_pre-commit.txt
+              run: pip install --upgrade --requirement requirements_dev.txt
             - name: Install Protobuf Dependencies
               run: sudo apt install --yes protobuf-compiler
             - name: Build Protobuf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     - id: black
       language_version: python3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
         - git submodule update --init --recursive
         - pip install -r requirements_dev.txt
         - python setup.py build_pbf
-        - pip install -r requirements_pre-commit.txt
         - pre-commit install
       script:
         - pre-commit run --all --show-diff-on-failure

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,5 +7,6 @@ pytest-cov==2.9.0
 docker==3.5.0
 mock==2.0.0
 pbr==4.2.0
+pre-commit==1.18.3
 requests-mock==1.5.2
 newrelic

--- a/requirements_pre-commit.txt
+++ b/requirements_pre-commit.txt
@@ -1,5 +1,0 @@
-black==18.9b0; python_version >= '3.6'
-mypy==0.670; python_version >= '3.5'
-mypy-extensions==0.4.1; python_version >= '3.5'
-flake8==3.5.0
-pre-commit==1.18.3


### PR DESCRIPTION
- Stabilize the Black version so there is no different version between local development and the CI.
- Removing the `requirements_pre-commit.txt` which is documented nowhere and is not useful since `pre-commit` will install whatever is needed automatically