### PR TITLE
Accept text only to avoid deserializing to dict

### DIFF
--- a/kirin/command/piv_worker.py
+++ b/kirin/command/piv_worker.py
@@ -100,7 +100,7 @@ class PivWorker(ConsumerMixin):
         return [
             Consumer(
                 queues=[self.queue],
-                accept=["application/json"],
+                accept=["plain/text"],
                 prefetch_count=1,
                 callbacks=[self.process_message],
             )


### PR DESCRIPTION
Otherwise we try to put a dict into db.