### PR TITLE
[tech] Fix coverage code SonarCloud

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -68,8 +68,12 @@ jobs:
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   file: ./coverage.xml
-            - name: fix code coverage path working-directory in coverage.xml
-              run: sed -i 's/\/home\/runner\/work\/kirin\/kirin\//\/github\/workspace\//g' coverage.xml
+            - name: Debug
+              run: |
+                echo $GITHUB_WORKSPACE
+                cat pytest_kirin.xml
+            - name: Change path in coverage.xml to match with working directory in docker SonarCloud container
+              run: sed -i 's#$GITHUB_WORKSPACE#/github/workspace/#g' coverage.xml
             - name: SonarCloud Scan
               uses: SonarSource/sonarcloud-github-action@master
               env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -68,12 +68,8 @@ jobs:
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   file: ./coverage.xml
-            - name: Debug
-              run: |
-                echo $GITHUB_WORKSPACE
-                cat pytest_kirin.xml
             - name: Change path in coverage.xml to match with working directory in docker SonarCloud container
-              run: sed -i 's#$GITHUB_WORKSPACE#/github/workspace/#g' coverage.xml
+              run: sed -i 's#/home/runner/work/kirin/kirin#/github/workspace#g' coverage.xml
             - name: SonarCloud Scan
               uses: SonarSource/sonarcloud-github-action@master
               env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -68,6 +68,8 @@ jobs:
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   file: ./coverage.xml
+            - name: fix code coverage path working-directory in coverage.xml
+              run: sed -i 's/\/home\/runner\/work\/kirin\/kirin\//\/github\/workspace\//g' coverage.xml
             - name: SonarCloud Scan
               uses: SonarSource/sonarcloud-github-action@master
               env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -68,7 +68,8 @@ jobs:
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   file: ./coverage.xml
-            - name: Change path in coverage.xml to match with working directory in docker SonarCloud container
+            - name: Change code path in coverage.xml to match current code path
+              # sonar accesses code while processing code-coverage
               run: sed -i 's#/home/runner/work/kirin/kirin#/github/workspace#g' coverage.xml
             - name: SonarCloud Scan
               uses: SonarSource/sonarcloud-github-action@master

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,10 @@
 # Kirin
 
 ![Continuous Integration Status](https://img.shields.io/github/workflow/status/CanalTP/kirin/Continuous%20Integration)
-![Code Coverage](https://img.shields.io/codecov/c/gh/CanalTP/kirin)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=CanalTP_kirin&metric=alert_status)](https://sonarcloud.io/dashboard?id=CanalTP_kirin)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=CanalTP_kirin&metric=security_rating)](https://sonarcloud.io/dashboard?id=CanalTP_kirin)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=CanalTP_kirin&metric=coverage)](https://sonarcloud.io/dashboard?id=CanalTP_kirin)
+
 
 ```py
                                                         /

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,7 @@ sonar.projectName=kirin
 # Language
 sonar.language=py
 sonar.sources=kirin
-sonar.python.coverage.reportPaths=./coverage.xml
+sonar.python.coverage.reportPaths=coverage.xml
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Fix code coverage for sonarCloud in Github actions. (85.4% Estimated after merge)
Add badges SonarCloud in Readme

NB: I didn't remove codecov from CI.
Info for fix problem: When CI create the coverage.xml file, it is created in the `/home/runner/work/kirin/kirin` directory and populated with a `<source>` tag in the file. The SonarCloud docker container mounts a volume `-v "/home/runner/work/kirin/kirin":"/github/workspace"` and therefore does not find this directory when it reads the coverage.xml file.

see https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/7

the `sed` command changes the content of the file because in the SonarCloud container the `/home/runner/work/kirin/kirin` directory no exists (it is mounted under the `/github/workspace` volume). 