### PR TITLE
[doc] Remove years from Copyright

### DIFF
--- a/kirin/__init__.py
+++ b/kirin/__init__.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/api.py
+++ b/kirin/api.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/command/__init__.py
+++ b/kirin/command/__init__.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/command/load_realtime.py
+++ b/kirin/command/load_realtime.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/command/piv_worker.py
+++ b/kirin/command/piv_worker.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/command/purge_rt.py
+++ b/kirin/command/purge_rt.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/core/__init__.py
+++ b/kirin/core/__init__.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/core/abstract_builder.py
+++ b/kirin/core/abstract_builder.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2020, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/core/handler.py
+++ b/kirin/core/handler.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/core/populate_pb.py
+++ b/kirin/core/populate_pb.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/core/types.py
+++ b/kirin/core/types.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/cots/__init__.py
+++ b/kirin/cots/__init__.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/cots/cots.py
+++ b/kirin/cots/cots.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/cots/message_handler.py
+++ b/kirin/cots/message_handler.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/cots/model_maker.py
+++ b/kirin/cots/model_maker.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/exceptions.py
+++ b/kirin/exceptions.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/gtfs_rt/__init__.py
+++ b/kirin/gtfs_rt/__init__.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2017, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/gtfs_rt/gtfs_rt.py
+++ b/kirin/gtfs_rt/gtfs_rt.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2017, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/gtfs_rt/model_maker.py
+++ b/kirin/gtfs_rt/model_maker.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2017, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/gtfs_rt/tasks.py
+++ b/kirin/gtfs_rt/tasks.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/helper.py
+++ b/kirin/helper.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/new_relic.py
+++ b/kirin/new_relic.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/piv/__init__.py
+++ b/kirin/piv/__init__.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2020, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/piv/model_maker.py
+++ b/kirin/piv/model_maker.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2020, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/piv/piv.py
+++ b/kirin/piv/piv.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2020, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/rabbitmq_handler.py
+++ b/kirin/rabbitmq_handler.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/resources/__init__.py
+++ b/kirin/resources/__init__.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/resources/contributors.py
+++ b/kirin/resources/contributors.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/resources/index.py
+++ b/kirin/resources/index.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/resources/status.py
+++ b/kirin/resources/status.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/tasks.py
+++ b/kirin/tasks.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/kirin/utils.py
+++ b/kirin/utils.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/manage.py
+++ b/manage.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding=utf-8
 
-#  Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/check_utils.py
+++ b/tests/check_utils.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/cots_rt_test.py
+++ b/tests/cots_rt_test.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/docker_wrapper.py
+++ b/tests/docker_wrapper.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/integration/cots_model_maker_test.py
+++ b/tests/integration/cots_model_maker_test.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/integration/cots_test.py
+++ b/tests/integration/cots_test.py
@@ -1,6 +1,6 @@
 # coding: utf8
 #
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/integration/gtfs_rt_test.py
+++ b/tests/integration/gtfs_rt_test.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2017, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/integration/handle_test.py
+++ b/tests/integration/handle_test.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/integration/model_test.py
+++ b/tests/integration/model_test.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/integration/piv_test.py
+++ b/tests/integration/piv_test.py
@@ -1,6 +1,6 @@
 # coding: utf8
 #
-# Copyright (c) 2001-2020, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/integration/populate_pb_test.py
+++ b/tests/integration/populate_pb_test.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/integration/test_end_point.py
+++ b/tests/integration/test_end_point.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/integration/utils_cots_test.py
+++ b/tests/integration/utils_cots_test.py
@@ -1,6 +1,6 @@
 # coding: utf8
 
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/integration/utils_sncf_test.py
+++ b/tests/integration/utils_sncf_test.py
@@ -1,6 +1,6 @@
 # coding: utf8
 
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/integration/utils_test.py
+++ b/tests/integration/utils_test.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/__init__.py
+++ b/tests/mock_navitia/__init__.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/company_1187.py
+++ b/tests/mock_navitia/company_1187.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/company_OCETH.py
+++ b/tests/mock_navitia/company_OCETH.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/empty_company_1180.py
+++ b/tests/mock_navitia/empty_company_1180.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/navitia_response.py
+++ b/tests/mock_navitia/navitia_response.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/physical_mode_Coach.py
+++ b/tests/mock_navitia/physical_mode_Coach.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/physical_mode_LongDistanceTrain.py
+++ b/tests/mock_navitia/physical_mode_LongDistanceTrain.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/st_0087_191981_WL.py
+++ b/tests/mock_navitia/st_0087_191981_WL.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/st_0087_215632_00.py
+++ b/tests/mock_navitia/st_0087_215632_00.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/st_0087_318964_BV.py
+++ b/tests/mock_navitia/st_0087_318964_BV.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/st_0087_319012_00.py
+++ b/tests/mock_navitia/st_0087_319012_00.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/st_0087_543009_BV.py
+++ b/tests/mock_navitia/st_0087_543009_BV.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/st_0087_683573_BV.py
+++ b/tests/mock_navitia/st_0087_683573_BV.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/st_0087_686667_BV.py
+++ b/tests/mock_navitia/st_0087_686667_BV.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/st_0087_751008_BV.py
+++ b/tests/mock_navitia/st_0087_751008_BV.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/st_713065.py
+++ b/tests/mock_navitia/st_713065.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/st_713666.py
+++ b/tests/mock_navitia/st_713666.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_6111.py
+++ b/tests/mock_navitia/vj_6111.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_6112.py
+++ b/tests/mock_navitia/vj_6112.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_6113.py
+++ b/tests/mock_navitia/vj_6113.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_6114.py
+++ b/tests/mock_navitia/vj_6114.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_840426.py
+++ b/tests/mock_navitia/vj_840426.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_870154.py
+++ b/tests/mock_navitia/vj_870154.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_8837.py
+++ b/tests/mock_navitia/vj_8837.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_9580.py
+++ b/tests/mock_navitia/vj_9580.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_96231.py
+++ b/tests/mock_navitia/vj_96231.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_R_vj1.py
+++ b/tests/mock_navitia/vj_R_vj1.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_R_vj2.py
+++ b/tests/mock_navitia/vj_R_vj2.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_bad_order.py
+++ b/tests/mock_navitia/vj_bad_order.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_john.py
+++ b/tests/mock_navitia/vj_john.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_lollipop.py
+++ b/tests/mock_navitia/vj_lollipop.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_pass_midnight.py
+++ b/tests/mock_navitia/vj_pass_midnight.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_pass_midnight_utc.py
+++ b/tests/mock_navitia/vj_pass_midnight_utc.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_start_midnight.py
+++ b/tests/mock_navitia/vj_start_midnight.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_start_midnight_utc.py
+++ b/tests/mock_navitia/vj_start_midnight_utc.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/tests/mock_navitia/vj_unknown_object.py
+++ b/tests/mock_navitia/vj_unknown_object.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.


### PR DESCRIPTION
The years are useless and are hard to maintain as years move forward.

This PR is a consequence of #323 (see https://github.com/CanalTP/kirin/pull/323#discussion_r498380210).

The commit has been realized with the following command.
```sh
sed -i 's/(Copyright \(c\) 20[0-9]{2})-20[0-9]+/\1/' ./**/*.py
```