### PR TITLE
[tech] Refactor merge of TripUpdates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,3 +216,6 @@ To generate a new release:
    ```sh
    git push canaltp release master --tags
    ```
+
+5. the pipe https://ci.navitia.io/view/kirin_release_deployment/ should be
+   triggered (and release the new docker among other things)

--- a/kirin/command/piv_worker.py
+++ b/kirin/command/piv_worker.py
@@ -29,6 +29,9 @@
 # [matrix] channel #navitia:matrix.org (https://app.element.io/#/room/#navitia:matrix.org)
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
+
+from __future__ import absolute_import, print_function, unicode_literals, division
+
 from kirin import manager, app, new_relic
 from kirin.core.model import db
 from kirin.core.types import ConnectorType
@@ -48,7 +51,7 @@ from kirin.utils import log_exception
 logger = logging.getLogger(__name__)
 
 CONF_RELOAD_INTERVAL = timedelta(
-    seconds=float(str(app.config.get("BROKER_CONSUMER_CONFIGURATION_RELOAD_INTERVAL")))
+    seconds=float(str(app.config.get(str("BROKER_CONSUMER_CONFIGURATION_RELOAD_INTERVAL"))))
 )
 
 

--- a/kirin/command/piv_worker.py
+++ b/kirin/command/piv_worker.py
@@ -100,7 +100,7 @@ class PivWorker(ConsumerMixin):
         return [
             Consumer(
                 queues=[self.queue],
-                accept=["plain/text"],
+                accept=["plain/text"],  # avoid deserializing to json dict
                 prefetch_count=1,
                 callbacks=[self.process_message],
             )

--- a/kirin/command/piv_worker.py
+++ b/kirin/command/piv_worker.py
@@ -35,7 +35,7 @@ from __future__ import absolute_import, print_function, unicode_literals, divisi
 from kirin import manager, app, new_relic
 from kirin.core.model import db
 from kirin.core.types import ConnectorType
-from kirin.core.abstract_builder import wrap_build
+from kirin.core.build_wrapper import wrap_build
 from kirin.piv import KirinModelBuilder
 from kirin.piv.piv import get_piv_contributors, get_piv_contributor
 

--- a/kirin/core/__init__.py
+++ b/kirin/core/__init__.py
@@ -30,4 +30,3 @@
 # www.navitia.io
 
 from __future__ import absolute_import, print_function, unicode_literals, division
-from kirin.core.handler import handle

--- a/kirin/core/abstract_builder.py
+++ b/kirin/core/abstract_builder.py
@@ -25,7 +25,7 @@
 #
 # Stay tuned using
 # twitter @navitia
-# IRC #navitia on freenode
+# [matrix] channel #navitia:matrix.org (https://app.element.io/#/room/#navitia:matrix.org)
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 

--- a/kirin/core/abstract_builder.py
+++ b/kirin/core/abstract_builder.py
@@ -31,79 +31,16 @@
 
 from __future__ import absolute_import, print_function, unicode_literals, division
 
-import logging
 from abc import ABCMeta
-from datetime import datetime
 from typing import Tuple, List, Dict, Any
 
 import navitia_wrapper
 import six
 from flask import current_app
 
-from kirin import core, redis_client
-from kirin.core import model
+from kirin import redis_client
+from kirin.core.merge_utils import merge
 from kirin.core.model import Contributor, RealTimeUpdate, TripUpdate
-from kirin.exceptions import KirinException
-from kirin.new_relic import is_invalid_input_exception, record_custom_parameter
-from kirin.utils import set_rtu_status_ko, allow_reprocess_same_data, record_call
-
-
-def wrap_build(builder, input_raw):
-    """
-    Function wrapping the processing of realtime information of an external feed
-    This manages errors/logger/newrelic
-    :param builder: the KirinModelBuilder to be called
-    :param input_raw: the feed to process
-    """
-    contributor = builder.contributor
-    start_datetime = datetime.utcnow()
-    rt_update = None
-    log_dict = {"contributor": contributor.id}
-    status = "OK"
-
-    try:
-        # create a raw rt_update obj, save the raw_input into the db
-        rt_update, rtu_log_dict = builder.build_rt_update(input_raw)
-        log_dict.update(rtu_log_dict)
-
-        # raw_input is interpreted
-        trip_updates, tu_log_dict = builder.build_trip_updates(rt_update)
-        log_dict.update(tu_log_dict)
-
-        # finally confront to previously existing information (base_schedule, previous real-time)
-        _, handler_log_dict = core.handle(rt_update, trip_updates, contributor.id, builder.is_new_complete)
-        log_dict.update(handler_log_dict)
-
-    except Exception as e:
-        status = "failure"
-        allow_reprocess = True
-        if is_invalid_input_exception(e):
-            status = "warning"  # Kirin did his job correctly if the input is invalid and rejected
-            allow_reprocess = False  # reprocess is useless if input is invalid
-
-        if rt_update is not None:
-            error = e.data["error"] if (isinstance(e, KirinException) and "error" in e.data) else e.message
-            set_rtu_status_ko(rt_update, error, is_reprocess_same_data_allowed=allow_reprocess)
-            model.db.session.add(rt_update)
-            model.db.session.commit()
-        else:
-            # rt_update is not built, make sure reprocess is allowed
-            allow_reprocess_same_data(contributor.id)
-
-        log_dict.update({"exc_summary": six.text_type(e), "reason": e})
-
-        record_custom_parameter("reason", e)  # using __str__() here to have complete details
-        raise  # filters later for APM (auto.)
-
-    finally:
-        log_dict.update({"duration": (datetime.utcnow() - start_datetime).total_seconds()})
-        record_call(status, **log_dict)
-        if status == "OK":
-            logging.getLogger(__name__).info(status, extra=log_dict)
-        elif status == "warning":
-            logging.getLogger(__name__).warning(status, extra=log_dict)
-        else:
-            logging.getLogger(__name__).error(status, extra=log_dict)
 
 
 class AbstractKirinModelBuilder(six.with_metaclass(ABCMeta, object)):
@@ -146,3 +83,15 @@ class AbstractKirinModelBuilder(six.with_metaclass(ABCMeta, object)):
         :return log_dict: dict of (k,v) to be displayed in logs and newrelic
         """
         raise NotImplementedError("Please implement this method")
+
+    def merge_trip_updates(self, navitia_vj, db_trip_update, new_trip_update):
+        # type: (Dict[unicode, Any], TripUpdate, TripUpdate) -> TripUpdate
+        """
+        Merges information from:
+        * navitia_vj (base-schedule VJ - complete, maybe nonexistent)
+        * db_trip_update (last known realtime VJ - complete, maybe nonexistent)
+        * new_trip_update (VJ information extracted from incoming feed - maybe incomplete)
+        Returns resulting TripUpdate:
+        usually update of the last known realtime VJ, or completed version of new_trip_update
+        """
+        return merge(navitia_vj, db_trip_update, new_trip_update, self.is_new_complete)

--- a/kirin/core/abstract_builder.py
+++ b/kirin/core/abstract_builder.py
@@ -39,7 +39,6 @@ import six
 from flask import current_app
 
 from kirin import redis_client
-from kirin.core.merge_utils import merge
 from kirin.core.model import Contributor, RealTimeUpdate, TripUpdate
 
 
@@ -53,8 +52,8 @@ class AbstractKirinModelBuilder(six.with_metaclass(ABCMeta, object)):
     This allows the KirinModelBuilder to be wrapped by wrap_build() function
     """
 
-    def __init__(self, contributor, is_new_complete):
-        # type: (Contributor, bool) -> None
+    def __init__(self, contributor):
+        # type: (Contributor) -> None
         self.navitia = navitia_wrapper.Navitia(
             url=current_app.config.get(str("NAVITIA_URL")),
             token=contributor.navitia_token,
@@ -64,7 +63,6 @@ class AbstractKirinModelBuilder(six.with_metaclass(ABCMeta, object)):
             pubdate_timeout=current_app.config.get(str("NAVITIA_PUBDATE_CACHE_TIMEOUT"), 600),
         ).instance(contributor.navitia_coverage)
         self.contributor = contributor
-        self.is_new_complete = is_new_complete
 
     def build_rt_update(self, input_raw):
         # type: (Any) -> Tuple[RealTimeUpdate, Dict[unicode, unicode]]
@@ -94,4 +92,4 @@ class AbstractKirinModelBuilder(six.with_metaclass(ABCMeta, object)):
         Returns resulting TripUpdate:
         usually update of the last known realtime VJ, or completed version of new_trip_update
         """
-        return merge(navitia_vj, db_trip_update, new_trip_update, self.is_new_complete)
+        raise NotImplementedError("Please implement this method")

--- a/kirin/core/build_wrapper.py
+++ b/kirin/core/build_wrapper.py
@@ -1,0 +1,280 @@
+# coding=utf-8
+
+# Copyright (c) 2001, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# [matrix] channel #navitia:matrix.org (https://app.element.io/#/room/#navitia:matrix.org)
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from __future__ import absolute_import, print_function, unicode_literals, division
+import datetime
+import logging
+import socket
+from collections import namedtuple
+
+import six
+
+import kirin
+from kirin import gtfs_realtime_pb2
+from kirin.core.model import TripUpdate
+from kirin.core.populate_pb import convert_to_gtfsrt
+from kirin.exceptions import MessageNotPublished, KirinException
+from kirin.new_relic import is_invalid_input_exception, record_custom_parameter
+from kirin.utils import set_rtu_status_ko, allow_reprocess_same_data, record_call, persist
+
+TimeDelayTuple = namedtuple("TimeDelayTuple", ["time", "delay"])
+
+
+def log_stu_modif(trip_update, stu, string_additional_info):
+    logger = logging.getLogger(__name__)
+    logger.debug(
+        "TripUpdate on navitia vj {nav_id} on {date}, "
+        "StopTimeUpdate {order} modified: {add_info}".format(
+            nav_id=trip_update.vj.navitia_trip_id,
+            date=trip_update.vj.get_circulation_date(),
+            order=stu.order,
+            add_info=string_additional_info,
+        )
+    )
+
+
+def manage_consistency(trip_update):
+    """
+    receive a TripUpdate, then manage and adjust its consistency
+    returns False if trip update cannot be managed
+    """
+    logger = logging.getLogger(__name__)
+    previous_stop_event = TimeDelayTuple(time=None, delay=None)
+    for current_order, stu in enumerate(trip_update.stop_time_updates):
+        # rejections
+        if stu.order != current_order:
+            logger.warning(
+                "TripUpdate on navitia vj {nav_id} on {date} rejected: "
+                "order problem [STU index ({stu_index}) != kirin index ({kirin_index})]".format(
+                    nav_id=trip_update.vj.navitia_trip_id,
+                    date=trip_update.vj.get_circulation_date(),
+                    stu_index=stu.order,
+                    kirin_index=current_order,
+                )
+            )
+            return False
+
+        # modifications
+        if stu.arrival is None:
+            stu.arrival = stu.departure
+            if stu.arrival is None and previous_stop_event.time is not None:
+                stu.arrival = previous_stop_event.time
+            if stu.arrival is None:
+                logger.warning(
+                    "TripUpdate on navitia vj {nav_id} on {date} rejected: "
+                    "StopTimeUpdate missing arrival time".format(
+                        nav_id=trip_update.vj.navitia_trip_id, date=trip_update.vj.get_circulation_date()
+                    )
+                )
+                return False
+            log_stu_modif(trip_update, stu, "arrival = {v}".format(v=stu.arrival))
+            if not stu.arrival_delay and stu.departure_delay:
+                stu.arrival_delay = stu.departure_delay
+                log_stu_modif(trip_update, stu, "arrival_delay = {v}".format(v=stu.arrival_delay))
+
+        if stu.departure is None:
+            stu.departure = stu.arrival
+            log_stu_modif(trip_update, stu, "departure = {v}".format(v=stu.departure))
+            if not stu.departure_delay and stu.arrival_delay:
+                stu.departure_delay = stu.arrival_delay
+                log_stu_modif(trip_update, stu, "departure_delay = {v}".format(v=stu.departure_delay))
+
+        if stu.arrival_delay is None:
+            stu.arrival_delay = datetime.timedelta(0)
+            log_stu_modif(trip_update, stu, "arrival_delay = {v}".format(v=stu.arrival_delay))
+
+        if stu.departure_delay is None:
+            stu.departure_delay = datetime.timedelta(0)
+            log_stu_modif(trip_update, stu, "departure_delay = {v}".format(v=stu.departure_delay))
+
+        # not considering deleted arrival
+        if not stu.is_stop_event_deleted("arrival"):
+            # if arrival is before previous stop-event's time:
+            # push arrival time so that its delay is the same than for previous time
+            if previous_stop_event.time is not None and previous_stop_event.time > stu.arrival:
+                delay_diff = previous_stop_event.delay - stu.arrival_delay
+                stu.arrival_delay += delay_diff
+                stu.arrival += delay_diff
+                log_stu_modif(
+                    trip_update,
+                    stu,
+                    "arrival = {t} and arrival_delay = {d}".format(t=stu.arrival, d=stu.arrival_delay),
+                )
+
+            # store arrival as previous stop-event
+            previous_stop_event = TimeDelayTuple(time=stu.arrival, delay=stu.arrival_delay)
+
+        # not considering deleted departure (same logic as before)
+        if not stu.is_stop_event_deleted("departure"):
+            # if departure is before previous stop-event's time:
+            # push departure time so that its delay is the same than for previous time
+            if previous_stop_event.time is not None and previous_stop_event.time > stu.departure:
+                delay_diff = previous_stop_event.delay - stu.departure_delay
+                stu.departure_delay += delay_diff
+                stu.departure += delay_diff
+                log_stu_modif(
+                    trip_update,
+                    stu,
+                    "departure = {t} and departure_delay = {d}".format(t=stu.departure, d=stu.departure_delay),
+                )
+            # store departure as previous stop-event
+            previous_stop_event = TimeDelayTuple(time=stu.departure, delay=stu.departure_delay)
+
+    return True
+
+
+def publish(feed, contributor_id):
+    """
+    send RT feed to navitia
+    """
+    try:
+        kirin.rmq_handler.publish(feed, contributor_id)
+
+    except socket.error:
+        logging.getLogger(__name__).exception(
+            "impossible to publish in rabbitmq", extra={"contributor": contributor_id}
+        )
+        raise MessageNotPublished()
+
+
+def handle(builder, real_time_update, trip_updates):
+    """
+    Receive a RealTimeUpdate with at least one TripUpdate filled with the data received
+    by the connector.
+    Each TripUpdate is associated with the base-schedule VehicleJourney, complete/merge realtime is done using builder
+    Then persist in db, publish for Navitia
+    Returns real_time_update and the log_dict
+    """
+    if not real_time_update:
+        raise TypeError()
+    id_timestamp_tuples = [(tu.vj.navitia_trip_id, tu.vj.start_timestamp) for tu in trip_updates]
+    old_trip_updates = TripUpdate.find_by_dated_vjs(id_timestamp_tuples)
+    for trip_update in trip_updates:
+        # find if there is already a row in db
+        old = next(
+            (
+                tu
+                for tu in old_trip_updates
+                if tu.vj.navitia_trip_id == trip_update.vj.navitia_trip_id
+                and tu.vj.start_timestamp == trip_update.vj.start_timestamp
+            ),
+            None,
+        )
+        # merge the base schedule, the current realtime, and the new realtime
+        current_trip_update = builder.merge_trip_updates(trip_update.vj.navitia_vj, old, trip_update)
+
+        # manage and adjust consistency if possible
+        if current_trip_update and manage_consistency(current_trip_update):
+            # we have to link the current_vj_update with the new real_time_update
+            # this link is done quite late to avoid too soon persistence of trip_update by sqlalchemy
+            current_trip_update.real_time_updates.append(real_time_update)
+
+    persist(real_time_update)
+
+    feed = convert_to_gtfsrt(real_time_update.trip_updates, gtfs_realtime_pb2.FeedHeader.DIFFERENTIAL)
+    feed_str = feed.SerializeToString()
+    publish(feed_str, builder.contributor.id)
+
+    data_time = datetime.datetime.utcfromtimestamp(feed.header.timestamp)
+    log_dict = {
+        "contributor": builder.contributor.id,
+        "timestamp": data_time,
+        "trip_update_count": len(feed.entity),
+        "size": len(feed_str),
+    }
+    # After merging trip_updates information of connector realtime, navitia and kirin database, if there is no new
+    # information destined to navitia, update real_time_update with status = 'KO' and a proper error message.
+    if not real_time_update.trip_updates and real_time_update.status == "OK":
+        msg = "No new information destined to navitia for this {}".format(real_time_update.connector)
+        set_rtu_status_ko(real_time_update, msg, is_reprocess_same_data_allowed=False)
+        logging.getLogger(__name__).warning(
+            "RealTimeUpdate id={}: {}".format(real_time_update.id, msg), extra=log_dict
+        )
+        persist(real_time_update)
+
+    return real_time_update, log_dict
+
+
+def wrap_build(builder, input_raw):
+    """
+    Function wrapping the processing of realtime information of an external feed
+    This manages errors/logger/newrelic
+    :param builder: the KirinModelBuilder to be called (must inherit from abstract_builder.AbstractKirinModelBuilder)
+    :param input_raw: the feed to process
+    """
+    contributor = builder.contributor
+    start_datetime = datetime.datetime.utcnow()
+    rt_update = None
+    log_dict = {"contributor": contributor.id}
+    status = "OK"
+
+    try:
+        # create a raw rt_update obj, save the raw_input into the db
+        rt_update, rtu_log_dict = builder.build_rt_update(input_raw)
+        log_dict.update(rtu_log_dict)
+
+        # raw_input is interpreted
+        trip_updates, tu_log_dict = builder.build_trip_updates(rt_update)
+        log_dict.update(tu_log_dict)
+
+        # finally confront to previously existing information (base_schedule, previous real-time)
+        _, handler_log_dict = handle(builder, rt_update, trip_updates)
+        log_dict.update(handler_log_dict)
+
+    except Exception as e:
+        status = "failure"
+        allow_reprocess = True
+        if is_invalid_input_exception(e):
+            status = "warning"  # Kirin did his job correctly if the input is invalid and rejected
+            allow_reprocess = False  # reprocess is useless if input is invalid
+
+        if rt_update is not None:
+            error = e.data["error"] if (isinstance(e, KirinException) and "error" in e.data) else e.message
+            set_rtu_status_ko(rt_update, error, is_reprocess_same_data_allowed=allow_reprocess)
+            persist(rt_update)
+        else:
+            # rt_update is not built, make sure reprocess is allowed
+            allow_reprocess_same_data(contributor.id)
+
+        log_dict.update({"exc_summary": six.text_type(e), "reason": e})
+
+        record_custom_parameter("reason", e)  # using __str__() here to have complete details
+        raise  # filters later for APM (auto.)
+
+    finally:
+        log_dict.update({"duration": (datetime.datetime.utcnow() - start_datetime).total_seconds()})
+        record_call(status, **log_dict)
+        if status == "OK":
+            logging.getLogger(__name__).info(status, extra=log_dict)
+        elif status == "warning":
+            logging.getLogger(__name__).warning(status, extra=log_dict)
+        else:
+            logging.getLogger(__name__).error(status, extra=log_dict)

--- a/kirin/core/handler.py
+++ b/kirin/core/handler.py
@@ -426,7 +426,7 @@ def merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete):
 
     The mechanism is quite simple:
         * the result trip status is the new_trip_update's status
-            (ie in the db the trip was cancelled, and a new update is only an update, the trip update is
+            (ie if in the db the trip was cancelled, and a new update is only an update, the trip update is
             not cancelled anymore, only updated)
 
         * for each navitia's stop_time and for departure|arrival:
@@ -607,7 +607,7 @@ def merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete):
         elif db_trip_update is not None and new_st is None:
             """
             Third case: we have already recorded a delay but nothing is mentioned in the new trip update
-            Then      : For IRE, we do nothing but only update stop time's order
+            Then      : For cots, we do nothing but only update stop time's order
                         For gtfs-rt, according to the specification, we should use the delay from the previous
                         stop time, which will be handled sooner by the connector-specified model maker
 

--- a/kirin/core/merge_utils.py
+++ b/kirin/core/merge_utils.py
@@ -30,132 +30,13 @@
 # www.navitia.io
 
 from __future__ import absolute_import, print_function, unicode_literals, division
-import datetime
+
 import logging
-import socket
-from collections import namedtuple
+import datetime
 
-import kirin
-from kirin import gtfs_realtime_pb2
-from kirin.core import model
-from kirin.core.model import TripUpdate, StopTimeUpdate
-from kirin.core.populate_pb import convert_to_gtfsrt
-from kirin.exceptions import MessageNotPublished
+from kirin.core.build_wrapper import TimeDelayTuple
+from kirin.core.model import StopTimeUpdate
 from kirin.core.types import ModificationType
-from kirin.utils import set_rtu_status_ko
-
-TimeDelayTuple = namedtuple("TimeDelayTuple", ["time", "delay"])
-
-
-def persist(real_time_update):
-    """
-    receive a RealTimeUpdate and persist it in the database
-    """
-    model.db.session.add(real_time_update)
-    model.db.session.commit()
-
-
-def log_stu_modif(trip_update, stu, string_additional_info):
-    logger = logging.getLogger(__name__)
-    logger.debug(
-        "TripUpdate on navitia vj {nav_id} on {date}, "
-        "StopTimeUpdate {order} modified: {add_info}".format(
-            nav_id=trip_update.vj.navitia_trip_id,
-            date=trip_update.vj.get_circulation_date(),
-            order=stu.order,
-            add_info=string_additional_info,
-        )
-    )
-
-
-def manage_consistency(trip_update):
-    """
-    receive a TripUpdate, then manage and adjust its consistency
-    returns False if trip update cannot be managed
-    """
-    logger = logging.getLogger(__name__)
-    previous_stop_event = TimeDelayTuple(time=None, delay=None)
-    for current_order, stu in enumerate(trip_update.stop_time_updates):
-        # rejections
-        if stu.order != current_order:
-            logger.warning(
-                "TripUpdate on navitia vj {nav_id} on {date} rejected: "
-                "order problem [STU index ({stu_index}) != kirin index ({kirin_index})]".format(
-                    nav_id=trip_update.vj.navitia_trip_id,
-                    date=trip_update.vj.get_circulation_date(),
-                    stu_index=stu.order,
-                    kirin_index=current_order,
-                )
-            )
-            return False
-
-        # modifications
-        if stu.arrival is None:
-            stu.arrival = stu.departure
-            if stu.arrival is None and previous_stop_event.time is not None:
-                stu.arrival = previous_stop_event.time
-            if stu.arrival is None:
-                logger.warning(
-                    "TripUpdate on navitia vj {nav_id} on {date} rejected: "
-                    "StopTimeUpdate missing arrival time".format(
-                        nav_id=trip_update.vj.navitia_trip_id, date=trip_update.vj.get_circulation_date()
-                    )
-                )
-                return False
-            log_stu_modif(trip_update, stu, "arrival = {v}".format(v=stu.arrival))
-            if not stu.arrival_delay and stu.departure_delay:
-                stu.arrival_delay = stu.departure_delay
-                log_stu_modif(trip_update, stu, "arrival_delay = {v}".format(v=stu.arrival_delay))
-
-        if stu.departure is None:
-            stu.departure = stu.arrival
-            log_stu_modif(trip_update, stu, "departure = {v}".format(v=stu.departure))
-            if not stu.departure_delay and stu.arrival_delay:
-                stu.departure_delay = stu.arrival_delay
-                log_stu_modif(trip_update, stu, "departure_delay = {v}".format(v=stu.departure_delay))
-
-        if stu.arrival_delay is None:
-            stu.arrival_delay = datetime.timedelta(0)
-            log_stu_modif(trip_update, stu, "arrival_delay = {v}".format(v=stu.arrival_delay))
-
-        if stu.departure_delay is None:
-            stu.departure_delay = datetime.timedelta(0)
-            log_stu_modif(trip_update, stu, "departure_delay = {v}".format(v=stu.departure_delay))
-
-        # not considering deleted arrival
-        if not stu.is_stop_event_deleted("arrival"):
-            # if arrival is before previous stop-event's time:
-            # push arrival time so that its delay is the same than for previous time
-            if previous_stop_event.time is not None and previous_stop_event.time > stu.arrival:
-                delay_diff = previous_stop_event.delay - stu.arrival_delay
-                stu.arrival_delay += delay_diff
-                stu.arrival += delay_diff
-                log_stu_modif(
-                    trip_update,
-                    stu,
-                    "arrival = {t} and arrival_delay = {d}".format(t=stu.arrival, d=stu.arrival_delay),
-                )
-
-            # store arrival as previous stop-event
-            previous_stop_event = TimeDelayTuple(time=stu.arrival, delay=stu.arrival_delay)
-
-        # not considering deleted departure (same logic as before)
-        if not stu.is_stop_event_deleted("departure"):
-            # if departure is before previous stop-event's time:
-            # push departure time so that its delay is the same than for previous time
-            if previous_stop_event.time is not None and previous_stop_event.time > stu.departure:
-                delay_diff = previous_stop_event.delay - stu.departure_delay
-                stu.departure_delay += delay_diff
-                stu.departure += delay_diff
-                log_stu_modif(
-                    trip_update,
-                    stu,
-                    "departure = {t} and departure_delay = {d}".format(t=stu.departure, d=stu.departure_delay),
-                )
-            # store departure as previous stop-event
-            previous_stop_event = TimeDelayTuple(time=stu.departure, delay=stu.departure_delay)
-
-    return True
 
 
 def find_st_in_vj(st_id, vj_sts):
@@ -166,140 +47,6 @@ def find_st_in_vj(st_id, vj_sts):
     :return: stop_time if found else None
     """
     return next((vj_st for vj_st in vj_sts if vj_st.get("stop_point", {}).get("id") == st_id), None)
-
-
-def handle(real_time_update, trip_updates, contributor_id, is_new_complete):
-    """
-    receive a RealTimeUpdate with at least one TripUpdate filled with the data received
-    by the connector. each TripUpdate is associated with the VehicleJourney returned by jormungandr
-    Returns real_time_update and the log_dict
-    """
-    if not real_time_update:
-        raise TypeError()
-    id_timestamp_tuples = [(tu.vj.navitia_trip_id, tu.vj.start_timestamp) for tu in trip_updates]
-    old_trip_updates = TripUpdate.find_by_dated_vjs(id_timestamp_tuples)
-    for trip_update in trip_updates:
-        # find if there is already a row in db
-        old = next(
-            (
-                tu
-                for tu in old_trip_updates
-                if tu.vj.navitia_trip_id == trip_update.vj.navitia_trip_id
-                and tu.vj.start_timestamp == trip_update.vj.start_timestamp
-            ),
-            None,
-        )
-        # merge the base schedule, the current realtime, and the new realtime
-        current_trip_update = merge(trip_update.vj.navitia_vj, old, trip_update, is_new_complete=is_new_complete)
-
-        # manage and adjust consistency if possible
-        if current_trip_update and manage_consistency(current_trip_update):
-            # we have to link the current_vj_update with the new real_time_update
-            # this link is done quite late to avoid too soon persistence of trip_update by sqlalchemy
-            current_trip_update.real_time_updates.append(real_time_update)
-
-    persist(real_time_update)
-
-    feed = convert_to_gtfsrt(real_time_update.trip_updates, gtfs_realtime_pb2.FeedHeader.DIFFERENTIAL)
-    feed_str = feed.SerializeToString()
-    publish(feed_str, contributor_id)
-
-    data_time = datetime.datetime.utcfromtimestamp(feed.header.timestamp)
-    log_dict = {
-        "contributor": contributor_id,
-        "timestamp": data_time,
-        "trip_update_count": len(feed.entity),
-        "size": len(feed_str),
-    }
-    # After merging trip_updates information of connector realtime, navitia and kirin database, if there is no new
-    # information destined to navitia, update real_time_update with status = 'KO' and a proper error message.
-    if not real_time_update.trip_updates and real_time_update.status == "OK":
-        msg = "No new information destined to navitia for this {}".format(real_time_update.connector)
-        set_rtu_status_ko(real_time_update, msg, is_reprocess_same_data_allowed=False)
-        logging.getLogger(__name__).warning(
-            "RealTimeUpdate id={}: {}".format(real_time_update.id, msg), extra=log_dict
-        )
-        model.db.session.add(real_time_update)
-        model.db.session.commit()
-
-    return real_time_update, log_dict
-
-
-def _get_datetime(circulation_date, time):
-    # in the db, dt with timezone cannot coexist with dt without timezone
-    # since at the beginning there was dt without tz, we keep naive dt
-    return datetime.datetime.combine(circulation_date, time)
-
-
-def _get_update_info_of_stop_event(base_time, input_time, input_status, input_delay):
-    """
-    Process information for a given stop event: given information available, compute info to be stored in db.
-    :param base_time: datetime in base_schedule
-    :param input_time: datetime in new feed
-    :param input_status: status in new feed
-    :param input_delay: delay in new feed
-    :return: new_time (base-schedule datetime in most case),
-             status (update, delete, ...)
-             delay (new_time + delay = RT datetime)
-    """
-    new_time = None
-    status = ModificationType.none.name
-    delay = datetime.timedelta(0)
-    if input_status == ModificationType.update.name:
-        new_time = base_time if base_time else None
-        if new_time is not None and input_delay:
-            new_time += input_delay
-        status = input_status
-        delay = input_delay
-    elif input_status in (ModificationType.delete.name, ModificationType.deleted_for_detour.name):
-        # passing status 'delete' on the stop_time
-        # Note: we keep providing base_schedule stop_time to better identify the stop_time
-        # in the vj (for lollipop lines for example)
-        status = input_status
-    elif input_status in (ModificationType.add.name, ModificationType.added_for_detour.name):
-        status = input_status
-        new_time = input_time.replace(tzinfo=None) if input_time else None
-        if new_time is not None and input_delay:
-            new_time += input_delay
-    else:
-        new_time = base_time
-    return new_time, status, delay
-
-
-def _make_stop_time_update(base_arrival, base_departure, last_departure, input_st, stop_point, order):
-    dep, dep_status, dep_delay = _get_update_info_of_stop_event(
-        base_departure, input_st.departure, input_st.departure_status, input_st.departure_delay
-    )
-    arr, arr_status, arr_delay = _get_update_info_of_stop_event(
-        base_arrival, input_st.arrival, input_st.arrival_status, input_st.arrival_delay
-    )
-
-    # in case where arrival/departure time are None
-    if arr is None:
-        arr = dep if dep is not None else last_departure
-    dep = dep if dep is not None else arr
-
-    # in case where the previous departure time are greater than the current arrival
-    if last_departure and last_departure > arr:
-        arr_delay += last_departure - arr
-        arr = last_departure
-
-    # in the real world, the departure time must be greater or equal to the arrival time
-    if arr > dep:
-        dep_delay += arr - dep
-        dep = arr
-
-    return StopTimeUpdate(
-        navitia_stop=stop_point,
-        departure=dep,
-        departure_delay=dep_delay,
-        dep_status=dep_status,
-        arrival=arr,
-        arrival_delay=arr_delay,
-        arr_status=arr_status,
-        message=input_st.message,
-        order=order,
-    )
 
 
 def is_stop_event_served(event_name, stop_id, stop_order, nav_stop, db_tu, new_stu):
@@ -412,6 +159,83 @@ def make_fake_realtime_stop_time(order, sp_id, new_stu, db_trip_update):
         "utc_departure_time": departure.time(),
         "utc_arrival_time": arrival.time(),
     }
+
+
+def _get_datetime(circulation_date, time):
+    # in the db, dt with timezone cannot coexist with dt without timezone
+    # since at the beginning there was dt without tz, we keep naive dt
+    return datetime.datetime.combine(circulation_date, time)
+
+
+def _get_update_info_of_stop_event(base_time, input_time, input_status, input_delay):
+    """
+    Process information for a given stop event: given information available, compute info to be stored in db.
+    :param base_time: datetime in base_schedule
+    :param input_time: datetime in new feed
+    :param input_status: status in new feed
+    :param input_delay: delay in new feed
+    :return: new_time (base-schedule datetime in most case),
+             status (update, delete, ...)
+             delay (new_time + delay = RT datetime)
+    """
+    new_time = None
+    status = ModificationType.none.name
+    delay = datetime.timedelta(0)
+    if input_status == ModificationType.update.name:
+        new_time = base_time if base_time else None
+        if new_time is not None and input_delay:
+            new_time += input_delay
+        status = input_status
+        delay = input_delay
+    elif input_status in (ModificationType.delete.name, ModificationType.deleted_for_detour.name):
+        # passing status 'delete' on the stop_time
+        # Note: we keep providing base_schedule stop_time to better identify the stop_time
+        # in the vj (for lollipop lines for example)
+        status = input_status
+    elif input_status in (ModificationType.add.name, ModificationType.added_for_detour.name):
+        status = input_status
+        new_time = input_time.replace(tzinfo=None) if input_time else None
+        if new_time is not None and input_delay:
+            new_time += input_delay
+    else:
+        new_time = base_time
+    return new_time, status, delay
+
+
+def _make_stop_time_update(base_arrival, base_departure, last_departure, input_st, stop_point, order):
+    dep, dep_status, dep_delay = _get_update_info_of_stop_event(
+        base_departure, input_st.departure, input_st.departure_status, input_st.departure_delay
+    )
+    arr, arr_status, arr_delay = _get_update_info_of_stop_event(
+        base_arrival, input_st.arrival, input_st.arrival_status, input_st.arrival_delay
+    )
+
+    # in case where arrival/departure time are None
+    if arr is None:
+        arr = dep if dep is not None else last_departure
+    dep = dep if dep is not None else arr
+
+    # in case where the previous departure time are greater than the current arrival
+    if last_departure and last_departure > arr:
+        arr_delay += last_departure - arr
+        arr = last_departure
+
+    # in the real world, the departure time must be greater or equal to the arrival time
+    if arr > dep:
+        dep_delay += arr - dep
+        dep = arr
+
+    return StopTimeUpdate(
+        navitia_stop=stop_point,
+        departure=dep,
+        departure_delay=dep_delay,
+        dep_status=dep_status,
+        arrival=arr,
+        arrival_delay=arr_delay,
+        arr_status=arr_status,
+        message=input_st.message,
+        order=order,
+    )
 
 
 def merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete):
@@ -646,17 +470,3 @@ def merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete):
         return res
 
     return None
-
-
-def publish(feed, contributor_id):
-    """
-    send RT feed to navitia
-    """
-    try:
-        kirin.rmq_handler.publish(feed, contributor_id)
-
-    except socket.error:
-        logging.getLogger(__name__).exception(
-            "impossible to publish in rabbitmq", extra={"contributor": contributor_id}
-        )
-        raise MessageNotPublished()

--- a/kirin/cots/cots.py
+++ b/kirin/cots/cots.py
@@ -36,7 +36,7 @@ import logging
 
 from flask_restful import Resource
 
-from kirin.core.abstract_builder import wrap_build
+from kirin.core.build_wrapper import wrap_build
 from kirin.cots import KirinModelBuilder
 from kirin.exceptions import InvalidArguments, SubServiceError
 from kirin.core import model

--- a/kirin/cots/model_maker.py
+++ b/kirin/cots/model_maker.py
@@ -44,6 +44,7 @@ import ujson
 
 from kirin.core import model
 from kirin.core.abstract_builder import AbstractKirinModelBuilder
+from kirin.core.merge_utils import merge
 from kirin.cots.message_handler import MessageHandler
 from kirin.exceptions import InvalidArguments, InternalException, ObjectNotFound
 from kirin.utils import (
@@ -319,7 +320,7 @@ def _get_action_on_trip(train_numbers, dict_version, pdps):
 
 class KirinModelBuilder(AbstractKirinModelBuilder):
     def __init__(self, contributor):
-        super(KirinModelBuilder, self).__init__(contributor, is_new_complete=True)
+        super(KirinModelBuilder, self).__init__(contributor)
         self.message_handler = MessageHandler(
             api_key=current_app.config[str("COTS_PAR_IV_API_KEY")],
             resource_server=current_app.config[str("COTS_PAR_IV_MOTIF_RESOURCE_SERVER")],
@@ -700,3 +701,6 @@ class KirinModelBuilder(AbstractKirinModelBuilder):
         if physical_modes:
             return physical_modes[0].get("id", None)
         return None
+
+    def merge_trip_updates(self, navitia_vj, db_trip_update, new_trip_update):
+        return merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete=True)

--- a/kirin/gtfs_rt/gtfs_rt.py
+++ b/kirin/gtfs_rt/gtfs_rt.py
@@ -35,7 +35,7 @@ from flask import url_for
 from flask.globals import current_app
 from flask_restful import Resource, abort
 
-from kirin.core.abstract_builder import wrap_build
+from kirin.core.build_wrapper import wrap_build
 from kirin.exceptions import InvalidArguments
 import navitia_wrapper
 from kirin.gtfs_rt import KirinModelBuilder

--- a/kirin/gtfs_rt/model_maker.py
+++ b/kirin/gtfs_rt/model_maker.py
@@ -39,6 +39,7 @@ from google.protobuf.message import DecodeError
 from kirin import gtfs_realtime_pb2
 from kirin.core import model
 from kirin.core.abstract_builder import AbstractKirinModelBuilder
+from kirin.core.merge_utils import merge
 from kirin.core.types import ModificationType, get_higher_status, get_effect_by_stop_time_status, ConnectorType
 from kirin.exceptions import InternalException, InvalidArguments
 from kirin.utils import make_rt_update, floor_datetime, to_navitia_utc_str, set_rtu_status_ko, manage_db_error
@@ -50,7 +51,7 @@ import calendar
 
 class KirinModelBuilder(AbstractKirinModelBuilder):
     def __init__(self, contributor):
-        super(KirinModelBuilder, self).__init__(contributor, is_new_complete=False)
+        super(KirinModelBuilder, self).__init__(contributor)
         self.log = logging.LoggerAdapter(logging.getLogger(__name__), extra={"contributor": self.contributor.id})
         self.period_filter_tolerance = datetime.timedelta(hours=3)  # TODO better period handling
         self.stop_code_key = "source"  # TODO conf
@@ -252,6 +253,9 @@ class KirinModelBuilder(AbstractKirinModelBuilder):
         self.log.debug("searching for vj {} on [{}, {}] in navitia".format(vj_source_code, since_dt, until_dt))
 
         return self._make_db_vj(vj_source_code, since_dt, until_dt)
+
+    def merge_trip_updates(self, navitia_vj, db_trip_update, new_trip_update):
+        return merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete=False)
 
 
 def _init_stop_update(nav_stop, stop_sequence):

--- a/kirin/gtfs_rt/tasks.py
+++ b/kirin/gtfs_rt/tasks.py
@@ -37,7 +37,7 @@ import requests
 import six
 
 from kirin.core import model
-from kirin.core.abstract_builder import wrap_build
+from kirin.core.build_wrapper import wrap_build
 from kirin.core.types import ConnectorType
 from kirin.cots.model_maker import as_duration
 

--- a/kirin/piv/model_maker.py
+++ b/kirin/piv/model_maker.py
@@ -25,7 +25,7 @@
 #
 # Stay tuned using
 # twitter @navitia
-# IRC #navitia on freenode
+# [matrix] channel #navitia:matrix.org (https://app.element.io/#/room/#navitia:matrix.org)
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 

--- a/kirin/piv/model_maker.py
+++ b/kirin/piv/model_maker.py
@@ -41,6 +41,7 @@ from operator import itemgetter
 
 from kirin.core import model
 from kirin.core.abstract_builder import AbstractKirinModelBuilder
+from kirin.core.merge_utils import merge
 from kirin.core.types import ModificationType, TripEffect, get_higher_status, get_effect_by_stop_time_status
 from kirin.exceptions import InvalidArguments, UnsupportedValue, ObjectNotFound
 from kirin.utils import make_rt_update, get_value, as_utc_naive_dt, record_internal_failure, as_duration
@@ -221,7 +222,7 @@ def _get_message(arret):
 
 class KirinModelBuilder(AbstractKirinModelBuilder):
     def __init__(self, contributor):
-        super(KirinModelBuilder, self).__init__(contributor, is_new_complete=True)
+        super(KirinModelBuilder, self).__init__(contributor)
 
     def build_rt_update(self, input_raw):
         rt_update = make_rt_update(
@@ -498,3 +499,6 @@ class KirinModelBuilder(AbstractKirinModelBuilder):
             return stop_points[0], {}
 
         return None, {"log": "No stop point found", "stop_point_code": uic8}
+
+    def merge_trip_updates(self, navitia_vj, db_trip_update, new_trip_update):
+        return merge(navitia_vj, db_trip_update, new_trip_update, is_new_complete=True)

--- a/kirin/piv/piv.py
+++ b/kirin/piv/piv.py
@@ -35,7 +35,7 @@ from flask import url_for
 from flask.globals import current_app
 from flask_restful import Resource, marshal, abort
 
-from kirin.core.abstract_builder import wrap_build
+from kirin.core.build_wrapper import wrap_build
 from kirin.exceptions import InvalidArguments
 from kirin.core import model
 from kirin.core.types import ConnectorType

--- a/kirin/resources/contributors.py
+++ b/kirin/resources/contributors.py
@@ -36,7 +36,7 @@ import sqlalchemy
 from flask_restful import Resource, marshal_with, fields, abort
 from kirin.core import model
 from kirin.core.types import ConnectorType
-from kirin.utils import persist
+from kirin.utils import db_commit
 
 contributor_fields = {
     "id": fields.String,
@@ -138,7 +138,7 @@ class Contributors(Resource):
                 nb_days_to_keep_trip_update,
                 nb_days_to_keep_rt_update,
             )
-            persist(new_contrib)
+            db_commit(new_contrib)
             return {"contributor": new_contrib}, 201
         except KeyError as e:
             err_msg = "Missing attribute '{}' in input data to construct a contributor".format(e)

--- a/kirin/resources/contributors.py
+++ b/kirin/resources/contributors.py
@@ -36,6 +36,7 @@ import sqlalchemy
 from flask_restful import Resource, marshal_with, fields, abort
 from kirin.core import model
 from kirin.core.types import ConnectorType
+from kirin.utils import persist
 
 contributor_fields = {
     "id": fields.String,
@@ -137,8 +138,7 @@ class Contributors(Resource):
                 nb_days_to_keep_trip_update,
                 nb_days_to_keep_rt_update,
             )
-            model.db.session.add(new_contrib)
-            model.db.session.commit()
+            persist(new_contrib)
             return {"contributor": new_contrib}, 201
         except KeyError as e:
             err_msg = "Missing attribute '{}' in input data to construct a contributor".format(e)

--- a/kirin/utils.py
+++ b/kirin/utils.py
@@ -139,7 +139,7 @@ def as_duration(seconds):
     return datetime.utcfromtimestamp(seconds) - datetime.utcfromtimestamp(0)
 
 
-def persist(orm_object):
+def db_commit(orm_object):
     """
     receive an ORM object (from model.py) and persist it in the database
     """
@@ -156,7 +156,7 @@ def make_rt_update(raw_data, connector_type, contributor_id, status="OK"):
     )
     new_relic.record_custom_parameter("real_time_update_id", rt_update.id)
 
-    persist(rt_update)
+    db_commit(rt_update)
     return rt_update
 
 
@@ -241,7 +241,7 @@ def save_rt_data_with_error(data, connector_type, contributor_id, error, is_repr
     raw_data = six.binary_type(data)
     rt_update = make_rt_update(raw_data, connector_type=connector_type, contributor_id=contributor_id)
     set_rtu_status_ko(rt_update, error, is_reprocess_same_data_allowed)
-    persist(rt_update)
+    db_commit(rt_update)
     return rt_update
 
 

--- a/kirin/utils.py
+++ b/kirin/utils.py
@@ -139,6 +139,14 @@ def as_duration(seconds):
     return datetime.utcfromtimestamp(seconds) - datetime.utcfromtimestamp(0)
 
 
+def persist(orm_object):
+    """
+    receive an ORM object (from model.py) and persist it in the database
+    """
+    model.db.session.add(orm_object)
+    model.db.session.commit()
+
+
 def make_rt_update(raw_data, connector_type, contributor_id, status="OK"):
     """
     Create an RealTimeUpdate object for the query and persist it
@@ -148,8 +156,7 @@ def make_rt_update(raw_data, connector_type, contributor_id, status="OK"):
     )
     new_relic.record_custom_parameter("real_time_update_id", rt_update.id)
 
-    model.db.session.add(rt_update)
-    model.db.session.commit()
+    persist(rt_update)
     return rt_update
 
 
@@ -234,8 +241,7 @@ def save_rt_data_with_error(data, connector_type, contributor_id, error, is_repr
     raw_data = six.binary_type(data)
     rt_update = make_rt_update(raw_data, connector_type=connector_type, contributor_id=contributor_id)
     set_rtu_status_ko(rt_update, error, is_reprocess_same_data_allowed)
-    model.db.session.add(rt_update)
-    model.db.session.commit()
+    persist(rt_update)
     return rt_update
 
 

--- a/migrations/versions/53647ffeb3c6_add_contributor.py
+++ b/migrations/versions/53647ffeb3c6_add_contributor.py
@@ -6,6 +6,8 @@ Create Date: 2019-08-13 12:36:25.829578
 
 """
 
+from __future__ import absolute_import, print_function, unicode_literals, division
+
 # revision identifiers, used by Alembic.
 revision = "53647ffeb3c6"
 down_revision = "4db0c66c3caf"

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -48,6 +48,7 @@ from kirin.core.model import (
 )
 from kirin.command.purge_rt import purge_contributor
 from kirin.core.types import ConnectorType
+from kirin.utils import persist
 from tests.integration.gtfs_rt_test import basic_gtfs_rt_data, navitia
 
 
@@ -269,7 +270,7 @@ def test_post_new_valid_contributor_with_unknown_parameter_should_work(test_clie
 
 
 def test_put_contributor_with_id(test_client):
-    db.session.add(
+    persist(
         model.Contributor(
             id="SaintMeuMeu",
             navitia_coverage="ca",
@@ -278,7 +279,6 @@ def test_put_contributor_with_id(test_client):
             feed_url="http://feed.url",
         )
     )
-    db.session.commit()
 
     resp = test_client.put(
         "/contributors/SaintMeuMeu",
@@ -302,7 +302,7 @@ def test_put_contributor_with_id(test_client):
 
 
 def test_put_partial_contributor(test_client):
-    db.session.add(
+    persist(
         model.Contributor(
             id="SaintMeuMeu",
             navitia_coverage="ca",
@@ -311,7 +311,6 @@ def test_put_partial_contributor(test_client):
             feed_url="http://feed.url",
         )
     )
-    db.session.commit()
 
     put_resp = test_client.put("/contributors/SaintMeuMeu", json={"navitia_coverage": "qb"})
     assert put_resp.status_code == 200
@@ -324,7 +323,7 @@ def test_put_partial_contributor(test_client):
 
 
 def test_put_contributor_with_no_data(test_client):
-    db.session.add(
+    persist(
         model.Contributor(
             id="SaintMeuMeu",
             navitia_coverage="ca",
@@ -333,7 +332,6 @@ def test_put_contributor_with_no_data(test_client):
             feed_url="http://feed.url",
         )
     )
-    db.session.commit()
 
     resp = test_client.put("/contributors/SaintMeuMeu")
     assert resp.status_code == 400

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -48,7 +48,7 @@ from kirin.core.model import (
 )
 from kirin.command.purge_rt import purge_contributor
 from kirin.core.types import ConnectorType
-from kirin.utils import persist
+from kirin.utils import db_commit
 from tests.integration.gtfs_rt_test import basic_gtfs_rt_data, navitia
 
 
@@ -270,7 +270,7 @@ def test_post_new_valid_contributor_with_unknown_parameter_should_work(test_clie
 
 
 def test_put_contributor_with_id(test_client):
-    persist(
+    db_commit(
         model.Contributor(
             id="SaintMeuMeu",
             navitia_coverage="ca",
@@ -302,7 +302,7 @@ def test_put_contributor_with_id(test_client):
 
 
 def test_put_partial_contributor(test_client):
-    persist(
+    db_commit(
         model.Contributor(
             id="SaintMeuMeu",
             navitia_coverage="ca",
@@ -323,7 +323,7 @@ def test_put_partial_contributor(test_client):
 
 
 def test_put_contributor_with_no_data(test_client):
-    persist(
+    db_commit(
         model.Contributor(
             id="SaintMeuMeu",
             navitia_coverage="ca",

--- a/tests/integration/cots_model_maker_test.py
+++ b/tests/integration/cots_model_maker_test.py
@@ -33,7 +33,7 @@ import pytest
 
 from kirin import app
 from kirin.core import model
-from kirin.core.abstract_builder import wrap_build
+from kirin.core.build_wrapper import wrap_build
 from kirin.core.model import TripUpdate
 from kirin.core.types import ConnectorType
 from kirin.cots import KirinModelBuilder, model_maker

--- a/tests/integration/cots_model_maker_test.py
+++ b/tests/integration/cots_model_maker_test.py
@@ -40,7 +40,7 @@ from kirin.cots import KirinModelBuilder, model_maker
 from kirin.cots.model_maker import ActionOnTrip
 from tests.check_utils import get_fixture_data
 from tests.integration.utils_cots_test import requests_mock_cause_message
-from tests.integration.conftest import clean_db, COTS_CONTRIBUTOR_ID
+from tests.integration.conftest import COTS_CONTRIBUTOR_ID
 import json
 
 

--- a/tests/integration/gtfs_rt_test.py
+++ b/tests/integration/gtfs_rt_test.py
@@ -36,7 +36,7 @@ import datetime
 import pytest
 
 from kirin.core import model
-from kirin.core.abstract_builder import wrap_build
+from kirin.core.build_wrapper import wrap_build
 from kirin.core.model import (
     RealTimeUpdate,
     db,

--- a/tests/integration/handle_test.py
+++ b/tests/integration/handle_test.py
@@ -33,18 +33,32 @@ from datetime import timedelta
 
 import pytest
 
-from kirin.core.handler import handle
+from kirin.core import model
+from kirin.core.build_wrapper import handle
 from kirin.core.model import RealTimeUpdate, TripUpdate, VehicleJourney, StopTimeUpdate
 from kirin.core.types import ConnectorType
+from kirin.gtfs_rt import gtfs_rt
 from kirin.utils import make_rt_update, persist
-from tests.integration.conftest import COTS_CONTRIBUTOR_ID
+from tests import mock_navitia
+from tests.integration.conftest import GTFS_CONTRIBUTOR_ID
 import datetime
 from kirin import app, db
 from tests.check_utils import _dt
 
 
+@pytest.fixture(scope="function", autouse=True)
+def navitia(monkeypatch):
+    """
+    Mock all calls to navitia for this fixture and get_publication_date
+    """
+    monkeypatch.setattr("navitia_wrapper._NavitiaWrapper.query", mock_navitia.mock_navitia_query)
+    monkeypatch.setattr(
+        "navitia_wrapper._NavitiaWrapper.get_publication_date", mock_navitia.mock_publication_date
+    )
+
+
 def create_trip_update(
-    id, trip_id, circulation_date, stops, status="update", contributor_id=COTS_CONTRIBUTOR_ID
+    id, trip_id, circulation_date, stops, status="update", contributor_id=GTFS_CONTRIBUTOR_ID
 ):
     trip_update = TripUpdate(
         VehicleJourney(
@@ -106,7 +120,7 @@ def setup_database():
                 },
             ],
         )
-        rtu = make_rt_update(None, ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID)
+        rtu = make_rt_update(None, ConnectorType.gtfs_rt.value, contributor_id=GTFS_CONTRIBUTOR_ID)
         rtu.id = "10866ce8-0638-4fa1-8556-1ddfa22d09d3"
         rtu.trip_updates.append(vju)
         db.session.add(rtu)
@@ -138,7 +152,7 @@ def setup_database():
                 },
             ],
         )
-        rtu = make_rt_update(None, ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID)
+        rtu = make_rt_update(None, ConnectorType.gtfs_rt.value, contributor_id=GTFS_CONTRIBUTOR_ID)
         rtu.id = "20866ce8-0638-4fa1-8556-1ddfa22d09d3"
         rtu.trip_updates.append(vju)
         persist(rtu)
@@ -175,15 +189,21 @@ def _create_db_vj(navitia_vj):
 
 
 def test_handle_basic():
-    with pytest.raises(TypeError):
-        handle(None, [], contributor_id=COTS_CONTRIBUTOR_ID, is_new_complete=False)
 
-    # a RealTimeUpdate without any TripUpdate doesn't do anything
     with app.app_context():
-        real_time_update = make_rt_update(
-            raw_data=None, connector_type=ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID
+        contributor = model.Contributor(
+            id=GTFS_CONTRIBUTOR_ID, navitia_coverage=None, connector_type=ConnectorType.gtfs_rt.value
         )
-        res, _ = handle(real_time_update, [], contributor_id=COTS_CONTRIBUTOR_ID, is_new_complete=False)
+        builder = gtfs_rt.KirinModelBuilder(contributor)
+
+        with pytest.raises(TypeError):
+            handle(builder, None, [])
+
+        # a RealTimeUpdate without any TripUpdate doesn't do anything
+        real_time_update = make_rt_update(
+            raw_data=None, connector_type=ConnectorType.gtfs_rt.value, contributor_id=GTFS_CONTRIBUTOR_ID
+        )
+        res, _ = handle(builder, real_time_update, [])
         assert res == real_time_update
 
 
@@ -205,15 +225,18 @@ def test_handle_new_vj():
         ],
     }
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), contributor_id=COTS_CONTRIBUTOR_ID, status="update")
+        contributor = model.Contributor(
+            id=GTFS_CONTRIBUTOR_ID, navitia_coverage=None, connector_type=ConnectorType.gtfs_rt.value
+        )
+        builder = gtfs_rt.KirinModelBuilder(contributor)
+
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), contributor_id=contributor.id, status="update")
         st = StopTimeUpdate({"id": "sa:1"}, departure_delay=timedelta(minutes=5), dep_status="update")
         real_time_update = make_rt_update(
-            raw_data=None, connector_type=ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID
+            raw_data=None, connector_type=ConnectorType.gtfs_rt.value, contributor_id=contributor.id
         )
         trip_update.stop_time_updates.append(st)
-        res, _ = handle(
-            real_time_update, [trip_update], contributor_id=COTS_CONTRIBUTOR_ID, is_new_complete=False
-        )
+        res, _ = handle(builder, real_time_update, [trip_update])
 
         assert len(res.trip_updates) == 1
         trip_update = res.trip_updates[0]
@@ -272,18 +295,21 @@ def test_past_midnight():
         ],
     }
     with app.app_context():
+        contributor = model.Contributor(
+            id=GTFS_CONTRIBUTOR_ID, navitia_coverage=None, connector_type=ConnectorType.gtfs_rt.value
+        )
+        builder = gtfs_rt.KirinModelBuilder(contributor)
+
         vj = VehicleJourney(
             navitia_vj, datetime.datetime(2015, 9, 8, 21, 15, 0), datetime.datetime(2015, 9, 9, 4, 20, 0)
         )
-        trip_update = TripUpdate(vj, status="update", contributor_id=COTS_CONTRIBUTOR_ID)
+        trip_update = TripUpdate(vj, status="update", contributor_id=contributor.id)
         st = StopTimeUpdate({"id": "sa:2"}, departure_delay=timedelta(minutes=31), dep_status="update", order=1)
         real_time_update = make_rt_update(
-            raw_data=None, connector_type=ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID
+            raw_data=None, connector_type=ConnectorType.gtfs_rt.value, contributor_id=contributor.id
         )
         trip_update.stop_time_updates.append(st)
-        res, _ = handle(
-            real_time_update, [trip_update], contributor_id=COTS_CONTRIBUTOR_ID, is_new_complete=False
-        )
+        res, _ = handle(builder, real_time_update, [trip_update])
 
         assert len(res.trip_updates) == 1
         trip_update = res.trip_updates[0]
@@ -313,7 +339,12 @@ def test_handle_new_trip_out_of_order(navitia_vj):
     so we have to reorder the stop times in the resulting trip_update
     """
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=COTS_CONTRIBUTOR_ID)
+        contributor = model.Contributor(
+            id=GTFS_CONTRIBUTOR_ID, navitia_coverage=None, connector_type=ConnectorType.gtfs_rt.value
+        )
+        builder = gtfs_rt.KirinModelBuilder(contributor)
+
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=contributor.id)
         st = StopTimeUpdate(
             {"id": "sa:2"},
             departure_delay=timedelta(minutes=40),
@@ -323,12 +354,10 @@ def test_handle_new_trip_out_of_order(navitia_vj):
             order=1,
         )
         real_time_update = make_rt_update(
-            raw_data=None, connector_type=ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID
+            raw_data=None, connector_type=ConnectorType.gtfs_rt.value, contributor_id=contributor.id
         )
         trip_update.stop_time_updates.append(st)
-        res, _ = handle(
-            real_time_update, [trip_update], contributor_id=COTS_CONTRIBUTOR_ID, is_new_complete=False
-        )
+        res, _ = handle(builder, real_time_update, [trip_update])
 
         assert len(res.trip_updates) == 1
         trip_update = res.trip_updates[0]
@@ -357,7 +386,12 @@ def test_manage_consistency(navitia_vj):
     expected result   08:10-08:10     10:15-10:15     11:10-11:10
     """
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=COTS_CONTRIBUTOR_ID)
+        contributor = model.Contributor(
+            id=GTFS_CONTRIBUTOR_ID, navitia_coverage=None, connector_type=ConnectorType.gtfs_rt.value
+        )
+        builder = gtfs_rt.KirinModelBuilder(contributor)
+
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=contributor.id)
         st = StopTimeUpdate(
             {"id": "sa:2"},
             arrival_delay=timedelta(minutes=70),
@@ -368,13 +402,11 @@ def test_manage_consistency(navitia_vj):
         )
         st.arrival_status = st.departure_status = "update"
         real_time_update = make_rt_update(
-            raw_data=None, connector_type=ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID
+            raw_data=None, connector_type=ConnectorType.gtfs_rt.value, contributor_id=contributor.id
         )
         real_time_update.id = "30866ce8-0638-4fa1-8556-1ddfa22d09d3"
         trip_update.stop_time_updates.append(st)
-        res, _ = handle(
-            real_time_update, [trip_update], contributor_id=COTS_CONTRIBUTOR_ID, is_new_complete=False
-        )
+        res, _ = handle(builder, real_time_update, [trip_update])
 
         assert len(res.trip_updates) == 1
         trip_update = res.trip_updates[0]
@@ -407,7 +439,12 @@ def test_handle_update_vj(setup_database, navitia_vj):
     update kirin       -      *9:15-9:20*      -
     """
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=COTS_CONTRIBUTOR_ID)
+        contributor = model.Contributor(
+            id=GTFS_CONTRIBUTOR_ID, navitia_coverage=None, connector_type=ConnectorType.gtfs_rt.value
+        )
+        builder = gtfs_rt.KirinModelBuilder(contributor)
+
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=contributor.id)
         st = StopTimeUpdate(
             {"id": "sa:2"},
             arrival_delay=timedelta(minutes=10),
@@ -418,13 +455,11 @@ def test_handle_update_vj(setup_database, navitia_vj):
         )
         st.arrival_status = st.departure_status = "update"
         real_time_update = make_rt_update(
-            raw_data=None, connector_type=ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID
+            raw_data=None, connector_type=ConnectorType.gtfs_rt.value, contributor_id=contributor.id
         )
         real_time_update.id = "30866ce8-0638-4fa1-8556-1ddfa22d09d3"
         trip_update.stop_time_updates.append(st)
-        res, _ = handle(
-            real_time_update, [trip_update], contributor_id=COTS_CONTRIBUTOR_ID, is_new_complete=False
-        )
+        res, _ = handle(builder, real_time_update, [trip_update])
 
         assert len(res.trip_updates) == 1
         trip_update = res.trip_updates[0]
@@ -489,7 +524,12 @@ def test_handle_update_vj(setup_database, navitia_vj):
 def test_simple_delay(navitia_vj):
     """Test on delay when there is nothing in the db"""
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=COTS_CONTRIBUTOR_ID)
+        contributor = model.Contributor(
+            id=GTFS_CONTRIBUTOR_ID, navitia_coverage=None, connector_type=ConnectorType.gtfs_rt.value
+        )
+        builder = gtfs_rt.KirinModelBuilder(contributor)
+
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=contributor.id)
         st = StopTimeUpdate(
             {"id": "sa:1"},
             departure_delay=timedelta(minutes=10),
@@ -499,12 +539,10 @@ def test_simple_delay(navitia_vj):
             order=0,
         )
         real_time_update = make_rt_update(
-            raw_data=None, connector_type=ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID
+            raw_data=None, connector_type=ConnectorType.gtfs_rt.value, contributor_id=contributor.id
         )
         trip_update.stop_time_updates.append(st)
-        res, _ = handle(
-            real_time_update, [trip_update], contributor_id=COTS_CONTRIBUTOR_ID, is_new_complete=False
-        )
+        res, _ = handle(builder, real_time_update, [trip_update])
         assert len(res.trip_updates) == 1
         trip_update = res.trip_updates[0]
         assert trip_update.status == "update"
@@ -589,18 +627,21 @@ def test_multiple_delays(setup_database, navitia_vj):
     update kirin      8:20*   *9:07-9:10     10:05
     """
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=COTS_CONTRIBUTOR_ID)
+        contributor = model.Contributor(
+            id=GTFS_CONTRIBUTOR_ID, navitia_coverage=None, connector_type=ConnectorType.gtfs_rt.value
+        )
+        builder = gtfs_rt.KirinModelBuilder(contributor)
+
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=contributor.id)
         real_time_update = make_rt_update(
-            raw_data=None, connector_type=ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID
+            raw_data=None, connector_type=ConnectorType.gtfs_rt.value, contributor_id=contributor.id
         )
         trip_update.stop_time_updates = [
             # Note: the delay is based of the navitia's vj
             StopTimeUpdate({"id": "sa:1"}, departure_delay=timedelta(minutes=10), dep_status="update"),
             StopTimeUpdate({"id": "sa:2"}, arrival_delay=timedelta(minutes=2), arr_status="update"),
         ]
-        res, _ = handle(
-            real_time_update, [trip_update], contributor_id=COTS_CONTRIBUTOR_ID, is_new_complete=False
-        )
+        res, _ = handle(builder, real_time_update, [trip_update])
 
         _check_multiples_delay(res)
 
@@ -618,26 +659,29 @@ def test_multiple_delays_in_2_updates(navitia_vj):
     same test as test_multiple_delays, but with nothing in the db and with 2 trip updates
     """
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=COTS_CONTRIBUTOR_ID)
+        contributor = model.Contributor(
+            id=GTFS_CONTRIBUTOR_ID, navitia_coverage=None, connector_type=ConnectorType.gtfs_rt.value
+        )
+        builder = gtfs_rt.KirinModelBuilder(contributor)
+
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=contributor.id)
         real_time_update = make_rt_update(
-            raw_data=None, connector_type=ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID
+            raw_data=None, connector_type=ConnectorType.gtfs_rt.value, contributor_id=contributor.id
         )
         trip_update.stop_time_updates = [
             StopTimeUpdate({"id": "sa:1"}, departure_delay=timedelta(minutes=5), dep_status="update")
         ]
-        handle(real_time_update, [trip_update], contributor_id=COTS_CONTRIBUTOR_ID, is_new_complete=False)
+        handle(builder, real_time_update, [trip_update])
 
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=COTS_CONTRIBUTOR_ID)
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=contributor.id)
         real_time_update = make_rt_update(
-            raw_data=None, connector_type=ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID
+            raw_data=None, connector_type=ConnectorType.gtfs_rt.value, contributor_id=contributor.id
         )
         trip_update.stop_time_updates = [
             StopTimeUpdate({"id": "sa:1"}, departure_delay=timedelta(minutes=10), dep_status="update"),
             StopTimeUpdate({"id": "sa:2"}, arrival_delay=timedelta(minutes=2), arr_status="update"),
         ]
-        res, _ = handle(
-            real_time_update, [trip_update], contributor_id=COTS_CONTRIBUTOR_ID, is_new_complete=False
-        )
+        res, _ = handle(builder, real_time_update, [trip_update])
 
         _check_multiples_delay(res)
         # we also check that there is what we want in the db
@@ -659,13 +703,16 @@ def test_delays_then_cancellation(setup_database, navitia_vj):
     update kirin                   -
     """
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="delete", contributor_id=COTS_CONTRIBUTOR_ID)
+        contributor = model.Contributor(
+            id=GTFS_CONTRIBUTOR_ID, navitia_coverage=None, connector_type=ConnectorType.gtfs_rt.value
+        )
+        builder = gtfs_rt.KirinModelBuilder(contributor)
+
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="delete", contributor_id=contributor.id)
         real_time_update = make_rt_update(
-            raw_data=None, connector_type=ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID
+            raw_data=None, connector_type=ConnectorType.gtfs_rt.value, contributor_id=contributor.id
         )
-        res, _ = handle(
-            real_time_update, [trip_update], contributor_id=COTS_CONTRIBUTOR_ID, is_new_complete=False
-        )
+        res, _ = handle(builder, real_time_update, [trip_update])
 
         assert len(res.trip_updates) == 1
         trip_update = res.trip_updates[0]
@@ -679,22 +726,25 @@ def test_delays_then_cancellation_in_2_updates(navitia_vj):
     Same test as above, but with nothing in the db, and with 2 updates
     """
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=COTS_CONTRIBUTOR_ID)
+        contributor = model.Contributor(
+            id=GTFS_CONTRIBUTOR_ID, navitia_coverage=None, connector_type=ConnectorType.gtfs_rt.value
+        )
+        builder = gtfs_rt.KirinModelBuilder(contributor)
+
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=contributor.id)
         real_time_update = make_rt_update(
-            raw_data=None, connector_type=ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID
+            raw_data=None, connector_type=ConnectorType.gtfs_rt.value, contributor_id=contributor.id
         )
         trip_update.stop_time_updates = [
             StopTimeUpdate({"id": "sa:1"}, departure_delay=timedelta(minutes=5), dep_status="update")
         ]
-        handle(real_time_update, [trip_update], contributor_id=COTS_CONTRIBUTOR_ID, is_new_complete=False)
+        handle(builder, real_time_update, [trip_update])
 
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="delete", contributor_id=COTS_CONTRIBUTOR_ID)
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="delete", contributor_id=contributor.id)
         real_time_update = make_rt_update(
-            raw_data=None, connector_type=ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID
+            raw_data=None, connector_type=ConnectorType.gtfs_rt.value, contributor_id=contributor.id
         )
-        res, _ = handle(
-            real_time_update, [trip_update], contributor_id=COTS_CONTRIBUTOR_ID, is_new_complete=False
-        )
+        res, _ = handle(builder, real_time_update, [trip_update])
 
         assert len(res.trip_updates) == 1
         trip_update = res.trip_updates[0]
@@ -758,20 +808,25 @@ def test_cancellation_then_delay(navitia_vj):
             [],
             status="delete",
         )
-        rtu = make_rt_update(None, ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID)
+        rtu = make_rt_update(None, ConnectorType.gtfs_rt.value, contributor_id=GTFS_CONTRIBUTOR_ID)
         rtu.id = "10866ce8-0638-4fa1-8556-1ddfa22d09d3"
         rtu.trip_updates.append(vju)
         persist(rtu)
 
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=COTS_CONTRIBUTOR_ID)
+        contributor = model.Contributor(
+            id=GTFS_CONTRIBUTOR_ID, navitia_coverage=None, connector_type=ConnectorType.gtfs_rt.value
+        )
+        builder = gtfs_rt.KirinModelBuilder(contributor)
+
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=contributor.id)
         real_time_update = make_rt_update(
-            raw_data=None, connector_type=ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID
+            raw_data=None, connector_type=ConnectorType.gtfs_rt.value, contributor_id=contributor.id
         )
         trip_update.stop_time_updates = [
             StopTimeUpdate({"id": "sa:3"}, arrival_delay=timedelta(minutes=40), arr_status="update", order=2)
         ]
-        res, _ = handle(real_time_update, [trip_update], COTS_CONTRIBUTOR_ID, is_new_complete=False)
+        res, _ = handle(builder, real_time_update, [trip_update])
 
         _check_cancellation_then_delay(res)
 
@@ -781,20 +836,25 @@ def test_cancellation_then_delay_in_2_updates(navitia_vj):
     same as test_cancellation_then_delay, but with a clear db and in 2 updates
     """
     with app.app_context():
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="delete", contributor_id=COTS_CONTRIBUTOR_ID)
+        contributor = model.Contributor(
+            id=GTFS_CONTRIBUTOR_ID, navitia_coverage=None, connector_type=ConnectorType.gtfs_rt.value
+        )
+        builder = gtfs_rt.KirinModelBuilder(contributor)
+
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="delete", contributor_id=contributor.id)
         trip_update.stop_time_updates = []
         real_time_update = make_rt_update(
-            raw_data=None, connector_type=ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID
+            raw_data=None, connector_type=ConnectorType.gtfs_rt.value, contributor_id=contributor.id
         )
-        handle(real_time_update, [trip_update], contributor_id=COTS_CONTRIBUTOR_ID, is_new_complete=False)
+        handle(builder, real_time_update, [trip_update])
 
-        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=COTS_CONTRIBUTOR_ID)
+        trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=contributor)
         real_time_update = make_rt_update(
-            raw_data=None, connector_type=ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID
+            raw_data=None, connector_type=ConnectorType.gtfs_rt.value, contributor_id=contributor.id
         )
         trip_update.stop_time_updates = [
             StopTimeUpdate({"id": "sa:3"}, arrival_delay=timedelta(minutes=40), arr_status="update", order=2)
         ]
-        res, _ = handle(real_time_update, [trip_update], COTS_CONTRIBUTOR_ID, is_new_complete=False)
+        res, _ = handle(builder, real_time_update, [trip_update])
 
         _check_cancellation_then_delay(res)

--- a/tests/integration/handle_test.py
+++ b/tests/integration/handle_test.py
@@ -38,7 +38,7 @@ from kirin.core.build_wrapper import handle
 from kirin.core.model import RealTimeUpdate, TripUpdate, VehicleJourney, StopTimeUpdate
 from kirin.core.types import ConnectorType
 from kirin.gtfs_rt import gtfs_rt
-from kirin.utils import make_rt_update, persist
+from kirin.utils import make_rt_update, db_commit
 from tests import mock_navitia
 from tests.integration.conftest import GTFS_CONTRIBUTOR_ID
 import datetime
@@ -155,7 +155,7 @@ def setup_database():
         rtu = make_rt_update(None, ConnectorType.gtfs_rt.value, contributor_id=GTFS_CONTRIBUTOR_ID)
         rtu.id = "20866ce8-0638-4fa1-8556-1ddfa22d09d3"
         rtu.trip_updates.append(vju)
-        persist(rtu)
+        db_commit(rtu)
 
 
 @pytest.fixture()
@@ -811,7 +811,7 @@ def test_cancellation_then_delay(navitia_vj):
         rtu = make_rt_update(None, ConnectorType.gtfs_rt.value, contributor_id=GTFS_CONTRIBUTOR_ID)
         rtu.id = "10866ce8-0638-4fa1-8556-1ddfa22d09d3"
         rtu.trip_updates.append(vju)
-        persist(rtu)
+        db_commit(rtu)
 
     with app.app_context():
         contributor = model.Contributor(

--- a/tests/integration/handle_test.py
+++ b/tests/integration/handle_test.py
@@ -36,7 +36,7 @@ import pytest
 from kirin.core.handler import handle
 from kirin.core.model import RealTimeUpdate, TripUpdate, VehicleJourney, StopTimeUpdate
 from kirin.core.types import ConnectorType
-from kirin.utils import make_rt_update
+from kirin.utils import make_rt_update, persist
 from tests.integration.conftest import COTS_CONTRIBUTOR_ID
 import datetime
 from kirin import app, db
@@ -141,8 +141,7 @@ def setup_database():
         rtu = make_rt_update(None, ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID)
         rtu.id = "20866ce8-0638-4fa1-8556-1ddfa22d09d3"
         rtu.trip_updates.append(vju)
-        db.session.add(rtu)
-        db.session.commit()
+        persist(rtu)
 
 
 @pytest.fixture()
@@ -762,8 +761,7 @@ def test_cancellation_then_delay(navitia_vj):
         rtu = make_rt_update(None, ConnectorType.cots.value, contributor_id=COTS_CONTRIBUTOR_ID)
         rtu.id = "10866ce8-0638-4fa1-8556-1ddfa22d09d3"
         rtu.trip_updates.append(vju)
-        db.session.add(rtu)
-        db.session.commit()
+        persist(rtu)
 
     with app.app_context():
         trip_update = TripUpdate(_create_db_vj(navitia_vj), status="update", contributor_id=COTS_CONTRIBUTOR_ID)

--- a/tests/integration/model_test.py
+++ b/tests/integration/model_test.py
@@ -35,6 +35,7 @@ from sqlalchemy.orm.exc import FlushError
 
 from kirin.core.model import TripUpdate, StopTimeUpdate, Contributor
 from kirin.core.types import ConnectorType
+from kirin.utils import persist
 from tests.integration.conftest import COTS_CONTRIBUTOR_ID, GTFS_CONTRIBUTOR_ID
 from tests.integration.utils_test import create_trip_update, create_rt_update_and_trip_update
 from kirin import db, app
@@ -430,8 +431,7 @@ def test_contributor_creation():
     with app.app_context():
         contrib = Contributor("realtime.george", "idf", ConnectorType.cots.value)
 
-        db.session.add(contrib)
-        db.session.commit()
+        persist(contrib)
 
         assert contrib.id == "realtime.george"
         assert contrib.navitia_coverage == "idf"
@@ -443,5 +443,4 @@ def test_contributor_creation():
             """
             Adding a second contributor with the same id should fail
             """
-            db.session.add(contrib_with_same_id)
-            db.session.commit()
+            persist(contrib_with_same_id)

--- a/tests/integration/model_test.py
+++ b/tests/integration/model_test.py
@@ -35,7 +35,7 @@ from sqlalchemy.orm.exc import FlushError
 
 from kirin.core.model import TripUpdate, StopTimeUpdate, Contributor
 from kirin.core.types import ConnectorType
-from kirin.utils import persist
+from kirin.utils import db_commit
 from tests.integration.conftest import COTS_CONTRIBUTOR_ID, GTFS_CONTRIBUTOR_ID
 from tests.integration.utils_test import create_trip_update, create_rt_update_and_trip_update
 from kirin import db, app
@@ -431,7 +431,7 @@ def test_contributor_creation():
     with app.app_context():
         contrib = Contributor("realtime.george", "idf", ConnectorType.cots.value)
 
-        persist(contrib)
+        db_commit(contrib)
 
         assert contrib.id == "realtime.george"
         assert contrib.navitia_coverage == "idf"
@@ -443,4 +443,4 @@ def test_contributor_creation():
             """
             Adding a second contributor with the same id should fail
             """
-            persist(contrib_with_same_id)
+            db_commit(contrib_with_same_id)

--- a/tests/integration/populate_pb_test.py
+++ b/tests/integration/populate_pb_test.py
@@ -38,7 +38,7 @@ from kirin import app, db
 from kirin import gtfs_realtime_pb2, kirin_pb2
 from kirin.core.types import ConnectorType
 from kirin.cots.model_maker import make_navitia_empty_vj
-from kirin.utils import make_rt_update
+from kirin.utils import make_rt_update, persist
 from tests.check_utils import _dt
 from tests.integration.conftest import COTS_CONTRIBUTOR_ID
 
@@ -77,8 +77,7 @@ def test_populate_pb_with_one_stop_time():
         real_time_update.trip_updates.append(trip_update)
         trip_update.stop_time_updates.append(st)
 
-        db.session.add(real_time_update)
-        db.session.commit()
+        persist(real_time_update)
 
         feed_entity = convert_to_gtfsrt(real_time_update.trip_updates)
 
@@ -143,8 +142,7 @@ def test_populate_pb_with_two_stop_time():
         )
         real_time_update.trip_updates[0].stop_time_updates.append(st)
 
-        db.session.add(real_time_update)
-        db.session.commit()
+        persist(real_time_update)
 
         feed_entity = convert_to_gtfsrt(real_time_update.trip_updates)
 
@@ -267,8 +265,7 @@ def test_populate_pb_with_deleted_stop_time():
         )
         real_time_update.trip_updates[0].stop_time_updates.append(st)
 
-        db.session.add(real_time_update)
-        db.session.commit()
+        persist(real_time_update)
 
         feed_entity = convert_to_gtfsrt(real_time_update.trip_updates)
 
@@ -372,8 +369,7 @@ def test_populate_pb_with_cancelation():
         trip_update.effect = "REDUCED_SERVICE"
         real_time_update.trip_updates.append(trip_update)
 
-        db.session.add(real_time_update)
-        db.session.commit()
+        persist(real_time_update)
 
         feed_entity = convert_to_gtfsrt(real_time_update.trip_updates)
 
@@ -417,8 +413,7 @@ def test_populate_pb_with_full_dataset():
         trip_update.effect = "DETOUR"
         real_time_update.trip_updates.append(trip_update)
 
-        db.session.add(real_time_update)
-        db.session.commit()
+        persist(real_time_update)
 
         feed_entity = convert_to_gtfsrt(real_time_update.trip_updates, gtfs_realtime_pb2.FeedHeader.FULL_DATASET)
 
@@ -537,8 +532,7 @@ def test_populate_pb_for_added_trip():
         )
         trip_update.stop_time_updates.append(st)
 
-        db.session.add(real_time_update)
-        db.session.commit()
+        persist(real_time_update)
 
         feed_entity = convert_to_gtfsrt(real_time_update.trip_updates)
 

--- a/tests/integration/populate_pb_test.py
+++ b/tests/integration/populate_pb_test.py
@@ -38,7 +38,7 @@ from kirin import app, db
 from kirin import gtfs_realtime_pb2, kirin_pb2
 from kirin.core.types import ConnectorType
 from kirin.cots.model_maker import make_navitia_empty_vj
-from kirin.utils import make_rt_update, persist
+from kirin.utils import make_rt_update, db_commit
 from tests.check_utils import _dt
 from tests.integration.conftest import COTS_CONTRIBUTOR_ID
 
@@ -77,7 +77,7 @@ def test_populate_pb_with_one_stop_time():
         real_time_update.trip_updates.append(trip_update)
         trip_update.stop_time_updates.append(st)
 
-        persist(real_time_update)
+        db_commit(real_time_update)
 
         feed_entity = convert_to_gtfsrt(real_time_update.trip_updates)
 
@@ -142,7 +142,7 @@ def test_populate_pb_with_two_stop_time():
         )
         real_time_update.trip_updates[0].stop_time_updates.append(st)
 
-        persist(real_time_update)
+        db_commit(real_time_update)
 
         feed_entity = convert_to_gtfsrt(real_time_update.trip_updates)
 
@@ -265,7 +265,7 @@ def test_populate_pb_with_deleted_stop_time():
         )
         real_time_update.trip_updates[0].stop_time_updates.append(st)
 
-        persist(real_time_update)
+        db_commit(real_time_update)
 
         feed_entity = convert_to_gtfsrt(real_time_update.trip_updates)
 
@@ -369,7 +369,7 @@ def test_populate_pb_with_cancelation():
         trip_update.effect = "REDUCED_SERVICE"
         real_time_update.trip_updates.append(trip_update)
 
-        persist(real_time_update)
+        db_commit(real_time_update)
 
         feed_entity = convert_to_gtfsrt(real_time_update.trip_updates)
 
@@ -413,7 +413,7 @@ def test_populate_pb_with_full_dataset():
         trip_update.effect = "DETOUR"
         real_time_update.trip_updates.append(trip_update)
 
-        persist(real_time_update)
+        db_commit(real_time_update)
 
         feed_entity = convert_to_gtfsrt(real_time_update.trip_updates, gtfs_realtime_pb2.FeedHeader.FULL_DATASET)
 
@@ -532,7 +532,7 @@ def test_populate_pb_for_added_trip():
         )
         trip_update.stop_time_updates.append(st)
 
-        persist(real_time_update)
+        db_commit(real_time_update)
 
         feed_entity = convert_to_gtfsrt(real_time_update.trip_updates)
 


### PR DESCRIPTION
:mag: Please review by commit with message.

:dart: Provide ability for each `KirinModelBuilder` to define its own way of merging `trip_update` info (from incoming RT feed, existing RT info in db and base-schedule info).

:broken_heart: On the way split `handler.py` :
* `merge_utils.py` receives tools to be used by `merge_trip_updates` methods
* `build_wrapper.py` receives functions that operate `KirinModelBuilder` (including `wrap_build`)
* cleanups of functions that did not especially fit in one of the 2

:stop_sign: Not done:
* completely remove boolean `is_new_complete` from `merge()` params, and separate more responsibilities toward `gtfs_rt.KirinModelBuilder` and `cots.KirinModelBuilder`: waiting to see the real need from PIV to see if a common structural need arises or not.

:broom: Also:
* minor side fixes and cleanups
* fix tests according to changes

Preliminary work for https://jira.kisio.org/browse/ND-1021