### PR TITLE
PIV: add specific merge() for new RT, old RT and base_schedule info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,7 @@ To generate a new release:
    ```sh
    git checkout release
    git pull
-   git merge canaltp/master
+   git merge <canaltp>/master
    ```
 
 2. tag and annotate the version:
@@ -214,7 +214,7 @@ To generate a new release:
 4. push master, release and tags to central repo
 
    ```sh
-   git push canaltp release master --tags
+   git push <canaltp> release master --tags
    ```
 
 5. the pipe https://ci.navitia.io/view/kirin_release_deployment/ should be

--- a/kirin/core/abstract_builder.py
+++ b/kirin/core/abstract_builder.py
@@ -89,7 +89,7 @@ class AbstractKirinModelBuilder(six.with_metaclass(ABCMeta, object)):
         * navitia_vj (base-schedule VJ - complete, maybe nonexistent)
         * db_trip_update (last known realtime VJ - complete, maybe nonexistent)
         * new_trip_update (VJ information extracted from incoming feed - maybe incomplete)
-        Returns resulting TripUpdate:
+        Returns resulting TripUpdate if different from last known (else None):
         usually update of the last known realtime VJ, or completed version of new_trip_update
         """
         raise NotImplementedError("Please implement this method")

--- a/kirin/core/build_wrapper.py
+++ b/kirin/core/build_wrapper.py
@@ -151,6 +151,7 @@ def wrap_build(builder, input_raw):
     start_datetime = datetime.datetime.utcnow()
     rt_update = None
     log_dict = {"contributor": contributor.id}
+    record_custom_parameter("contributor", contributor.id)
     status = "OK"
 
     try:

--- a/kirin/core/build_wrapper.py
+++ b/kirin/core/build_wrapper.py
@@ -48,28 +48,12 @@ from kirin.utils import set_rtu_status_ko, allow_reprocess_same_data, record_cal
 TimeDelayTuple = namedtuple("TimeDelayTuple", ["time", "delay"])
 
 
-def log_stu_modif(trip_update, stu, string_additional_info):
-    logger = logging.getLogger(__name__)
-    logger.debug(
-        "TripUpdate on navitia vj {nav_id} on {date}, "
-        "StopTimeUpdate {order} modified: {add_info}".format(
-            nav_id=trip_update.vj.navitia_trip_id,
-            date=trip_update.vj.get_circulation_date(),
-            order=stu.order,
-            add_info=string_additional_info,
-        )
-    )
-
-
-def manage_consistency(trip_update):
+def check_consistency(trip_update):
     """
-    receive a TripUpdate, then manage and adjust its consistency
-    returns False if trip update cannot be managed
+    returns False if trip update is inconsistent
     """
     logger = logging.getLogger(__name__)
-    previous_stop_event = TimeDelayTuple(time=None, delay=None)
     for current_order, stu in enumerate(trip_update.stop_time_updates):
-        # rejections
         if stu.order != current_order:
             logger.warning(
                 "TripUpdate on navitia vj {nav_id} on {date} rejected: "
@@ -81,73 +65,6 @@ def manage_consistency(trip_update):
                 )
             )
             return False
-
-        # modifications
-        if stu.arrival is None:
-            stu.arrival = stu.departure
-            if stu.arrival is None and previous_stop_event.time is not None:
-                stu.arrival = previous_stop_event.time
-            if stu.arrival is None:
-                logger.warning(
-                    "TripUpdate on navitia vj {nav_id} on {date} rejected: "
-                    "StopTimeUpdate missing arrival time".format(
-                        nav_id=trip_update.vj.navitia_trip_id, date=trip_update.vj.get_circulation_date()
-                    )
-                )
-                return False
-            log_stu_modif(trip_update, stu, "arrival = {v}".format(v=stu.arrival))
-            if not stu.arrival_delay and stu.departure_delay:
-                stu.arrival_delay = stu.departure_delay
-                log_stu_modif(trip_update, stu, "arrival_delay = {v}".format(v=stu.arrival_delay))
-
-        if stu.departure is None:
-            stu.departure = stu.arrival
-            log_stu_modif(trip_update, stu, "departure = {v}".format(v=stu.departure))
-            if not stu.departure_delay and stu.arrival_delay:
-                stu.departure_delay = stu.arrival_delay
-                log_stu_modif(trip_update, stu, "departure_delay = {v}".format(v=stu.departure_delay))
-
-        if stu.arrival_delay is None:
-            stu.arrival_delay = datetime.timedelta(0)
-            log_stu_modif(trip_update, stu, "arrival_delay = {v}".format(v=stu.arrival_delay))
-
-        if stu.departure_delay is None:
-            stu.departure_delay = datetime.timedelta(0)
-            log_stu_modif(trip_update, stu, "departure_delay = {v}".format(v=stu.departure_delay))
-
-        # not considering deleted arrival
-        if not stu.is_stop_event_deleted("arrival"):
-            # if arrival is before previous stop-event's time:
-            # push arrival time so that its delay is the same than for previous time
-            if previous_stop_event.time is not None and previous_stop_event.time > stu.arrival:
-                delay_diff = previous_stop_event.delay - stu.arrival_delay
-                stu.arrival_delay += delay_diff
-                stu.arrival += delay_diff
-                log_stu_modif(
-                    trip_update,
-                    stu,
-                    "arrival = {t} and arrival_delay = {d}".format(t=stu.arrival, d=stu.arrival_delay),
-                )
-
-            # store arrival as previous stop-event
-            previous_stop_event = TimeDelayTuple(time=stu.arrival, delay=stu.arrival_delay)
-
-        # not considering deleted departure (same logic as before)
-        if not stu.is_stop_event_deleted("departure"):
-            # if departure is before previous stop-event's time:
-            # push departure time so that its delay is the same than for previous time
-            if previous_stop_event.time is not None and previous_stop_event.time > stu.departure:
-                delay_diff = previous_stop_event.delay - stu.departure_delay
-                stu.departure_delay += delay_diff
-                stu.departure += delay_diff
-                log_stu_modif(
-                    trip_update,
-                    stu,
-                    "departure = {t} and departure_delay = {d}".format(t=stu.departure, d=stu.departure_delay),
-                )
-            # store departure as previous stop-event
-            previous_stop_event = TimeDelayTuple(time=stu.departure, delay=stu.departure_delay)
-
     return True
 
 
@@ -192,7 +109,7 @@ def handle(builder, real_time_update, trip_updates):
         current_trip_update = builder.merge_trip_updates(trip_update.vj.navitia_vj, old, trip_update)
 
         # manage and adjust consistency if possible
-        if current_trip_update and manage_consistency(current_trip_update):
+        if current_trip_update is not None and check_consistency(current_trip_update):
             # we have to link the current_vj_update with the new real_time_update
             # this link is done quite late to avoid too soon persistence of trip_update by sqlalchemy
             current_trip_update.real_time_updates.append(real_time_update)

--- a/kirin/core/merge_utils.py
+++ b/kirin/core/merge_utils.py
@@ -305,16 +305,18 @@ def convert_nav_stop_list_to_stu_list(nav_stop_list, circulation_date):
     return stus
 
 
-def time_to_timedelta(hour):
+def time_to_timedelta(t):
     """
-    Convert a datetime.time to a datetime.timedelta (allow adds)
-    :param hour: datetime.time to convert
+    Convert a datetime.time to a datetime.timedelta, ignoring timezone (allow adds)
+    :param t: datetime.time to convert
     :return: corresponding datetime.timedelta or None
     >>> time_to_timedelta(None)
 
     >>> time_to_timedelta(datetime.time(0))
     datetime.timedelta(0)
-    >>> time_to_timedelta(datetime.time(8, 0)) == datetime.timedelta(hours=8)
+    >>> from pytz import timezone
+    >>> time_to_timedelta(datetime.time(8, 1, 2, 44555, timezone('Australia/Sydney'))) == \
+        datetime.timedelta(hours=8, minutes=1, seconds=2, milliseconds=44, microseconds=555)
     True
     >>> d = time_to_timedelta(datetime.time(0, 5)) + datetime.timedelta(minutes=-10)
     >>> d == datetime.timedelta(minutes=-5)
@@ -323,15 +325,15 @@ def time_to_timedelta(hour):
     >>> d == datetime.timedelta(hours=24, minutes=20)
     True
     """
-    if hour is None:
+    if t is None:
         return None
-    return datetime.datetime.combine(datetime.date.min, hour) - datetime.datetime.min
+    return datetime.timedelta(hours=t.hour, minutes=t.minute, seconds=t.second, microseconds=t.microsecond)
 
 
-def is_past_midnight(previous_hour, current_hour):
-    if previous_hour is None or current_hour is None:
+def is_past_midnight(previous_time, current_time):
+    if previous_time is None or current_time is None:
         return False
-    return previous_hour > current_hour
+    return previous_time > current_time
 
 
 def is_past_midnight_event(prev_stop_event, current_stop_event):

--- a/kirin/core/merge_utils.py
+++ b/kirin/core/merge_utils.py
@@ -235,7 +235,7 @@ def _make_stop_time_update(base_arrival, base_departure, last_departure, input_s
 def yield_next_stop_from_trip_update(new_trip_update, db_trip_update):
     # Iterate on the new trip update stop_times if it is complete (all stop_times present in it)
     for order, new_stu in enumerate(new_trip_update.stop_time_updates):
-        # Find corresponding stop_time in the theoretical VJ
+        # Find corresponding stop_time in the base-schedule VJ
         vj_st = find_st_in_vj(new_stu.stop_id, new_trip_update.vj.navitia_vj.get("stop_times", []))
         if vj_st:
             yield order, vj_st
@@ -264,7 +264,7 @@ def yield_next_stop_from_trip_update(new_trip_update, db_trip_update):
 
 
 def yield_next_stop_from_base_schedule_vj(navitia_vj):
-    # Iterate on the theoretical VJ if the new trip update doesn't list all stop_times
+    # Iterate on the base-schedule VJ if the new trip update doesn't list all stop_times
     for order, vj_st in enumerate(navitia_vj.get("stop_times", [])):
         yield order, vj_st
 

--- a/kirin/core/merge_utils.py
+++ b/kirin/core/merge_utils.py
@@ -36,7 +36,7 @@ import datetime
 
 from kirin.core.build_wrapper import TimeDelayTuple
 from kirin.core.model import StopTimeUpdate
-from kirin.core.types import ModificationType
+from kirin.core.types import ModificationType, DELETED_STATUSES, ADDED_STATUSES
 
 
 def find_st_in_vj(st_id, vj_sts):
@@ -181,12 +181,12 @@ def _get_update_info_of_stop_event(base_time, input_time, input_status, input_de
             new_time += input_delay
         status = input_status
         delay = input_delay
-    elif input_status in (ModificationType.delete.name, ModificationType.deleted_for_detour.name):
+    elif input_status in DELETED_STATUSES:
         # passing status 'delete' on the stop_time
         # Note: we keep providing base_schedule stop_time to better identify the stop_time
         # in the vj (for lollipop lines for example)
         status = input_status
-    elif input_status in (ModificationType.add.name, ModificationType.added_for_detour.name):
+    elif input_status in ADDED_STATUSES:
         status = input_status
         new_time = input_time.replace(tzinfo=None) if input_time else None
         if new_time is not None and input_delay:

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -267,6 +267,15 @@ class StopTimeUpdate(db.Model, TimestampMixin):  # type: ignore
         status = self.get_stop_event_status(event_name)
         return status in ADDED_STATUSES
 
+    def is_fully_added(self, index):
+        if index == 0:
+            # first stop
+            return self.departure_status in ADDED_STATUSES
+        if index == -1:
+            # last stop
+            return self.arrival_status in ADDED_STATUSES
+        return self.arrival_status in ADDED_STATUSES and self.departure_status in ADDED_STATUSES
+
 
 associate_realtimeupdate_tripupdate = db.Table(
     "associate_realtimeupdate_tripupdate",

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -236,22 +236,22 @@ class StopTimeUpdate(db.Model, TimestampMixin):  # type: ignore
         if status:
             self.arrival_status = status
 
-    def is_not_equal(self, other):
+    def is_equal(self, other):
         """
-        we don't want to override the __ne__ function to avoid side effects
+        we don't want to override the __eq__ function to avoid side effects
         :param other:
         :return:
         """
         return (
-            self.stop_id != other.stop_id
-            or self.message != other.message
-            or self.order != other.order
-            or self.departure != other.departure
-            or self.departure_delay != other.departure_delay
-            or self.departure_status != other.departure_status
-            or self.arrival != other.arrival
-            or self.arrival_delay != other.arrival_delay
-            or self.arrival_status != other.arrival_status
+            self.stop_id == other.stop_id
+            and self.message == other.message
+            and self.order == other.order
+            and self.departure == other.departure
+            and self.departure_delay == other.departure_delay
+            and self.departure_status == other.departure_status
+            and self.arrival == other.arrival
+            and self.arrival_delay == other.arrival_delay
+            and self.arrival_status == other.arrival_status
         )
 
     def get_stop_event_status(self, event_name):

--- a/kirin/core/model.py
+++ b/kirin/core/model.py
@@ -38,7 +38,7 @@ from flask_sqlalchemy import SQLAlchemy
 import datetime
 import sqlalchemy
 from sqlalchemy import desc
-from kirin.core.types import ModificationType, TripEffect, ConnectorType
+from kirin.core.types import ModificationType, TripEffect, ConnectorType, DELETED_STATUSES, ADDED_STATUSES
 from kirin.exceptions import ObjectNotFound, InternalException
 
 db = SQLAlchemy()
@@ -261,11 +261,11 @@ class StopTimeUpdate(db.Model, TimestampMixin):  # type: ignore
 
     def is_stop_event_deleted(self, event_name):
         status = self.get_stop_event_status(event_name)
-        return status in (ModificationType.delete.name, ModificationType.deleted_for_detour.name)
+        return status in DELETED_STATUSES
 
     def is_stop_event_added(self, event_name):
         status = self.get_stop_event_status(event_name)
-        return status in (ModificationType.add.name, ModificationType.added_for_detour.name)
+        return status in ADDED_STATUSES
 
 
 associate_realtimeupdate_tripupdate = db.Table(

--- a/kirin/core/populate_pb.py
+++ b/kirin/core/populate_pb.py
@@ -132,7 +132,7 @@ def fill_trip_update(pb_trip_update, trip_update):
         fill_message(pb_trip_update, trip_update.message)
     if trip_update.company_id:
         pb_trip.Extensions[kirin_pb2.company_id] = trip_update.company_id
-    if trip_update.effect:
+    if trip_update.effect and get_trip_event(trip_update.effect) is not None:
         pb_trip_update.Extensions[kirin_pb2.effect] = get_trip_event(trip_update.effect)
     if trip_update.physical_mode_id:
         pb_trip_update.vehicle.Extensions[kirin_pb2.physical_mode_id] = trip_update.physical_mode_id

--- a/kirin/core/types.py
+++ b/kirin/core/types.py
@@ -46,6 +46,11 @@ class ModificationType(Enum):
     added_for_detour = 6
 
 
+SIMPLE_MODIF_STATUSES = [ModificationType.update.name, ModificationType.none.name]
+ADDED_STATUSES = [ModificationType.add.name, ModificationType.added_for_detour.name]
+DELETED_STATUSES = [ModificationType.delete.name, ModificationType.deleted_for_detour.name]
+
+
 def stop_time_status_to_protobuf(stop_time_status):
     return {
         "add": kirin_pb2.ADDED,

--- a/kirin/core/types.py
+++ b/kirin/core/types.py
@@ -121,3 +121,20 @@ def get_mode_filter(indicator=None):
         "FERRE": "physical_mode.id=physical_mode:LongDistanceTrain",
         "ROUTIER": "physical_mode.id=physical_mode:Coach",
     }.get(indicator, "physical_mode.id=physical_mode:LongDistanceTrain")
+
+
+class StopTimeEvent(Enum):
+    """
+    Represent the 2 possible events at a stop
+    """
+
+    # TODO: remove "name" and dispatch use directly in model.py and everywhere useful
+    arrival = "arrival"  # drop-off
+    departure = "departure"  # pickup
+
+    def opposite(self):
+        if self == StopTimeEvent.arrival:
+            return StopTimeEvent.departure
+        if self == StopTimeEvent.departure:
+            return StopTimeEvent.arrival
+        return None

--- a/kirin/piv/model_maker.py
+++ b/kirin/piv/model_maker.py
@@ -32,7 +32,7 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 
 import logging
-from datetime import timedelta, datetime
+import datetime
 from sys import maxint
 
 import jmespath
@@ -203,7 +203,9 @@ def _extract_navitia_stop_time(uic8, nav_vj):
 
 def _check_stop_time_consistency(previous_rt_stop_time_dep, current_rt_stop_time, uic8):
     previous_rt_stop_time_dep = (
-        previous_rt_stop_time_dep if previous_rt_stop_time_dep is not None else datetime.fromtimestamp(0)
+        previous_rt_stop_time_dep
+        if previous_rt_stop_time_dep is not None
+        else datetime.datetime.fromtimestamp(0)
     )
 
     rt_arrival = current_rt_stop_time.get("arrivee")
@@ -334,7 +336,7 @@ class KirinModelBuilder(AbstractKirinModelBuilder):
         else:
             navitia_vj = navitia_vjs[0]
             try:
-                base_vs_rt_error_margin = timedelta(hours=1)
+                base_vs_rt_error_margin = datetime.timedelta(hours=1)
                 vj_base_start = _get_first_stop_base_datetime(ads, "depart", skip_fully_added_stops=True)
                 vj = model.VehicleJourney(
                     navitia_vj,

--- a/tests/integration/piv_test.py
+++ b/tests/integration/piv_test.py
@@ -975,7 +975,14 @@ def test_piv_trip_removal_simple_post(mock_rabbitmq):
     with app.app_context():
         assert RealTimeUpdate.query.count() == 1
         assert TripUpdate.query.count() == 1
-        assert StopTimeUpdate.query.count() == 0
+        # The 6 stops from base-schedule are marked as deleted.
+        # We could also have none as trip-delete is enough.
+        # It may help if trip is reactivated in tricky chaining of feeds:
+        # 1. Add a stop
+        # 2. Delete whole trip
+        # 3. Reactivate base-schedule trip only : stop added previously should appear as
+        #    deleted (so it has to be remembered).
+        assert StopTimeUpdate.query.count() == 6
 
         db_trip_removal = TripUpdate.query.first()
         assert db_trip_removal
@@ -984,8 +991,10 @@ def test_piv_trip_removal_simple_post(mock_rabbitmq):
         assert db_trip_removal.status == "delete"
         assert db_trip_removal.effect == "NO_SERVICE"
         assert db_trip_removal.message == "Indisponibilité d'un matériel"
-        # full trip removal : no stop_time to precise
-        assert len(db_trip_removal.stop_time_updates) == 0
+        assert len(db_trip_removal.stop_time_updates) == 6
+        for st in db_trip_removal.stop_time_updates:
+            assert st.arrival_status == ModificationType.delete.name
+            assert st.departure_status == ModificationType.delete.name
 
     assert mock_rabbitmq.call_count == 1
 
@@ -1015,7 +1024,7 @@ def test_piv_event_priority(mock_rabbitmq):
     with app.app_context():
         assert RealTimeUpdate.query.count() == 1
         assert TripUpdate.query.count() == 1
-        assert StopTimeUpdate.query.count() == 0
+        assert StopTimeUpdate.query.count() == 6  # Remembering all stops that were served once
 
         db_trip_removal = TripUpdate.query.first()
         assert db_trip_removal
@@ -1024,8 +1033,10 @@ def test_piv_event_priority(mock_rabbitmq):
         assert db_trip_removal.status == "delete"
         assert db_trip_removal.effect == "NO_SERVICE"
         assert db_trip_removal.message == "Indisponibilité d'un matériel"
-        # full trip removal : no stop_time to precise
-        assert len(db_trip_removal.stop_time_updates) == 0
+        assert len(db_trip_removal.stop_time_updates) == 6
+        for st in db_trip_removal.stop_time_updates:
+            assert st.arrival_status == ModificationType.delete.name
+            assert st.departure_status == ModificationType.delete.name
 
     assert mock_rabbitmq.call_count == 1
 

--- a/tests/integration/piv_test.py
+++ b/tests/integration/piv_test.py
@@ -916,8 +916,14 @@ def test_piv_delayed_post_twice(mock_rabbitmq):
     piv_str = ujson.dumps(_get_stomp_20201022_23187_delayed_5min_fixture())
     res = api_post("/piv/{}".format(PIV_CONTRIBUTOR_ID), data=piv_str)
     assert "PIV feed processed" in res.get("message")
+    status = api_get("/status")
+    assert not status["last_update_error"]  # check no error
     res = api_post("/piv/{}".format(PIV_CONTRIBUTOR_ID), data=piv_str)
     assert "PIV feed processed" in res.get("message")
+    status = api_get("/status")
+    assert (
+        status["last_update_error"][PIV_CONTRIBUTOR_ID] == "No new information destined to navitia for this piv"
+    )  # check the same-feed detection is working
 
     with app.app_context():
         assert RealTimeUpdate.query.count() == 2


### PR DESCRIPTION
:mag: Please review by commit with message.

Also:
* move TripUpdate self-consistency adjustment into merge_trip_updates()
* minor refactors

:dart: main work is in 6th (last) commit 

:information_source: Things to consider (and why work did not go further):
* Some cleanup and a wider use of the new patterns could be done (for COTS and GTFSRT).
However there is some work to do that, and we have to consider that COTS should be deprecated soon and GTFSRT management will probably evolve (so it will be a more watched/tested occasion to improve patterns).
* The work did not go as far as adding a middle representation model detached to ORM, which would be way cleaner and lead to more consistent code, clearer responsibilities for objects (let ORM just manage db, and use intermediate model to manage functionnal needs) : tracked in https://jira.kisio.org/browse/ND-583 (not decided if it will ever be done).

TODO:

- [x] Improve extremities management (first arrival, last departure): those are mostly unused, except for stay-in. So doing "whatever looks easier/nicer in code" is not nice for final display in navitia (even in case info is not used) and can lead to bad journeys if there is stay-in.
  > Not handled in that PR (as it's no problem for PIV), tracked as part of https://jira.kisio.org/browse/ND-1169

JIRA: https://jira.kisio.org/browse/ND-1142