### PR TITLE
[tech] GithubActions: build only master, release and PRs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,5 +1,13 @@
 name: Continuous Integration
-on: [push, pull_request]
+
+on:
+    push:
+        branches:  # Build 'master' and 'release' branches
+            - 'master'
+            - 'release'
+        tags-ignore:  # No build on tags
+            - '**'
+    pull_request:  # Build any PR
 
 jobs:
     quality:

--- a/kirin/command/piv_worker.py
+++ b/kirin/command/piv_worker.py
@@ -126,11 +126,12 @@ class PivWorker(ConsumerMixin):
     def on_iteration(self):
         if datetime.now() - self.last_config_checked_time < CONF_RELOAD_INTERVAL:
             return
-        else:
-            # SQLAlchemy is not querying the DB for read (uses cache instead),
-            # unless we specifically tell that the data is expired.
-            db.session.expire(self.builder.contributor)
-            self.last_config_checked_time = datetime.now()
+
+        # SQLAlchemy is not querying the DB for read (uses cache instead),
+        # unless we specifically tell that the data is expired.
+        db.session.expire(self.builder.contributor)
+        self.last_config_checked_time = datetime.now()
+
         contributor = get_piv_contributor(self.builder.contributor.id)
         if (
             not contributor


### PR DESCRIPTION
For now, all the deployment system is based on `release` branch and `git describe`, tags are only used for clearer information.
So they are built as they are always on `release` branch, but it's a side effect.
The goal is to avoid duplicate builds.