### PR TITLE
[tech] Delegate New Relic error filter to newrelic.ini

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,29 @@ The main separations are:
   components are disconnected.\
   Those are expected to alert developers and OPS.
 
+### Filter errors in New Relic
+
+Errors in NewRelic summary are filtered by adding a type of exception in `newrelic.ini`.
+This allows the filtering to be effective for all cases (flask, celery, piv-worker).
+
+The line to modify/add will look like:
+
+```ini
+[newrelic]
+
+...
+
+error_collector.ignore_errors = kirin.exceptions:ObjectNotFound werkzeug.exceptions:MethodNotAllowed
+```
+
+#### Troubleshooting New Relic
+
+For python agent, one can add environment variable to log NewRelic's calls to a given file.
+
+```bash
+NEW_RELIC_AUDIT_LOG=newrelic.log honcho start
+```
+
 ## Tests
 
 Most tests are implemented in `/tests` directory.\

--- a/kirin/core/build_wrapper.py
+++ b/kirin/core/build_wrapper.py
@@ -186,7 +186,10 @@ def wrap_build(builder, input_raw):
         log_dict.update({"exc_summary": six.text_type(e), "reason": e})
 
         record_custom_parameter("reason", e)  # using __str__() here to have complete details
-        raise  # filters later for errors in newrelic's summary (auto for flask)
+        # Re-raise all exceptions (as flask manages exceptions for output)
+        # try/except mechanism must wrap calls to this wrap_build() function (auto. for flask)
+        # See CONTRIBUTING.md for newrelic's error filtering
+        raise
 
     finally:
         log_dict.update({"duration": (datetime.datetime.utcnow() - start_datetime).total_seconds()})

--- a/kirin/new_relic.py
+++ b/kirin/new_relic.py
@@ -85,16 +85,6 @@ def is_reprocess_allowed(exception):  # next time Kirin receives the same feed, 
     return True
 
 
-def allow_newrelic_error_summary_logging(exception):
-    if must_never_log(exception):
-        return False
-    # Not tracking warnings in newrelic's errors summary
-    if is_only_warning_exception(exception):
-        return False
-
-    return True
-
-
 def record_exception():
     """
     record the exception currently handled to newrelic

--- a/kirin/utils.py
+++ b/kirin/utils.py
@@ -49,7 +49,7 @@ from kirin.core.model import RealTimeUpdate
 from kirin.exceptions import InternalException, InvalidArguments
 import requests
 
-from kirin.new_relic import allow_newrelic_error_summary_logging, must_never_log, record_exception
+from kirin.new_relic import must_never_log, record_exception
 
 
 def floor_datetime(datetime):
@@ -358,6 +358,6 @@ def log_exception(exception, exception_source):
     else:
         logger.exception(error)
 
-    # must filter on ALL exceptions (including flask's ones)
-    if allow_newrelic_error_summary_logging(exception):
-        record_exception()
+    # Record all exceptions by default
+    # See CONTRIBUTING.md for newrelic's error filtering
+    record_exception()


### PR DESCRIPTION
Previous to this work (and after https://github.com/CanalTP/kirin/pull/360), webservice was still logging filtered errors to New Relic, as flask's integration of New Relic is not tweakable.
Let's just delegate all filtering to external `newrelic.ini` file.

Note:
This only affects NR errors summary.
Kirin's status processing is independant and still required.

JIRA: https://jira.kisio.org/browse/ND-841