### PR TITLE
[test] Add tests for PivWorker

### DIFF
--- a/kirin/piv/piv.py
+++ b/kirin/piv/piv.py
@@ -56,7 +56,6 @@ def get_piv_contributor(contributor_id):
     :param contributor_id: Identifier of the contributor
     :return: The PIV contributor from DB corresponding to the input ID
     """
-    # FIXME: Raise an exception if no contributor is found?
     contributors = [c for c in get_piv_contributors() if c.id == contributor_id]
     return contributors[0] if contributors else None
 

--- a/kirin/rabbitmq_handler.py
+++ b/kirin/rabbitmq_handler.py
@@ -133,10 +133,12 @@ class RTReloader(ConsumerProducerMixin):
 
 
 class RabbitMQHandler(object):
-    def __init__(self, connection_string, exchange):
+    def __init__(self, connection_string, exchange_name, exchange_type="topic"):
         self._connection = BrokerConnection(connection_string)
         self._connections = {self._connection}  # set of connection for the heartbeat
-        self._exchange = Exchange(exchange, durable=True, delivery_mode=2, type="topic")
+        self._exchange = Exchange(
+            exchange_name, durable=True, delivery_mode=2, type=exchange_type, auto_delete=False, no_declare=False
+        )
         monitor_heartbeats(self._connections)
 
     @retry(wait_fixed=200, stop_max_attempt_number=3)

--- a/kirin/test_settings.py
+++ b/kirin/test_settings.py
@@ -9,3 +9,5 @@ COTS_PAR_IV_MOTIF_RESOURCE_SERVER = "https://messages.service/resource"
 COTS_PAR_IV_TOKEN_SERVER = "https://messages.service/token"
 COTS_PAR_IV_CLIENT_ID = "tchoutchou_id"
 COTS_PAR_IV_CLIENT_SECRET = "tchoutchou_secret"
+
+BROKER_CONSUMER_CONFIGURATION_RELOAD_INTERVAL = 1  # in seconds

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,4 +85,4 @@ def rabbitmq_docker_fixture():
 @pytest.fixture(scope="session", autouse=True)
 def init_rabbitmq(rabbitmq_docker_fixture):
     # Switch global RabbitMQ-client's connection to use the RabbitMQ server from docker (instead of the conf)
-    kirin.rmq_handler = rabbitmq_docker_fixture.get_rabbitmq_handler()
+    kirin.rmq_handler = rabbitmq_docker_fixture.create_rabbitmq_handler("navitia", "topic")

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -51,13 +51,6 @@ from kirin.core.types import ConnectorType
 from tests.integration.gtfs_rt_test import basic_gtfs_rt_data, navitia
 
 
-@pytest.yield_fixture
-def test_client():
-    app.testing = True
-    with app.app_context(), app.test_client() as tester:
-        yield tester
-
-
 def test_get_contributor_end_point(test_client):
     assert test_client.get("/contributors").status_code == 200
 

--- a/tests/integration/cots_model_maker_test.py
+++ b/tests/integration/cots_model_maker_test.py
@@ -143,11 +143,8 @@ def test_cots_train_trip_removal(mock_navitia_fixture):
 
 def test_get_action_on_trip_add(mock_navitia_fixture):
     """
-    Test the function _get_action_on_trip with different type of flux cots
-    returns:
-    1. Fist trip add(AJOUTEE)->  FIRST_TIME_ADDED
-    2. Add followed by update (PERTURBEE) -> PREVIOUSLY_ADDED
-    3. Delete followed by add -> FIRST_TIME_ADDED
+    Test the function _get_action_on_trip:
+    - Fist trip add(AJOUTEE)-> FIRST_TIME_ADDED
     """
 
     with app.app_context():
@@ -161,7 +158,11 @@ def test_get_action_on_trip_add(mock_navitia_fixture):
         action_on_trip = model_maker._get_action_on_trip(train_numbers, dict_version, pdps)
         assert action_on_trip == ActionOnTrip.FIRST_TIME_ADDED.name
 
+
+def test_get_action_on_trip_previously_added(mock_navitia_fixture):
+    with app.app_context():
         # Test for add followed by update should be PREVIOUSLY_ADDED
+        input_trip_add = get_fixture_data("cots_train_151515_added_trip.json")
         contributor = model.Contributor(
             id=COTS_CONTRIBUTOR_ID, navitia_coverage=None, connector_type=ConnectorType.cots.value
         )
@@ -177,10 +178,15 @@ def test_get_action_on_trip_add(mock_navitia_fixture):
         action_on_trip = model_maker._get_action_on_trip(train_numbers, dict_version, pdps)
         assert action_on_trip == ActionOnTrip.PREVIOUSLY_ADDED.name
 
-        # Clean database for further test
-        clean_db()
 
+def test_get_action_on_trip_delete(mock_navitia_fixture):
+    with app.app_context():
         # Delete the recently added trip followed by add: should be FIRST_TIME_ADDED
+        contributor = model.Contributor(
+            id=COTS_CONTRIBUTOR_ID, navitia_coverage=None, connector_type=ConnectorType.cots.value
+        )
+        builder = KirinModelBuilder(contributor)
+        input_trip_add = get_fixture_data("cots_train_151515_added_trip.json")
         wrap_build(builder, input_trip_add)
         input_trip_delete = get_fixture_data(
             "cots_train_151515_deleted_trip_with_delay_and_stop_time_added.json"

--- a/tests/integration/piv_worker_test.py
+++ b/tests/integration/piv_worker_test.py
@@ -1,0 +1,149 @@
+# coding: utf8
+#
+# Copyright (c) 2020, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# [matrix] channel #navitia:matrix.org (https://app.element.io/#/room/#navitia:matrix.org)
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+from kirin import app, db
+from kirin.command.piv_worker import PivWorker
+from kirin.core.model import RealTimeUpdate
+from kirin.core.types import ConnectorType
+from kirin.piv.piv import get_piv_contributor
+from tests.integration.conftest import PIV_CONTRIBUTOR_ID, PIV_EXCHANGE_NAME, PIV_QUEUE_NAME
+
+from amqp.exceptions import NotFound
+from kombu import Connection, Exchange, Queue
+import pytest
+import threading
+from retrying import retry
+
+
+@retry(stop_max_delay=20000, wait_exponential_multiplier=100)
+def wait_until(predicate):
+    assert predicate()
+
+
+def is_exchange_created(connection, exchange_name, exchange_type="fanout"):
+    try:
+        channel = connection.channel()
+        channel.exchange_declare(exchange_name, exchange_type, nowait=False, passive=True)
+    except NotFound as e:
+        return False
+    except Exception as e:
+        raise e
+    return True
+
+
+def is_queue_created(connection, queue_name):
+    try:
+        channel = connection.channel()
+        channel.queue_declare(queue=queue_name, nowait=False, passive=True)
+    except NotFound as e:
+        return False
+    except Exception as e:
+        raise e
+    return True
+
+
+@pytest.fixture(scope="session", autouse=True)
+def broker_connection(rabbitmq_docker_fixture):
+    return Connection(rabbitmq_docker_fixture.url)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mq_handler(rabbitmq_docker_fixture, broker_connection):
+    return rabbitmq_docker_fixture.create_rabbitmq_handler(PIV_EXCHANGE_NAME, "fanout")
+
+
+def create_exchange(broker_connection, exchange_name):
+    exchange = Exchange(
+        exchange_name,
+        durable=True,
+        delivery_mode=2,
+        type="fanout",
+        auto_delete=False,
+        no_declare=False,
+    )
+    exchange.declare(channel=broker_connection.channel())
+
+
+# Use scope 'function' so the Exchange is recreated for every test.
+# It is useful because some tests are deleting the Exchange.
+@pytest.fixture(scope="function", autouse=True)
+def init_piv_exchange(broker_connection):
+    create_exchange(broker_connection, PIV_EXCHANGE_NAME)
+    assert is_exchange_created(broker_connection, PIV_EXCHANGE_NAME)
+
+
+def launch_piv_worker(pg_docker_fixture):
+    import kirin
+    from kirin import app, db, manager
+    from tests.conftest import init_flask_db
+    from tests.integration.conftest import PIV_CONTRIBUTOR_ID
+
+    with app.app_context():
+        # re-init the db by overriding the db_url
+        init_flask_db(pg_docker_fixture)
+        contributor = get_piv_contributor(PIV_CONTRIBUTOR_ID)
+        with PivWorker(contributor) as worker:
+            worker.run()
+
+
+class PivWorkerTest:
+    def __init__(self, test_client, broker_url, broker_connection, pg_docker_fixture):
+        self.test_client = test_client
+        self.broker_url = broker_url
+        self.broker_connection = broker_connection
+        self.pg_docker_fixture = pg_docker_fixture
+
+    def __enter__(self):
+        # Launch a PivWorker
+        self.thread = threading.Thread(target=launch_piv_worker, args=(self.pg_docker_fixture,))
+        self.thread.start()
+        wait_until(lambda: self.thread.is_alive())
+        # Check that PivWorker is ready (a good hint is when queue is created)
+        wait_until(lambda: is_queue_created(self.broker_connection, PIV_QUEUE_NAME))
+
+    def __exit__(self, type, value, traceback):
+        # Remove the contributor
+        self.test_client.delete("/contributors/{}".format(PIV_CONTRIBUTOR_ID))
+        # PivWorker should die eventually when no PIV contributors is available
+        wait_until(lambda: not self.thread.is_alive())
+
+
+def test_mq_message_received_and_stored(
+    test_client, pg_docker_fixture, rabbitmq_docker_fixture, broker_connection, mq_handler
+):
+    with PivWorkerTest(test_client, rabbitmq_docker_fixture.url, broker_connection, pg_docker_fixture):
+        # Check that PivWorker is creating the queue
+        wait_until(lambda: is_queue_created(broker_connection, PIV_QUEUE_NAME))
+
+        # Check that MQ message is received and stored in DB
+        mq_handler.publish(str('{"key": "Some valid JSON"}'), PIV_CONTRIBUTOR_ID)
+        wait_until(lambda: RealTimeUpdate.query.count() == 1)


### PR DESCRIPTION
A few things to notice:
- The tests are only testing `kirin.command.piv_worker.PivWorker` meaning that the function `kirin.command.piv_worker.piv_worker` is not tested (this function is an infinite loop that would need to be launch into a thread and then never dies... therefore the test would hang up forever)
- PivWorkerTest exists in order to always clean up the thread at the end of the test (much better since when the test fails, raising an `AssertionError`, the thread is still destroyed)
- Testing that the RabbitMQ container is up has been completely rewritten
- Now, the docker wrapper for RabbitMQ create MQ handler on-demand (before, it was creating one and only one at initialization)
- Since these tests involve multi-threading, some of the assertions can't be done synchronously, therefore, I use a `Retrying` object to try asserting until the other thread has done the expected work

I was not able to create a test for a change of `broker_url`, any help is welcome but in the worst case, there might not be any case for that.

ref: ND-1066