### PR TITLE
[tech] fix venv leak on CI host

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,8 +56,8 @@ pre-commit run --all
 ### Design recommandations
 
 * Consider a trip as a sorted list of stop-events (pickup or drop-off).\
-  This should be easier to manipulate than a list of stops with 0, 1 or 2 events,
-  considering stop-events can individually be deleted, added, useless at extremities unless stay-in exist...
+  This should be easier to manipulate than a list of stops with 0, 1 or 2 events.\
+  Why: stop-events can individually be deleted, added, useless at extremities unless stay-in exist...
 
 ## Internal data format
 

--- a/tests/launch_tests.sh
+++ b/tests/launch_tests.sh
@@ -3,7 +3,7 @@
 set -e
 
 # clean all existing cache and previous build artifacts
-rm -rf venv && virtualenv venv && . venv/bin/activate
+rm -rf /tmp/venv && virtualenv /tmp/venv && . /tmp/venv/bin/activate
 rm -rf .pytest_cache
 find . -name "*.pyc" -o -name "__pycache__" -exec rm -rfv {} \;
 
@@ -18,4 +18,4 @@ PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. KIRIN_CONFIG_FILE=test_settings.py \
 	--cov-report xml --junitxml=pytest_kirin.xml --cov=kirin .
 
 # Final clean
-rm -rf venv
+rm -rf /tmp/venv


### PR DESCRIPTION
To avoid files with wrong permissions on host

:heavy_check_mark: Checked manually that it doesn't leak on jenkins' agent.