### PR TITLE
[tech] navitia_wrapper:NavitiaException are errors

### DIFF
--- a/kirin/new_relic.py
+++ b/kirin/new_relic.py
@@ -68,7 +68,7 @@ def must_never_log(exception):
 
 NOT_REPROCESSABLE_EXCEPTIONS = [InvalidArguments, UnsupportedValue]
 
-WARNING_EXCEPTIONS = [ObjectNotFound, NavitiaException] + NOT_REPROCESSABLE_EXCEPTIONS
+WARNING_EXCEPTIONS = NOT_REPROCESSABLE_EXCEPTIONS + [ObjectNotFound]
 
 
 def is_only_warning_exception(exception):


### PR DESCRIPTION
Those exceptions are unexpected, as navitia's 200, 404 and 400 do not raise.
So we must let them out of warnings, and in errors.