### PR TITLE
[feature] Keep 'nb_days_to_keep_*' fields optional in API

### DIFF
--- a/documentation/internal_format.md
+++ b/documentation/internal_format.md
@@ -29,8 +29,8 @@ is_active | Boolean, Optional | Used to activate/deactivate the kirin service fo
 broker_url| String, Optional | Url of the AMQP broker to listen for realtime information queue
 exchange_name| String, Optional | Exchange of the AMQP broker to listen for realtime information
 queue_name| String, Optional | Queue of the AMQP broker to listen for realtime information queue
-nb_days_to_keep_trip_update| Integer, Optional | number of days to keep in trip_update table
-nb_days_to_keep_rt_update| Integer, Optional | number of days to keep in real_time_update table
+nb_days_to_keep_trip_update| Integer, Optional | For trip_update table (archive of all the processed realtime-trips, used by Navitia in case of reload): number of days to keep before purge (considering trip's start date)
+nb_days_to_keep_rt_update| Integer, Optional | For real_time_update table (text archive of all "raw" feeds received, used for diagnostic): number of days to keep before purge (considering date of reception of the feed)
 
 Note: `broker_url`, `exchange_name` and `queue_name` are used for `piv` contributor only for now.
 All 3 must be filled if used.

--- a/kirin/resources/contributors.py
+++ b/kirin/resources/contributors.py
@@ -70,8 +70,8 @@ class Contributors(Resource):
         "broker_url": {"type": ["string", "null"], "format": "uri"},
         "exchange_name": {"type": ["string", "null"]},
         "queue_name": {"type": ["string", "null"]},
-        "nb_days_to_keep_trip_update": {"type": "integer"},
-        "nb_days_to_keep_rt_update": {"type": "integer"},
+        "nb_days_to_keep_trip_update": {"type": ["integer", "null"]},
+        "nb_days_to_keep_rt_update": {"type": ["integer", "null"]},
     }
 
     post_data_schema = {
@@ -80,8 +80,6 @@ class Contributors(Resource):
         "required": [
             "navitia_coverage",
             "connector_type",
-            "nb_days_to_keep_trip_update",
-            "nb_days_to_keep_rt_update",
         ],
     }
 

--- a/tests/integration/contributors_test.py
+++ b/tests/integration/contributors_test.py
@@ -218,8 +218,6 @@ def test_post_with_id_in_the_resource_path_and_data(test_client):
             "id": "overridden_id",
             "navitia_coverage": "jp",
             "connector_type": ConnectorType.gtfs_rt.value,
-            "nb_days_to_keep_trip_update": DEFAULT_DAYS_TO_KEEP_TRIP_UPDATE,
-            "nb_days_to_keep_rt_update": DEFAULT_DAYS_TO_KEEP_RT_UPDATE,
         },
     )
     assert resp.status_code == 201


### PR DESCRIPTION
Related to this comment in our channel #navitia on Element
https://matrix.to/#/!FsygHZEAWANEgbeCMB:matrix.org/$1608631737617468xVRTf:matrix.org?via=matrix.org&via=bitma.st&via=kde.org

To summarize, `nb_days_to_keep_*` fields are documented as optional and indeed, the database does have a [default value](https://github.com/CanalTP/kirin/blob/master/kirin/core/model.py#L531-L532)... but our API makes it mandatory.